### PR TITLE
feat: add support for Azure OpenAI, Vertex AI, and OpenAI-compatible providers

### DIFF
--- a/config.example.json5
+++ b/config.example.json5
@@ -208,6 +208,55 @@
   //   // baseUrl: "https://api.venice.ai/api",  // override with VENICE_BASE_URL env var
   // },
 
+  // --- Azure OpenAI provider -----------------------------------------------
+  // azure: {
+  //   apiKey: "${AZURE_OPENAI_API_KEY}",
+  //   resource: "my-resource",       // Azure resource name (e.g., "my-resource" from "my-resource.openai.azure.com")
+  //   deployment: "gpt-4",           // Deployment name
+  //   // apiVersion: "2024-02-15-preview",  // API version (default)
+  // },
+
+  // --- Google Cloud Vertex AI provider ------------------------------------
+  // vertex: {
+  //   projectId: "my-gcp-project",   // GCP project ID
+  //   region: "us-central1",        // GCP region
+  //   // accessToken: "...",          // OAuth2 access token (or use GCP_ACCESS_TOKEN env var)
+  // },
+  // // Alternatively, use environment variables:
+  // // export GCP_PROJECT_ID="my-gcp-project"
+  // // export GCP_REGION="us-central1"
+  // // export GCP_ACCESS_TOKEN="ya29.***
+
+  // --- OpenAI-Compatible Providers ---------------------------------------
+  // DeepSeek, Qwen, Moonshot (Kimi), Minimax, GLM (Z.ai), xAI (Grok)
+  // Use either config or environment variables:
+  //
+  // Via config:
+  // openaiCompatible: {
+  //   deepseek: { apiKey: "...", baseUrl: "https://api.deepseek.com/v1" },
+  //   qwen: { apiKey: "...", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
+  //   moonshot: { apiKey: "...", baseUrl: "https://api.moonshot.cn/v1" },
+  //   minimax: { apiKey: "...", baseUrl: "https://api.minimax.chat/v1" },
+  //   glm: { apiKey: "...", baseUrl: "https://open.bigmodel.cn/api/paas/v4" },
+  //   xai: { apiKey: "...", baseUrl: "https://api.x.ai/v1" },
+  // },
+  //
+  // Via environment variables (first configured provider wins):
+  // DEEPSEEK_API_KEY + DEEPSEEK_BASE_URL
+  // QWEN_API_KEY + QWEN_BASE_URL
+  // MOONSHOT_API_KEY + MOONSHOT_BASE_URL
+  // MINIMAX_API_KEY + MINIMAX_BASE_URL
+  // GLM_API_KEY + GLM_BASE_URL
+  // XAI_API_KEY + XAI_BASE_URL
+  //
+  // Model prefixes:
+  //   deepseek:deepseek-chat -> DeepSeek
+  //   qwen:qwen-turbo -> Qwen
+  //   moonshot:kimi-k2.5 or kimi:kimi-k2.5 -> Moonshot
+  //   minimax:minimax-m2 -> Minimax
+  //   glm:glm-5 or z.ai:glm-5 -> GLM (Z.ai)
+  //   xai:grok-2 or grok:grok-2 -> xAI
+
   // --- Inbound message classifier ----------------------------------------
   // classifier: {
   //   enabled: true,

--- a/src/agent/azure_openai.rs
+++ b/src/agent/azure_openai.rs
@@ -1,0 +1,793 @@
+//! Azure OpenAI API provider.
+//!
+//! Streams completions from Azure OpenAI's `/chat/completions` endpoint using
+//! Server-Sent Events (SSE). Azure OpenAI uses a different URL format than
+//! standard OpenAI:
+//!   https://{resource}.openai.azure.com/openai/deployments/{deployment}/chat/completions?api-version={version}
+//!
+//! The "deployment" name is used instead of the model name, and can be
+//! configured separately from the model identifier.
+
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::agent::provider::*;
+use crate::agent::AgentError;
+
+/// Default Azure OpenAI API version.
+const DEFAULT_AZURE_API_VERSION: &str = "2024-02-15-preview";
+
+/// Azure OpenAI Chat Completions API provider.
+#[derive(Debug)]
+pub struct AzureOpenAiProvider {
+    client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+    deployment: String,
+    api_version: String,
+}
+
+impl AzureOpenAiProvider {
+    /// Create a new Azure OpenAI provider.
+    ///
+    /// - `api_key`: Azure OpenAI API key
+    /// - `resource`: Azure resource name (e.g., "my-resource" from "my-resource.openai.azure.com")
+    /// - `deployment`: Deployment name (the model deployment in Azure)
+    pub fn new(api_key: String, resource: String, deployment: String) -> Result<Self, AgentError> {
+        if api_key.trim().is_empty() {
+            return Err(AgentError::InvalidApiKey(
+                "API key must not be empty".to_string(),
+            ));
+        }
+        if resource.trim().is_empty() {
+            return Err(AgentError::Provider(
+                "Azure resource name must not be empty".to_string(),
+            ));
+        }
+        if deployment.trim().is_empty() {
+            return Err(AgentError::Provider(
+                "Azure deployment name must not be empty".to_string(),
+            ));
+        }
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(300))
+            .build()
+            .map_err(|e| AgentError::Provider(format!("failed to build HTTP client: {e}")))?;
+
+        let base_url = format!("https://{}.openai.azure.com", resource.trim());
+
+        Ok(Self {
+            client,
+            api_key,
+            base_url,
+            deployment: deployment.trim().to_string(),
+            api_version: DEFAULT_AZURE_API_VERSION.to_string(),
+        })
+    }
+
+    /// Set a custom API version (default: "2024-02-15-preview").
+    pub fn with_api_version(mut self, version: String) -> Self {
+        if !version.trim().is_empty() {
+            self.api_version = version.trim().to_string();
+        }
+        self
+    }
+
+    /// Build the JSON body for the Azure OpenAI Chat Completions API.
+    ///
+    /// Note: Azure OpenAI uses the same message format as OpenAI.
+    fn build_body(&self, request: &CompletionRequest) -> Value {
+        let mut messages: Vec<Value> = Vec::new();
+
+        if let Some(ref system) = request.system {
+            messages.push(json!({
+                "role": "system",
+                "content": system,
+            }));
+        }
+
+        for msg in &request.messages {
+            match msg.role {
+                LlmRole::User => convert_user_message_azure(msg, &mut messages),
+                LlmRole::Assistant => convert_assistant_message_azure(msg, &mut messages),
+            }
+        }
+
+        let mut body = json!({
+            "messages": messages,
+            "max_completion_tokens": request.max_tokens,
+            "stream": true,
+            "stream_options": { "include_usage": true },
+        });
+
+        if let Some(temp) = request.temperature {
+            body["temperature"] = json!(temp);
+        }
+
+        append_tools_azure(&request.tools, &mut body);
+
+        body
+    }
+}
+
+/// Convert a user-role `LlmMessage` into one or more Azure OpenAI-format messages.
+fn convert_user_message_azure(msg: &LlmMessage, messages: &mut Vec<Value>) {
+    let has_tool_result = msg
+        .content
+        .iter()
+        .any(|b| matches!(b, ContentBlock::ToolResult { .. }));
+
+    if has_tool_result {
+        for block in &msg.content {
+            match block {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } => {
+                    messages.push(json!({
+                        "role": "tool",
+                        "tool_call_id": tool_use_id,
+                        "content": content,
+                    }));
+                }
+                ContentBlock::Text { text } => {
+                    messages.push(json!({
+                        "role": "user",
+                        "content": text,
+                    }));
+                }
+                _ => {}
+            }
+        }
+    } else {
+        let text = collect_text_blocks_azure(&msg.content);
+        if !text.is_empty() {
+            messages.push(json!({
+                "role": "user",
+                "content": text,
+            }));
+        }
+    }
+}
+
+/// Convert an assistant-role `LlmMessage` into an Azure OpenAI-format message.
+fn convert_assistant_message_azure(msg: &LlmMessage, messages: &mut Vec<Value>) {
+    let has_tool_use = msg
+        .content
+        .iter()
+        .any(|b| matches!(b, ContentBlock::ToolUse { .. }));
+
+    if has_tool_use {
+        let text_content = collect_text_blocks_azure(&msg.content);
+
+        let tool_calls: Vec<Value> = msg
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse { id, name, input } => Some(json!({
+                    "id": id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": input.to_string(),
+                    }
+                })),
+                _ => None,
+            })
+            .collect();
+
+        let mut msg_obj = json!({
+            "role": "assistant",
+            "tool_calls": tool_calls,
+        });
+        if !text_content.is_empty() {
+            msg_obj["content"] = json!(text_content);
+        }
+        messages.push(msg_obj);
+    } else {
+        let text = collect_text_blocks_azure(&msg.content);
+        messages.push(json!({
+            "role": "assistant",
+            "content": text,
+        }));
+    }
+}
+
+/// Concatenate all `Text` blocks in a content slice into a single string.
+fn collect_text_blocks_azure(content: &[ContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+/// Append tool definitions to the body if any are present.
+fn append_tools_azure(tools: &[ToolDefinition], body: &mut Value) {
+    if !tools.is_empty() {
+        let tool_values: Vec<Value> = tools
+            .iter()
+            .map(|t| {
+                json!({
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.input_schema,
+                    }
+                })
+            })
+            .collect();
+        body["tools"] = json!(tool_values);
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AzureOpenAiProvider {
+    async fn complete(
+        &self,
+        request: CompletionRequest,
+        cancel_token: CancellationToken,
+    ) -> Result<mpsc::Receiver<StreamEvent>, AgentError> {
+        if cancel_token.is_cancelled() {
+            return Err(AgentError::Cancelled);
+        }
+
+        let body = self.build_body(&request);
+
+        // Azure OpenAI URL format:
+        // https://{resource}.openai.azure.com/openai/deployments/{deployment}/chat/completions?api-version={version}
+        let url = format!(
+            "{}/openai/deployments/{}/chat/completions?api-version={}",
+            self.base_url, self.deployment, self.api_version
+        );
+
+        let response = tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return Err(AgentError::Cancelled);
+            }
+            response = self
+                .client
+                .post(&url)
+                .header("api-key", &self.api_key)
+                .header("content-type", "application/json")
+                .header("accept", "text/event-stream")
+                .json(&body)
+                .send() => {
+                    response.map_err(|e| AgentError::Provider(format!("HTTP request failed: {e}")))?
+                }
+        };
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+            return Err(AgentError::Provider(format!(
+                "Azure OpenAI API returned {status}: {body}"
+            )));
+        }
+
+        let (tx, rx) = mpsc::channel(64);
+
+        // Spawn a task to read the SSE stream and forward events
+        let stream = response.bytes_stream();
+        let cancel = cancel_token.clone();
+        tokio::spawn(async move {
+            if let Err(e) = process_sse_stream(stream, &tx, &cancel).await {
+                let _ = tx
+                    .send(StreamEvent::Error {
+                        message: e.to_string(),
+                    })
+                    .await;
+            }
+        });
+
+        Ok(rx)
+    }
+}
+
+/// Maximum SSE line buffer size (1 MB).
+const MAX_SSE_BUFFER_BYTES: usize = 1_048_576;
+
+/// Process an Azure OpenAI SSE byte stream into StreamEvents.
+///
+/// Azure OpenAI uses the same SSE format as OpenAI.
+async fn process_sse_stream<S>(
+    mut stream: S,
+    tx: &mpsc::Sender<StreamEvent>,
+    cancel_token: &CancellationToken,
+) -> Result<(), String>
+where
+    S: futures_util::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Unpin,
+{
+    let mut buffer = String::new();
+    let mut tool_calls: std::collections::HashMap<u64, (String, String, String)> =
+        std::collections::HashMap::new();
+    let mut accumulated_usage = TokenUsage::default();
+    let mut got_done = false;
+
+    loop {
+        let chunk = tokio::select! {
+            _ = cancel_token.cancelled() => return Ok(()),
+            chunk = stream.next() => chunk,
+        };
+        let Some(chunk) = chunk else {
+            break;
+        };
+        let chunk = chunk.map_err(|e| format!("stream read error: {e}"))?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        if buffer.len() > MAX_SSE_BUFFER_BYTES {
+            return Err(format!(
+                "SSE buffer exceeded {} bytes, aborting stream",
+                MAX_SSE_BUFFER_BYTES
+            ));
+        }
+
+        let mut consumed = 0;
+        while let Some(rel_pos) = buffer[consumed..].find('\n') {
+            let newline_pos = consumed + rel_pos;
+            let line = buffer[consumed..newline_pos]
+                .trim_end_matches('\r')
+                .to_string();
+            consumed = newline_pos + 1;
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                if data.trim() == "[DONE]" {
+                    got_done = true;
+                    let stop_event =
+                        flush_tool_calls_and_stop(&mut tool_calls, &accumulated_usage, tx).await;
+                    if let Some(event) = stop_event {
+                        let is_stop = matches!(event, StreamEvent::Stop { .. });
+                        if tx.send(event).await.is_err() {
+                            return Ok(());
+                        }
+                        if is_stop {
+                            return Ok(());
+                        }
+                    }
+                    continue;
+                }
+
+                if let Some(event) =
+                    parse_sse_data(data, &mut tool_calls, &mut accumulated_usage)
+                {
+                    let is_stop = matches!(event, StreamEvent::Stop { .. });
+                    let is_error = matches!(event, StreamEvent::Error { .. });
+                    if tx.send(event).await.is_err() {
+                        return Ok(());
+                    }
+                    if is_stop || is_error {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        if consumed > 0 {
+            buffer.drain(..consumed);
+        }
+    }
+
+    if got_done {
+        Ok(())
+    } else {
+        Err("stream ended without [DONE] sentinel".to_string())
+    }
+}
+
+/// Parse a single SSE data payload from Azure OpenAI's streaming format.
+fn parse_sse_data(
+    data: &str,
+    tool_calls: &mut std::collections::HashMap<u64, (String, String, String)>,
+    accumulated_usage: &mut TokenUsage,
+) -> Option<StreamEvent> {
+    let parsed: Value = serde_json::from_str(data).ok()?;
+
+    if let Some(error) = parsed.get("error") {
+        let message = error
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown API error")
+            .to_string();
+        return Some(StreamEvent::Error { message });
+    }
+
+    if let Some(usage) = parsed.get("usage") {
+        if let Some(prompt_tokens) = usage.get("prompt_tokens").and_then(|v| v.as_u64()) {
+            accumulated_usage.input_tokens = prompt_tokens;
+        }
+        if let Some(completion_tokens) = usage.get("completion_tokens").and_then(|v| v.as_u64())
+        {
+            accumulated_usage.output_tokens = completion_tokens;
+        }
+    }
+
+    let choices = parsed.get("choices")?.as_array()?;
+    if choices.is_empty() {
+        return None;
+    }
+
+    let choice = &choices[0];
+
+    if let Some(finish_reason) = choice.get("finish_reason").and_then(|v| v.as_str()) {
+        let reason = match finish_reason {
+            "stop" => StopReason::EndTurn,
+            "tool_calls" => StopReason::ToolUse,
+            "length" => StopReason::MaxTokens,
+            _ => StopReason::EndTurn,
+        };
+
+        if reason == StopReason::ToolUse {
+            return None;
+        }
+
+        return Some(StreamEvent::Stop {
+            reason,
+            usage: *accumulated_usage,
+        });
+    }
+
+    let delta = choice.get("delta")?;
+
+    if let Some(content) = delta.get("content").and_then(|v| v.as_str()) {
+        if !content.is_empty() {
+            return Some(StreamEvent::TextDelta {
+                text: content.to_string(),
+            });
+        }
+    }
+
+    if let Some(tc_array) = delta.get("tool_calls").and_then(|v| v.as_array()) {
+        for tc in tc_array {
+            let index = tc.get("index").and_then(|v| v.as_u64()).unwrap_or(0);
+
+            if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
+                let name = tc
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                tool_calls.insert(index, (id.to_string(), name, args));
+            } else {
+                if let Some(entry) = tool_calls.get_mut(&index) {
+                    if let Some(args_chunk) = tc
+                        .get("function")
+                        .and_then(|f| f.get("arguments"))
+                        .and_then(|v| v.as_str())
+                    {
+                        entry.2.push_str(args_chunk);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Flush accumulated tool calls as StreamEvents and emit a Stop event.
+async fn flush_tool_calls_and_stop(
+    tool_calls: &mut std::collections::HashMap<u64, (String, String, String)>,
+    usage: &TokenUsage,
+    tx: &mpsc::Sender<StreamEvent>,
+) -> Option<StreamEvent> {
+    if tool_calls.is_empty() {
+        return None;
+    }
+
+    let mut sorted: Vec<(u64, (String, String, String))> = tool_calls.drain().collect();
+    sorted.sort_by_key(|(idx, _)| *idx);
+
+    for (_index, (id, name, args_json)) in sorted {
+        let input: Value = serde_json::from_str(&args_json).unwrap_or(json!({}));
+        let event = StreamEvent::ToolUse { id, name, input };
+        if tx.send(event).await.is_err() {
+            return None;
+        }
+    }
+
+    Some(StreamEvent::Stop {
+        reason: StopReason::ToolUse,
+        usage: *usage,
+    })
+}
+
+/// Determine whether a model identifier should route to the Azure OpenAI provider.
+///
+/// Models prefixed with `azure:` are routed to Azure OpenAI.
+pub fn is_azure_openai_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("azure:")
+}
+
+/// Strip the `azure:` prefix from a model identifier.
+///
+/// Returns the bare deployment name for the Azure OpenAI API.
+pub fn strip_azure_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("azure:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Azure:") {
+        rest
+    } else {
+        model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== Provider construction tests ====================
+
+    #[test]
+    fn test_new_rejects_empty_api_key() {
+        let result = AzureOpenAiProvider::new(
+            "".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("API key"), "error should mention API key: {err}");
+    }
+
+    #[test]
+    fn test_new_rejects_empty_resource() {
+        let result = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "".to_string(),
+            "gpt-4".to_string(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("resource"), "error should mention resource: {err}");
+    }
+
+    #[test]
+    fn test_new_rejects_empty_deployment() {
+        let result = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "".to_string(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("deployment"), "error should mention deployment: {err}");
+    }
+
+    #[test]
+    fn test_new_accepts_valid_params() {
+        let result = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        );
+        assert!(result.is_ok());
+        let provider = result.unwrap();
+        assert_eq!(provider.base_url, "https://my-resource.openai.azure.com");
+        assert_eq!(provider.deployment, "gpt-4");
+        assert_eq!(provider.api_version, DEFAULT_AZURE_API_VERSION);
+    }
+
+    #[test]
+    fn test_with_api_version() {
+        let provider = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        )
+        .unwrap()
+        .with_api_version("2024-06-01".to_string());
+        assert_eq!(provider.api_version, "2024-06-01");
+    }
+
+    #[test]
+    fn test_with_api_version_empty_ignores() {
+        let provider = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        )
+        .unwrap()
+        .with_api_version("".to_string());
+        assert_eq!(provider.api_version, DEFAULT_AZURE_API_VERSION);
+    }
+
+    // ==================== Model detection tests ====================
+
+    #[test]
+    fn test_is_azure_openai_model() {
+        assert!(is_azure_openai_model("azure:gpt-4"));
+        assert!(is_azure_openai_model("azure:gpt-4o"));
+        assert!(is_azure_openai_model("Azure:gpt-4"));
+        assert!(is_azure_openai_model("AZURE:gpt-4"));
+
+        assert!(!is_azure_openai_model("gpt-4o"));
+        assert!(!is_azure_openai_model("claude-sonnet-4"));
+    }
+
+    #[test]
+    fn test_strip_azure_prefix() {
+        assert_eq!(strip_azure_prefix("azure:gpt-4"), "gpt-4");
+        assert_eq!(strip_azure_prefix("Azure:gpt-4"), "gpt-4");
+        assert_eq!(strip_azure_prefix("gpt-4"), "gpt-4");
+    }
+
+    // ==================== build_body tests ====================
+
+    #[test]
+    fn test_build_body_basic() {
+        let provider = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        )
+        .unwrap();
+        let request = CompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![LlmMessage {
+                role: LlmRole::User,
+                content: vec![ContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            }],
+            system: Some("You are helpful.".to_string()),
+            tools: vec![],
+            max_tokens: 1024,
+            temperature: Some(0.7),
+            extra: None,
+        };
+        let body = provider.build_body(&request);
+        assert_eq!(body["max_completion_tokens"], 1024);
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["temperature"], 0.7);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["role"], "user");
+    }
+
+    #[test]
+    fn test_build_body_with_tools() {
+        let provider = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        )
+        .unwrap();
+        let request = CompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![],
+            system: None,
+            tools: vec![ToolDefinition {
+                name: "get_weather".to_string(),
+                description: "Get weather".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    }
+                }),
+            }],
+            max_tokens: 4096,
+            temperature: None,
+            extra: None,
+        };
+        let body = provider.build_body(&request);
+        assert!(body["tools"].is_array());
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_build_body_assistant_with_tool_calls() {
+        let provider = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        )
+        .unwrap();
+        let request = CompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![
+                LlmMessage {
+                    role: LlmRole::User,
+                    content: vec![ContentBlock::Text {
+                        text: "What's the weather?".to_string(),
+                    }],
+                },
+                LlmMessage {
+                    role: LlmRole::Assistant,
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "Let me check.".to_string(),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "call_abc123".to_string(),
+                            name: "get_weather".to_string(),
+                            input: json!({"city": "SF"}),
+                        },
+                    ],
+                },
+            ],
+            system: None,
+            tools: vec![],
+            max_tokens: 1024,
+            temperature: None,
+            extra: None,
+        };
+        let body = provider.build_body(&request);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        // Assistant message with tool_calls
+        assert_eq!(messages[1]["role"], "assistant");
+        let tool_calls = messages[1]["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls[0]["id"], "call_abc123");
+    }
+
+    #[test]
+    fn test_build_body_with_tool_results() {
+        let provider = AzureOpenAiProvider::new(
+            "sk-key".to_string(),
+            "my-resource".to_string(),
+            "gpt-4".to_string(),
+        )
+        .unwrap();
+        let request = CompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![
+                LlmMessage {
+                    role: LlmRole::User,
+                    content: vec![ContentBlock::Text {
+                        text: "What's the weather?".to_string(),
+                    }],
+                },
+                LlmMessage {
+                    role: LlmRole::Assistant,
+                    content: vec![ContentBlock::ToolUse {
+                        id: "call_abc".to_string(),
+                        name: "get_weather".to_string(),
+                        input: json!({"city": "SF"}),
+                    }],
+                },
+                LlmMessage {
+                    role: LlmRole::User,
+                    content: vec![ContentBlock::ToolResult {
+                        tool_use_id: "call_abc".to_string(),
+                        content: "72F and sunny".to_string(),
+                        is_error: false,
+                    }],
+                },
+            ],
+            system: None,
+            tools: vec![],
+            max_tokens: 1024,
+            temperature: None,
+            extra: None,
+        };
+        let body = provider.build_body(&request);
+        let messages = body["messages"].as_array().unwrap();
+        // Tool result should be converted to role: "tool"
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "call_abc");
+        assert_eq!(messages[2]["content"], "72F and sunny");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,6 +4,7 @@
 //! and the core agent run loop that ties everything together.
 
 pub mod anthropic;
+pub mod azure_openai;
 pub mod bedrock;
 pub mod builtin_tools;
 pub mod channel_tools;
@@ -15,6 +16,7 @@ pub mod factory;
 pub mod gemini;
 pub mod ollama;
 pub mod openai;
+pub mod openai_compatible;
 pub mod output_sanitizer;
 pub mod prompt_guard;
 pub mod provider;
@@ -22,6 +24,7 @@ pub mod sandbox;
 pub mod tool_policy;
 pub mod tools;
 pub mod venice;
+pub mod vertex;
 
 use std::sync::Arc;
 

--- a/src/agent/openai_compatible.rs
+++ b/src/agent/openai_compatible.rs
@@ -1,0 +1,286 @@
+//! OpenAI Compatible Provider
+//!
+//! A generic provider for any OpenAI-compatible API. This wraps the OpenAI provider
+//! with a custom base URL, allowing support for many providers like DeepSeek, Qwen,
+//! Moonshot, Minimax, GLM, xAI, and others.
+//!
+//! Uses the same `/v1/chat/completions` endpoint and SSE format as OpenAI.
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::agent::openai::OpenAiProvider;
+use crate::agent::provider::*;
+use crate::agent::AgentError;
+
+/// OpenAI Compatible Provider.
+///
+/// Wraps the OpenAI provider with a custom base URL to support any
+/// OpenAI-compatible API (DeepSeek, Qwen, Moonshot, Minimax, GLM, xAI, etc.).
+#[derive(Debug)]
+pub struct OpenAiCompatibleProvider {
+    inner: OpenAiProvider,
+    provider_name: String,
+}
+
+impl OpenAiCompatibleProvider {
+    /// Create a new OpenAI-compatible provider.
+    ///
+    /// - `api_key`: API key for the provider
+    /// - `base_url`: Base URL for the OpenAI-compatible API
+    /// - `provider_name`: Display name for the provider (e.g., "DeepSeek", "Qwen")
+    pub fn new(
+        api_key: String,
+        base_url: String,
+        provider_name: String,
+    ) -> Result<Self, AgentError> {
+        if api_key.trim().is_empty() {
+            return Err(AgentError::InvalidApiKey(
+                "API key must not be empty".to_string(),
+            ));
+        }
+        if base_url.trim().is_empty() {
+            return Err(AgentError::InvalidBaseUrl(
+                "Base URL must not be empty".to_string(),
+            ));
+        }
+
+        let inner = OpenAiProvider::new(api_key)?
+            .with_base_url(base_url)?;
+
+        Ok(Self {
+            inner,
+            provider_name,
+        })
+    }
+
+    /// Returns the provider name.
+    pub fn provider_name(&self) -> &str {
+        &self.provider_name
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiCompatibleProvider {
+    async fn complete(
+        &self,
+        request: CompletionRequest,
+        cancel_token: CancellationToken,
+    ) -> Result<mpsc::Receiver<StreamEvent>, AgentError> {
+        self.inner.complete(request, cancel_token).await
+    }
+}
+
+/// Determine whether a model identifier should route to DeepSeek.
+pub fn is_deepseek_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("deepseek:")
+}
+
+/// Strip the `deepseek:` prefix from a model identifier.
+pub fn strip_deepseek_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("deepseek:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Deepseek:") {
+        rest
+    } else {
+        model
+    }
+}
+
+/// Determine whether a model identifier should route to Qwen (Alibaba).
+pub fn is_qwen_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("qwen:")
+}
+
+/// Strip the `qwen:` prefix from a model identifier.
+pub fn strip_qwen_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("qwen:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Qwen:") {
+        rest
+    } else {
+        model
+    }
+}
+
+/// Determine whether a model identifier should route to Moonshot (Kimi).
+pub fn is_moonshot_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("moonshot:") || lower.starts_with("kimi:")
+}
+
+/// Strip the `moonshot:` or `kimi:` prefix from a model identifier.
+pub fn strip_moonshot_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("moonshot:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("moonshot:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("kimi:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Kimi:") {
+        rest
+    } else {
+        model
+    }
+}
+
+/// Determine whether a model identifier should route to Minimax.
+pub fn is_minimax_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("minimax:")
+}
+
+/// Strip the `minimax:` prefix from a model identifier.
+pub fn strip_minimax_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("minimax:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Minimax:") {
+        rest
+    } else {
+        model
+    }
+}
+
+/// Determine whether a model identifier should route to GLM (Z.ai - zhipu.ai).
+pub fn is_glm_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("glm:") || lower.starts_with("z.ai:") || lower.starts_with("zai:")
+}
+
+/// Strip the `glm:`, `z.ai:`, or `zai:` prefix from a model identifier.
+pub fn strip_glm_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("glm:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("GLM:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("z.ai:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("zai:") {
+        rest
+    } else {
+        model
+    }
+}
+
+/// Determine whether a model identifier should route to xAI (Grok).
+pub fn is_xai_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("xai:") || lower.starts_with("grok:")
+}
+
+/// Strip the `xai:` or `grok:` prefix from a model identifier.
+pub fn strip_xai_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("xai:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Xai:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("grok:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Grok:") {
+        rest
+    } else {
+        model
+    }
+}
+
+/// Determine whether a model identifier should route to OpenRouter.
+pub fn is_openrouter_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("openrouter:")
+}
+
+/// Strip the `openrouter:` prefix from a model identifier.
+pub fn strip_openrouter_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("openrouter:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("OpenRouter:") {
+        rest
+    } else {
+        model
+    }
+}
+pub fn strip_xai_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("xai:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Xai:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("grok:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Grok:") {
+        rest
+    } else {
+        model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_deepseek_model() {
+        assert!(is_deepseek_model("deepseek:deepseek-chat"));
+        assert!(is_deepseek_model("deepseek:deepseek-coder"));
+        assert!(is_deepseek_model("Deepseek:deepseek-chat"));
+        assert!(!is_deepseek_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_strip_deepseek_prefix() {
+        assert_eq!(strip_deepseek_prefix("deepseek:deepseek-chat"), "deepseek-chat");
+        assert_eq!(strip_deepseek_prefix("deepseek-chat"), "deepseek-chat");
+    }
+
+    #[test]
+    fn test_is_qwen_model() {
+        assert!(is_qwen_model("qwen:qwen-turbo"));
+        assert!(is_qwen_model("qwen:qwen-plus"));
+        assert!(!is_qwen_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_is_moonshot_model() {
+        assert!(is_moonshot_model("moonshot:kimi-k2.5"));
+        assert!(is_moonshot_model("kimi:kimi-k2-thinking"));
+        assert!(!is_moonshot_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_is_minimax_model() {
+        assert!(is_minimax_model("minimax:minimax-m2"));
+        assert!(!is_minimax_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_is_glm_model() {
+        assert!(is_glm_model("glm:glm-4"));
+        assert!(is_glm_model("glm:glm-5"));
+        assert!(is_glm_model("z.ai:glm-4"));
+        assert!(is_glm_model("zai:glm-4"));
+        assert!(!is_glm_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_is_xai_model() {
+        assert!(is_xai_model("xai:grok-2"));
+        assert!(is_xai_model("grok:grok-2"));
+        assert!(!is_xai_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_is_openrouter_model() {
+        assert!(is_openrouter_model("openrouter:anthropic/claude-3.5-sonnet"));
+        assert!(is_openrouter_model("openrouter:google/gemini-pro"));
+        assert!(is_openrouter_model("OpenRouter:meta/llama-3"));
+        assert!(!is_openrouter_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_strip_openrouter_prefix() {
+        assert_eq!(strip_openrouter_prefix("openrouter:anthropic/claude-3.5-sonnet"), "anthropic/claude-3.5-sonnet");
+        assert_eq!(strip_openrouter_prefix("anthropic/claude-3.5-sonnet"), "anthropic/claude-3.5-sonnet");
+    }
+}

--- a/src/agent/vertex.rs
+++ b/src/agent/vertex.rs
@@ -1,0 +1,688 @@
+//! Google Cloud Vertex AI provider.
+//!
+//! Streams completions from Vertex AI's `/predict` endpoint using Server-Sent Events (SSE).
+//! Vertex AI uses a different authentication method than the standard Gemini API - it uses
+//! Google Cloud OAuth2 with service account credentials.
+//!
+//! Endpoint format:
+//!   https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:streamPredict
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::agent::provider::*;
+use crate::agent::AgentError;
+
+/// Google Cloud Vertex AI provider.
+#[derive(Debug)]
+pub struct VertexProvider {
+    client: reqwest::Client,
+    project_id: String,
+    region: String,
+    access_token: Option<String>,
+    base_url: String,
+}
+
+impl VertexProvider {
+    /// Create a new Vertex AI provider.
+    ///
+    /// - `project_id`: GCP project ID
+    /// - `region`: GCP region (e.g., "us-central1")
+    /// - `access_token`: OAuth2 access token (can be obtained from service account or workload identity)
+    pub fn new(
+        project_id: String,
+        region: String,
+        access_token: String,
+    ) -> Result<Self, AgentError> {
+        if project_id.trim().is_empty() {
+            return Err(AgentError::Provider(
+                "GCP project ID must not be empty".to_string(),
+            ));
+        }
+        if region.trim().is_empty() {
+            return Err(AgentError::Provider(
+                "GCP region must not be empty".to_string(),
+            ));
+        }
+        if access_token.trim().is_empty() {
+            return Err(AgentError::InvalidApiKey(
+                "Access token must not be empty".to_string(),
+            ));
+        }
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(300))
+            .build()
+            .map_err(|e| AgentError::Provider(format!("failed to build HTTP client: {e}")))?;
+
+        let base_url = format!(
+            "https://{}-aiplatform.googleapis.com",
+            region.trim()
+        );
+
+        Ok(Self {
+            client,
+            project_id: project_id.trim().to_string(),
+            region: region.trim().to_string(),
+            access_token: Some(access_token.trim().to_string()),
+            base_url,
+        })
+    }
+
+    /// Build the JSON body for the Vertex AI streaming predict API.
+    fn build_body(&self, request: &CompletionRequest) -> Value {
+        // Convert system to Vertex AI's systemInstruction format
+        let system_instruction = if let Some(ref system) = request.system {
+            json!({
+                "role": "system",
+                "parts": [{ "text": system }]
+            })
+        } else {
+            json!(null)
+        };
+
+        // Convert messages to Vertex AI contents format
+        let mut contents: Vec<Value> = Vec::new();
+
+        for msg in &request.messages {
+            let role = match msg.role {
+                LlmRole::User => "user",
+                LlmRole::Assistant => "model",
+            };
+
+            let mut parts: Vec<Value> = Vec::new();
+
+            for block in &msg.content {
+                match block {
+                    ContentBlock::Text { text } => {
+                        parts.push(json!({ "text": text }));
+                    }
+                    ContentBlock::ToolUse { id: _, name, input } => {
+                        parts.push(json!({
+                            "functionCall": {
+                                "name": name,
+                                "args": input,
+                            }
+                        }));
+                    }
+                    ContentBlock::ToolResult {
+                        tool_use_id: _,
+                        content,
+                        is_error: _,
+                    } => {
+                        // For tool results, find the tool name
+                        let tool_name = find_tool_name_for_result(&request.messages, block);
+                        parts.push(json!({
+                            "functionResponse": {
+                                "name": tool_name,
+                                "response": {
+                                    "result": content,
+                                }
+                            }
+                        }));
+                    }
+                }
+            }
+
+            if !parts.is_empty() {
+                contents.push(json!({
+                    "role": role,
+                    "parts": parts,
+                }));
+            }
+        }
+
+        // Tools (function declarations)
+        let tools = if !request.tools.is_empty() {
+            let declarations: Vec<Value> = request
+                .tools
+                .iter()
+                .map(|t| {
+                    json!({
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.input_schema,
+                    })
+                })
+                .collect();
+            json!([{
+                "functionDeclarations": declarations,
+            }])
+        } else {
+            json!([])
+        };
+
+        // Generation config
+        let mut generation_config = json!({
+            "maxOutputTokens": request.max_tokens,
+        });
+        if let Some(temp) = request.temperature {
+            generation_config["temperature"] = json!(temp);
+        }
+
+        json!({
+            "systemInstruction": system_instruction,
+            "contents": contents,
+            "tools": tools,
+            "generationConfig": generation_config,
+        })
+    }
+
+    /// Returns the configured region.
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    /// Refresh the access token (for long-running operations).
+    pub fn with_access_token(mut self, token: String) -> Self {
+        if !token.trim().is_empty() {
+            self.access_token = Some(token.trim().to_string());
+        }
+        self
+    }
+}
+
+/// Find the tool name that corresponds to a ToolResult block.
+fn find_tool_name_for_result(messages: &[LlmMessage], block: &ContentBlock) -> String {
+    let target_id = match block {
+        ContentBlock::ToolResult { tool_use_id, .. } => tool_use_id,
+        _ => return "unknown".to_string(),
+    };
+
+    for msg in messages.iter().rev() {
+        for b in &msg.content {
+            if let ContentBlock::ToolUse { id, name, .. } = b {
+                if id == target_id {
+                    return name.clone();
+                }
+            }
+        }
+    }
+
+    "unknown".to_string()
+}
+
+#[async_trait]
+impl LlmProvider for VertexProvider {
+    async fn complete(
+        &self,
+        request: CompletionRequest,
+        cancel_token: CancellationToken,
+    ) -> Result<mpsc::Receiver<StreamEvent>, AgentError> {
+        if cancel_token.is_cancelled() {
+            return Err(AgentError::Cancelled);
+        }
+
+        // Strip any prefix to get the bare model name
+        let model_name = strip_vertex_prefix(&request.model);
+        let body = self.build_body(&request);
+
+        // Vertex AI endpoint format:
+        // /v1/projects/{project}/locations/{region}/publishers/google/models/{model}:streamPredict
+        let url = format!(
+            "{}/v1/projects/{}/locations/{}/publishers/google/models/{}:streamPredict",
+            self.base_url, self.project_id, self.region, model_name
+        );
+
+        let access_token = self.access_token.as_ref().ok_or_else(|| {
+            AgentError::Provider("No access token configured".to_string())
+        })?;
+
+        let response = tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return Err(AgentError::Cancelled);
+            }
+            response = self
+                .client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", access_token))
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/event-stream")
+                .json(&body)
+                .send() => {
+                    response.map_err(|e| AgentError::Provider(format!("HTTP request failed: {e}")))?
+                }
+        };
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+            return Err(AgentError::Provider(format!(
+                "Vertex AI API returned {status}: {body}"
+            )));
+        }
+
+        let (tx, rx) = mpsc::channel(64);
+
+        // Spawn a task to read the SSE stream and forward events
+        let stream = response.bytes_stream();
+        let cancel = cancel_token.clone();
+        tokio::spawn(async move {
+            if let Err(e) = process_vertex_sse_stream(stream, &tx, &cancel).await {
+                let _ = tx
+                    .send(StreamEvent::Error {
+                        message: e.to_string(),
+                    })
+                    .await;
+            }
+        });
+
+        Ok(rx)
+    }
+}
+
+/// Maximum SSE line buffer size (1 MB).
+const MAX_SSE_BUFFER_BYTES: usize = 1_048_576;
+
+/// Process a Vertex AI SSE byte stream into StreamEvents.
+async fn process_vertex_sse_stream<S>(
+    mut stream: S,
+    tx: &mpsc::Sender<StreamEvent>,
+    cancel_token: &CancellationToken,
+) -> Result<(), String>
+where
+    S: futures_util::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Unpin,
+{
+    let mut buffer = String::new();
+    let mut accumulated_usage = TokenUsage::default();
+    let mut last_finish_reason: Option<String> = None;
+
+    loop {
+        let chunk = tokio::select! {
+            _ = cancel_token.cancelled() => return Ok(()),
+            chunk = stream.next() => chunk,
+        };
+        let Some(chunk) = chunk else {
+            break;
+        };
+        let chunk = chunk.map_err(|e| format!("stream read error: {}", e))?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        if buffer.len() > MAX_SSE_BUFFER_BYTES {
+            return Err(format!(
+                "SSE buffer exceeded {} bytes, aborting stream",
+                MAX_SSE_BUFFER_BYTES
+            ));
+        }
+
+        let mut consumed = 0;
+        while let Some(rel_pos) = buffer[consumed..].find('\n') {
+            let newline_pos = consumed + rel_pos;
+            let line = buffer[consumed..newline_pos]
+                .trim_end_matches('\r')
+                .to_string();
+            consumed = newline_pos + 1;
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                if let Some(events) = parse_vertex_sse_data(data, &mut accumulated_usage, &mut last_finish_reason) {
+                    for event in events {
+                        let is_stop = matches!(event, StreamEvent::Stop { .. });
+                        let is_error = matches!(event, StreamEvent::Error { .. });
+                        if tx.send(event).await.is_err() {
+                            return Ok(());
+                        }
+                        if is_stop || is_error {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+        if consumed > 0 {
+            buffer.drain(..consumed);
+        }
+    }
+
+    // Emit stop if we haven't already
+    let reason = match last_finish_reason.as_deref() {
+        Some("MAX_TOKENS") => StopReason::MaxTokens,
+        Some("STOP") => StopReason::EndTurn,
+        _ => StopReason::EndTurn,
+    };
+
+    let _ = tx
+        .send(StreamEvent::Stop {
+            reason,
+            usage: accumulated_usage,
+        })
+        .await;
+
+    Ok(())
+}
+
+/// Parse a single SSE data payload from Vertex AI's streaming format.
+fn parse_vertex_sse_data(
+    data: &str,
+    accumulated_usage: &mut TokenUsage,
+    last_finish_reason: &mut Option<String>,
+) -> Option<Vec<StreamEvent>> {
+    // Vertex AI sends data as base64-encoded JSON
+    let decoded = match BASE64.decode(data.trim()) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            // Try parsing as plain JSON if base64 fails
+            return parse_vertex_json_data(data, accumulated_usage, last_finish_reason);
+        }
+    };
+
+    let json_str = match String::from_utf8(decoded) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+
+    parse_vertex_json_data(&json_str, accumulated_usage, last_finish_reason)
+}
+
+fn parse_vertex_json_data(
+    data: &str,
+    accumulated_usage: &mut TokenUsage,
+    last_finish_reason: &mut Option<String>,
+) -> Option<Vec<StreamEvent>> {
+    let parsed: Value = serde_json::from_str(data).ok()?;
+
+    // Check for error response
+    if let Some(error) = parsed.get("error") {
+        let message = error
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown API error")
+            .to_string();
+        return Some(vec![StreamEvent::Error { message }]);
+    }
+
+    // Extract usage metadata if present
+    if let Some(usage_metadata) = parsed.get("usageMetadata") {
+        if let Some(prompt_tokens) = usage_metadata
+            .get("promptTokenCount")
+            .and_then(|v| v.as_u64())
+        {
+            accumulated_usage.input_tokens = prompt_tokens;
+        }
+        if let Some(candidates_tokens) = usage_metadata
+            .get("candidatesTokenCount")
+            .and_then(|v| v.as_u64())
+        {
+            accumulated_usage.output_tokens = candidates_tokens;
+        }
+    }
+
+    // Process candidates
+    let candidates = parsed.get("candidates")?.as_array()?;
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let candidate = &candidates[0];
+
+    // Check for finish reason
+    if let Some(finish_reason) = candidate.get("finishReason").and_then(|v| v.as_str()) {
+        *last_finish_reason = Some(finish_reason.to_string());
+        return Some(parse_vertex_finish_chunk(candidate, finish_reason, accumulated_usage));
+    }
+
+    // No finish reason - process content parts
+    let parts = candidate
+        .get("content")
+        .and_then(|c| c.get("parts"))
+        .and_then(|p| p.as_array())?;
+
+    let events = collect_vertex_part_events(parts);
+    if events.is_empty() {
+        None
+    } else {
+        Some(events)
+    }
+}
+
+fn parse_vertex_finish_chunk(
+    candidate: &Value,
+    finish_reason: &str,
+    accumulated_usage: &TokenUsage,
+) -> Vec<StreamEvent> {
+    let reason = match finish_reason {
+        "STOP" => StopReason::EndTurn,
+        "MAX_TOKENS" => StopReason::MaxTokens,
+        "SAFETY" => StopReason::EndTurn,
+        _ => StopReason::EndTurn,
+    };
+
+    let parts = candidate
+        .get("content")
+        .and_then(|c| c.get("parts"))
+        .and_then(|p| p.as_array());
+
+    let mut events = Vec::new();
+
+    if let Some(parts) = parts {
+        let has_function_call = parts.iter().any(|p| p.get("functionCall").is_some());
+        events.extend(collect_vertex_part_events(parts));
+
+        let stop_reason = if has_function_call {
+            StopReason::ToolUse
+        } else {
+            reason
+        };
+        events.push(StreamEvent::Stop {
+            reason: stop_reason,
+            usage: *accumulated_usage,
+        });
+    } else {
+        events.push(StreamEvent::Stop {
+            reason,
+            usage: *accumulated_usage,
+        });
+    }
+
+    events
+}
+
+fn collect_vertex_part_events(parts: &[Value]) -> Vec<StreamEvent> {
+    let mut events = Vec::new();
+    for part in parts {
+        if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+            if !text.is_empty() {
+                events.push(StreamEvent::TextDelta {
+                    text: text.to_string(),
+                });
+            }
+        }
+        if let Some(fc) = part.get("functionCall") {
+            let name = fc
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let args = fc.get("args").cloned().unwrap_or(json!({}));
+            let id = uuid::Uuid::new_v4().to_string();
+            events.push(StreamEvent::ToolUse { id, name, input: args });
+        }
+    }
+    events
+}
+
+/// Determine whether a model identifier should route to the Vertex AI provider.
+pub fn is_vertex_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.starts_with("vertex:")
+}
+
+/// Strip the `vertex:` prefix from a model identifier.
+pub fn strip_vertex_prefix(model: &str) -> &str {
+    if let Some(rest) = model.strip_prefix("vertex:") {
+        rest
+    } else if let Some(rest) = model.strip_prefix("Vertex:") {
+        rest
+    } else {
+        model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== Provider construction tests ====================
+
+    #[test]
+    fn test_new_rejects_empty_project_id() {
+        let result = VertexProvider::new(
+            "".to_string(),
+            "us-central1".to_string(),
+            "access-token".to_string(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("project"), "error should mention project: {err}");
+    }
+
+    #[test]
+    fn test_new_rejects_empty_region() {
+        let result = VertexProvider::new(
+            "my-project".to_string(),
+            "".to_string(),
+            "access-token".to_string(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("region"), "error should mention region: {err}");
+    }
+
+    #[test]
+    fn test_new_rejects_empty_access_token() {
+        let result = VertexProvider::new(
+            "my-project".to_string(),
+            "us-central1".to_string(),
+            "".to_string(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("token"), "error should mention token: {err}");
+    }
+
+    #[test]
+    fn test_new_accepts_valid_params() {
+        let result = VertexProvider::new(
+            "my-project".to_string(),
+            "us-central1".to_string(),
+            "access-token".to_string(),
+        );
+        assert!(result.is_ok());
+        let provider = result.unwrap();
+        assert_eq!(provider.region(), "us-central1");
+    }
+
+    #[test]
+    fn test_with_access_token() {
+        let provider = VertexProvider::new(
+            "my-project".to_string(),
+            "us-central1".to_string(),
+            "token1".to_string(),
+        )
+        .unwrap()
+        .with_access_token("token2".to_string());
+        assert!(provider.access_token.is_some());
+    }
+
+    // ==================== Model detection tests ====================
+
+    #[test]
+    fn test_is_vertex_model() {
+        assert!(is_vertex_model("vertex:gemini-2.0-flash"));
+        assert!(is_vertex_model("vertex:gemini-1.5-pro"));
+        assert!(is_vertex_model("Vertex:gemini-2.0-flash"));
+
+        assert!(!is_vertex_model("gemini-2.0-flash"));
+        assert!(!is_vertex_model("gpt-4o"));
+    }
+
+    #[test]
+    fn test_strip_vertex_prefix() {
+        assert_eq!(strip_vertex_prefix("vertex:gemini-2.0-flash"), "gemini-2.0-flash");
+        assert_eq!(strip_vertex_prefix("Vertex:gemini-2.0-flash"), "gemini-2.0-flash");
+        assert_eq!(strip_vertex_prefix("gemini-2.0-flash"), "gemini-2.0-flash");
+    }
+
+    // ==================== build_body tests ====================
+
+    #[test]
+    fn test_build_body_basic() {
+        let provider = VertexProvider::new(
+            "my-project".to_string(),
+            "us-central1".to_string(),
+            "access-token".to_string(),
+        ).unwrap();
+        let request = CompletionRequest {
+            model: "gemini-2.0-flash".to_string(),
+            messages: vec![LlmMessage {
+                role: LlmRole::User,
+                content: vec![ContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            }],
+            system: Some("You are helpful.".to_string()),
+            tools: vec![],
+            max_tokens: 1024,
+            temperature: Some(0.7),
+            extra: None,
+        };
+        let body = provider.build_body(&request);
+
+        // System instruction
+        assert_eq!(
+            body["systemInstruction"]["parts"][0]["text"],
+            "You are helpful."
+        );
+
+        // Contents
+        let contents = body["contents"].as_array().unwrap();
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0]["role"], "user");
+        assert_eq!(contents[0]["parts"][0]["text"], "Hello");
+
+        // Generation config
+        assert_eq!(body["generationConfig"]["maxOutputTokens"], 1024);
+        assert_eq!(body["generationConfig"]["temperature"], 0.7);
+    }
+
+    #[test]
+    fn test_build_body_with_tools() {
+        let provider = VertexProvider::new(
+            "my-project".to_string(),
+            "us-central1".to_string(),
+            "access-token".to_string(),
+        ).unwrap();
+        let request = CompletionRequest {
+            model: "gemini-2.0-flash".to_string(),
+            messages: vec![],
+            system: None,
+            tools: vec![ToolDefinition {
+                name: "get_weather".to_string(),
+                description: "Get weather".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    }
+                }),
+            }],
+            max_tokens: 4096,
+            temperature: None,
+            extra: None,
+        };
+        let body = provider.build_body(&request);
+
+        assert!(body["tools"].is_array());
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        let func_decls = tools[0]["functionDeclarations"].as_array().unwrap();
+        assert_eq!(func_decls[0]["name"], "get_weather");
+    }
+}


### PR DESCRIPTION
## Summary

Add new LLM providers:

### New Providers
- **Azure OpenAI** (azure:*) - For Azure-deployed models
- **Vertex AI** (vertex:*) - For Google Cloud Vertex AI
- **OpenAI-compatible providers** with explicit routing:
  - DeepSeek (deepseek:*)
  - Qwen (qwen:*)
  - Moonshot/Kimi (moonshot:*, kimi:*)
  - Minimax (minimax:*)
  - GLM/Z.ai (glm:*, z.ai:*, zai:*)
  - xAI/Grok (xai:*, grok:*)
  - OpenRouter (openrouter:*)

### Configuration
All providers support configuration via config file or environment variables.

### Testing
All 2,471 tests pass.