### PR TITLE
ci: run jobs only when relevant categories change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:v1.7.1
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
         with:
           args: -color -shellcheck=
 


### PR DESCRIPTION
## Summary
- add a `changes` job using `dorny/paths-filter` with explicit categories:
  - `docs` (`docs/**`, `*.md`, and doc-adjacent files)
  - `workflow` (`.github/workflows/**`)
  - `rust_runtime` (Rust source/tests/build-critical files)
  - `docker` (Docker-related files)
- gate heavy Rust CI jobs (`fmt`, `clippy`, `build`, matrix `test`, `msrv`, `audit`, `deny`, `geiger`) behind `rust_runtime`
- gate container checks behind `docker`
- add `workflow-lint` and `docs-check` lightweight jobs
- add `ci-required` aggregator job so one required status remains stable even when many jobs are skipped
- add workflow-level concurrency cancellation for stale runs

## Why
- docs-only PRs no longer pay the cost of full multi-OS test matrix
- workflow-only PRs run fast targeted checks
- required-check behavior remains predictable with conditional jobs
