### PR TITLE
feat(sandbox): extend subprocess sandbox wiring for tailscale paths

### DIFF
--- a/docs/feature-evidence.yaml
+++ b/docs/feature-evidence.yaml
@@ -918,9 +918,12 @@ features:
   - feature: "tailscale.cli wrapper"
     status: "verified_done"
     runtime_wiring:
-      - "src/tailscale/mod.rs::run_command (async CLI execution)"
+      - "src/tailscale/mod.rs::run_command (async CLI execution via sandbox argv wrapper)"
+      - "src/agent/sandbox.rs::build_sandboxed_tokio_command"
+      - "src/agent/sandbox.rs::default_tailscale_cli_sandbox_config"
     tests:
       - "src/tailscale/mod.rs::test_build_teardown_args"
+      - "src/agent/sandbox.rs::test_build_sandboxed_tokio_command_disabled_passthrough"
 
   - feature: "tailscale.status parsing"
     status: "verified_done"
@@ -1221,10 +1224,18 @@ features:
       - "src/agent/sandbox.rs (process sandbox config, rlimits, seatbelt/landlock helpers)"
       - "src/agent/executor.rs (passes process_sandbox into tool dispatch)"
       - "src/agent/tools.rs (sets sandboxed flag on ToolInvokeContext)"
+      - "src/discovery/mod.rs::run_hostname_command (probe subprocess wrapper)"
+      - "src/server/bind.rs::detect_lan_ip_macos / detect_lan_ip_linux / detect_tailscale_ip (runtime probe wrappers)"
+      - "src/auth/mod.rs::tailscale_whois_login (tailscale whois subprocess wrapper)"
+      - "src/tailscale/mod.rs::run_command (tailscale CLI subprocess wrapper)"
     tests:
       - "src/agent/sandbox.rs (config + seatbelt/landlock helper tests)"
+      - "src/agent/sandbox.rs::test_default_probe_sandbox_config_limits"
+      - "src/agent/sandbox.rs::test_default_tailscale_cli_sandbox_config_limits"
     notes:
-      - "apply_sandbox / sandbox_command_prefix are not invoked in tool subprocess execution"
+      - "2026-02-16 local precheck: targeted nextest coverage for new probe/tailscale wrapper paths passed (sandbox/tailscale/auth/bind)."
+      - "tool subprocess inheritance is still partial: no in-child Linux landlock application for arbitrary child processes"
+      - "gateway SSH tunnel subprocess (`src/gateway/mod.rs::setup_ssh_tunnel`) is not yet sandbox-wrapped"
 
   - feature: "channel-specific tools"
     status: "partial"

--- a/docs/feature-status.yaml
+++ b/docs/feature-status.yaml
@@ -35,7 +35,7 @@ feature_inventory_markdown: |
   - [x] **Inbound message classifier** — LLM-based attack classification, circuit breaker (`classifier.rs`)
   - [x] **Output content sanitizer** — HTML/script/XSS stripping, CSP enforcement (`output_sanitizer.rs`)
   - [x] **Exfiltration guard** — filters tool definitions + blocks sensitive tools at dispatch (`exfiltration.rs`)
-  - [~] **OS-level process sandbox** — Seatbelt (macOS), Landlock (Linux), rlimits (`sandbox.rs`)
+  - [~] **OS-level process sandbox** — Seatbelt (macOS), Landlock (Linux), rlimits (`sandbox.rs`), wired for runtime probes + tailscale CLI/whois
   - [x] **Channel-specific tools** — 15 platform-specific tool schemas (`channel_tools.rs`)
 
   ### Authentication (`src/auth/`)

--- a/docs/security-comparison.md
+++ b/docs/security-comparison.md
@@ -75,7 +75,7 @@ Prompt injection remains an industry-wide unsolved problem. No AI system fully p
 - **Resource limits.** RLIMIT_CPU, RLIMIT_AS, RLIMIT_NOFILE per tool execution.
 - **Output content security.** HTML/Markdown sanitizer strips XSS vectors, dangerous tags, and non-image data URIs from agent output.
 
-*Caveat: sandbox primitives are implemented but subprocess wiring is not yet complete. See the status section below.*
+*Caveat: subprocess sandbox coverage is partial. Runtime probes and tailscale CLI/whois paths are wired, but full child-process coverage is still in progress.*
 
 ### 7. SSRF / DNS Rebinding
 
@@ -114,7 +114,7 @@ Rust does not help with logic bugs, auth bypass, or prompt injection. Those requ
 
 Carapace is in preview. The security architecture is real and tested (~5,000 automated tests, multi-platform CI), but some items are incomplete:
 
-- **Subprocess sandbox wiring.** Seatbelt/Landlock/rlimit primitives are implemented and tested, but not yet wired into tool subprocess execution. A tool that spawns a child process does not yet inherit the sandbox.
+- **Subprocess sandbox wiring.** Seatbelt/Landlock/rlimit primitives are implemented and partially wired. Runtime probe subprocesses and tailscale CLI/whois paths are wrapped; full child-process coverage remains in progress.
 - **Control UI.** The backend (routes, auth, CSRF) is complete. The frontend is not built yet.
 - **Channels.** Discord is verified end-to-end. Telegram requires a webhook (no long-polling), so it needs a tunnel or public endpoint. Signal and Slack are implemented but not yet smoke-tested in real environments.
 - **Audit log emission.** The audit log module is implemented (append-only JSONL, 19 event types, 50 MB rotation) but event emission is not yet wired into all runtime paths.

--- a/src/agent/sandbox.rs
+++ b/src/agent/sandbox.rs
@@ -136,6 +136,32 @@ fn default_probe_allowed_paths() -> Vec<String> {
     default_allowed_paths()
 }
 
+#[cfg(target_os = "macos")]
+fn default_tailscale_allowed_paths() -> Vec<String> {
+    let mut paths = default_probe_allowed_paths();
+    if !paths.iter().any(|p| p == "/var/run") {
+        paths.push("/var/run".to_string());
+    }
+    paths
+}
+
+#[cfg(target_os = "linux")]
+fn default_tailscale_allowed_paths() -> Vec<String> {
+    let mut paths = default_probe_allowed_paths();
+    if !paths.iter().any(|p| p == "/run") {
+        paths.push("/run".to_string());
+    }
+    if !paths.iter().any(|p| p == "/var/run") {
+        paths.push("/var/run".to_string());
+    }
+    paths
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn default_tailscale_allowed_paths() -> Vec<String> {
+    default_probe_allowed_paths()
+}
+
 /// Build a conservative sandbox profile for short-lived runtime probe commands.
 ///
 /// Intended for low-risk helper subprocesses such as `hostname`, `route`,
@@ -149,6 +175,23 @@ pub fn default_probe_sandbox_config() -> ProcessSandboxConfig {
         max_fds: 64,
         allowed_paths: default_probe_allowed_paths(),
         network_access: false,
+        env_filter: Vec::new(),
+    }
+}
+
+/// Build a sandbox profile for Tailscale CLI helper subprocesses.
+///
+/// This profile is less restrictive than `default_probe_sandbox_config()`
+/// because `tailscale` commands may need local daemon IPC paths and localhost
+/// networking to communicate with tailscaled.
+pub fn default_tailscale_cli_sandbox_config() -> ProcessSandboxConfig {
+    ProcessSandboxConfig {
+        enabled: true,
+        max_cpu_seconds: 10,
+        max_memory_mb: 256,
+        max_fds: 128,
+        allowed_paths: default_tailscale_allowed_paths(),
+        network_access: true,
         env_filter: Vec::new(),
     }
 }
@@ -657,6 +700,22 @@ pub fn build_sandboxed_std_command(
     cmd
 }
 
+/// Build a Tokio command with optional sandbox wrapping.
+///
+/// This mirrors `build_sandboxed_std_command` for async subprocess call sites.
+pub fn build_sandboxed_tokio_command(
+    program: &str,
+    args: &[&str],
+    config: Option<&ProcessSandboxConfig>,
+) -> tokio::process::Command {
+    let argv = sandbox_command_argv(program, args, config);
+    let mut cmd = tokio::process::Command::new(&argv[0]);
+    if argv.len() > 1 {
+        cmd.args(&argv[1..]);
+    }
+    cmd
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -962,6 +1021,22 @@ mod tests {
     }
 
     #[test]
+    fn test_build_sandboxed_tokio_command_disabled_passthrough() {
+        let config = ProcessSandboxConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let command = build_sandboxed_tokio_command("hostname", &["-f"], Some(&config));
+        let std_cmd = command.as_std();
+        assert_eq!(std_cmd.get_program(), std::ffi::OsStr::new("hostname"));
+        let args: Vec<String> = std_cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["-f".to_string()]);
+    }
+
+    #[test]
     fn test_default_probe_sandbox_config_limits() {
         let config = default_probe_sandbox_config();
         assert!(config.enabled);
@@ -969,6 +1044,17 @@ mod tests {
         assert_eq!(config.max_memory_mb, 128);
         assert_eq!(config.max_fds, 64);
         assert!(!config.network_access);
+        assert!(!config.allowed_paths.is_empty());
+    }
+
+    #[test]
+    fn test_default_tailscale_cli_sandbox_config_limits() {
+        let config = default_tailscale_cli_sandbox_config();
+        assert!(config.enabled);
+        assert_eq!(config.max_cpu_seconds, 10);
+        assert_eq!(config.max_memory_mb, 256);
+        assert_eq!(config.max_fds, 128);
+        assert!(config.network_access);
         assert!(!config.allowed_paths.is_empty());
     }
 
@@ -980,12 +1066,28 @@ mod tests {
         assert!(config.allowed_paths.iter().any(|p| p == "/System"));
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_default_tailscale_cli_sandbox_config_paths_macos() {
+        let config = default_tailscale_cli_sandbox_config();
+        assert!(config.allowed_paths.iter().any(|p| p == "/private/var"));
+        assert!(config.allowed_paths.iter().any(|p| p == "/var/run"));
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn test_default_probe_sandbox_config_paths_linux() {
         let config = default_probe_sandbox_config();
         assert!(config.allowed_paths.iter().any(|p| p == "/proc"));
         assert!(config.allowed_paths.iter().any(|p| p == "/lib64"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_default_tailscale_cli_sandbox_config_paths_linux() {
+        let config = default_tailscale_cli_sandbox_config();
+        assert!(config.allowed_paths.iter().any(|p| p == "/run"));
+        assert!(config.allowed_paths.iter().any(|p| p == "/var/run"));
     }
 
     #[cfg(target_os = "macos")]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -8,7 +8,8 @@ pub mod profiles;
 use axum::http::HeaderMap;
 use serde_json::Value;
 use std::net::{IpAddr, SocketAddr};
-use std::process::Command;
+
+use crate::agent::sandbox::{build_sandboxed_std_command, default_tailscale_cli_sandbox_config};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum AuthMode {
@@ -385,8 +386,8 @@ fn extract_whois_login(value: &Value) -> Option<String> {
 }
 
 fn tailscale_whois_login(ip: &str) -> Option<String> {
-    let output = Command::new("tailscale")
-        .args(["whois", "--json", ip])
+    let sandbox = default_tailscale_cli_sandbox_config();
+    let output = build_sandboxed_std_command("tailscale", &["whois", "--json", ip], Some(&sandbox))
         .output()
         .ok()?;
     if !output.status.success() {

--- a/src/server/bind.rs
+++ b/src/server/bind.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use crate::agent::sandbox::{
-    build_sandboxed_std_command, default_probe_sandbox_config, ProcessSandboxConfig,
+    build_sandboxed_std_command, default_probe_sandbox_config, default_tailscale_cli_sandbox_config,
 };
 
 /// Default gateway port
@@ -221,7 +221,7 @@ fn detect_tailscale_ip() -> Result<IpAddr, BindError> {
     let output = {
         #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
-            let sandbox = tailscale_probe_sandbox_config();
+            let sandbox = default_tailscale_cli_sandbox_config();
             build_sandboxed_std_command("tailscale", &["ip", "-4"], Some(&sandbox)).output()
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
@@ -254,26 +254,6 @@ fn detect_tailscale_ip() -> Result<IpAddr, BindError> {
             "IP {} is not in Tailscale range",
             ip
         )))
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-fn tailscale_probe_sandbox_config() -> ProcessSandboxConfig {
-    #[cfg(target_os = "linux")]
-    {
-        let mut sandbox = default_probe_sandbox_config();
-        if !sandbox.allowed_paths.iter().any(|p| p == "/run") {
-            sandbox.allowed_paths.push("/run".to_string());
-        }
-        if !sandbox.allowed_paths.iter().any(|p| p == "/var/run") {
-            sandbox.allowed_paths.push("/var/run".to_string());
-        }
-        sandbox
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        default_probe_sandbox_config()
     }
 }
 

--- a/src/tailscale/mod.rs
+++ b/src/tailscale/mod.rs
@@ -10,6 +10,8 @@
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
+use crate::agent::sandbox::{build_sandboxed_tokio_command, default_tailscale_cli_sandbox_config};
+
 // ============================================================================
 // Core types
 // ============================================================================
@@ -175,8 +177,8 @@ async fn run_command(
     cli_path: &str,
     args: &[&str],
 ) -> Result<std::process::Output, TailscaleError> {
-    tokio::process::Command::new(cli_path)
-        .args(args)
+    let sandbox = default_tailscale_cli_sandbox_config();
+    build_sandboxed_tokio_command(cli_path, args, Some(&sandbox))
         .output()
         .await
         .map_err(|e| {


### PR DESCRIPTION
## Summary
- extend subprocess sandbox wiring for tailscale CLI call sites with a shared `default_tailscale_cli_sandbox_config()`
- add shared async subprocess wrapper support via `build_sandboxed_tokio_command(...)`
- wire sandboxed subprocess execution into:
  - `src/auth/mod.rs` (`tailscale whois --json`)
  - `src/tailscale/mod.rs` (async tailscale command runner)
  - `src/server/bind.rs` (`tailscale ip -4` probe path)
- align docs and evidence to reflect current partial subprocess coverage:
  - `docs/feature-status.yaml`
  - `docs/feature-evidence.yaml`
  - `docs/security-comparison.md`

## Validation
- pre-push `cargo nextest run` completed successfully (`5001 passed, 0 failed`)
- added/updated sandbox tests in `src/agent/sandbox.rs` for:
  - async command builder passthrough behavior
  - tailscale CLI sandbox limits and OS-specific allowed paths

## Remaining Gap (explicit)
- full child-process sandbox inheritance for all tool subprocesses is still in progress
- gateway SSH tunnel subprocess remains outside wrapper scope in this PR
