### PR TITLE
ci/security: reduce high-priority CodeQL findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,6 +5,10 @@ on:
     types: [created]
   issues:
     types: [opened]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
@@ -15,6 +19,7 @@ jobs:
     if: |
       (
         github.event_name == 'issue_comment' &&
+        !github.event.issue.pull_request &&
         contains(github.event.comment.body || '', '@claude') &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       ) ||
@@ -22,24 +27,34 @@ jobs:
         github.event_name == 'issues' &&
         (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title || '', '@claude')) &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body || '', '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body || '', '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
       actions: read
     steps:
-      - name: Checkout repository (PR context)
-        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+      - name: Checkout repository (PR review context)
+        if: ${{ github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Checkout repository (issue context)
-        if: ${{ github.event_name == 'issues' || (github.event_name == 'issue_comment' && !github.event.issue.pull_request) }}
+        if: ${{ github.event_name == 'issues' || github.event_name == 'issue_comment' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1

--- a/src/agent/gemini.rs
+++ b/src/agent/gemini.rs
@@ -186,8 +186,8 @@ impl LlmProvider for GeminiProvider {
         // Strip any prefix (gemini/, models/) to get the bare model name for the URL
         let model_name = strip_gemini_prefix(&request.model);
         let url = format!(
-            "{}/v1beta/models/{}:streamGenerateContent?alt=sse&key={}",
-            self.base_url, model_name, self.api_key
+            "{}/v1beta/models/{}:streamGenerateContent?alt=sse",
+            self.base_url, model_name
         );
 
         let response = tokio::select! {
@@ -197,6 +197,7 @@ impl LlmProvider for GeminiProvider {
             response = self
                 .client
                 .post(&url)
+                .header("x-goog-api-key", &self.api_key)
                 .header("content-type", "application/json")
                 .header("accept", "text/event-stream")
                 .json(&body)


### PR DESCRIPTION
## Summary
- harden `claude.yml` event handling to avoid privileged PR-head checkout from `issue_comment`
- add explicit top-level token permissions in `ci.yml` (`contents: read`)
- remove Gemini API key from request URL query params; send it in `x-goog-api-key` header instead

## Why
This is a focused pass to reduce the highest-value open CodeQL findings while PR #48 continues review.

Targets addressed in this PR:
- `actions/untrusted-checkout/high`
- `actions/untrusted-checkout-toctou/high`
- `actions/missing-workflow-permissions`
- `rust/cleartext-transmission` in Gemini provider path

## Notes
- PR review triggers for `@claude` remain enabled, but checkout now uses the default branch context (not PR head) in this workflow.
- This does **not** attempt to clear all 105 alerts in one batch; remaining items (notably test-only crypto-value findings and other likely false positives/noise) should be handled in follow-up triage PR(s).

## Validation
- `cargo fmt`
- `cargo check`
- YAML parse check for modified workflow files
