### PR TITLE
Improve setup sensitive-input UX across channels

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1787,7 +1787,7 @@ fn prompt_optional_value_from_env(
     if let Some(value) = env_value {
         let use_env = prompt_yes_no(&format!("Use {label} from ${env_var}?"), true)?;
         if use_env {
-            return Ok(Some(value));
+            return Ok(Some(value.trim().to_string()));
         }
     }
 
@@ -1851,28 +1851,50 @@ fn prompt_hidden_line(prompt: &str) -> Result<String, Box<dyn std::error::Error>
     Ok(input.trim().to_string())
 }
 
-fn prompt_sensitive_line(
-    label: &str,
-    hide_sensitive_input: bool,
-    allow_blank: bool,
-) -> Result<String, Box<dyn std::error::Error>> {
+fn sensitive_prompt_text(label: &str, hide_sensitive_input: bool, allow_blank: bool) -> String {
     let visibility_hint = if hide_sensitive_input {
         "input hidden; pasted text will not be shown"
     } else {
-        "input visible"
+        "input visible (WARNING: secrets will be shown on screen)"
     };
     let blank_hint = if allow_blank {
         ", leave blank to skip for now"
     } else {
         ""
     };
-    let prompt = format!("Enter {label} ({visibility_hint}{blank_hint}): ");
 
+    format!("Enter {label} ({visibility_hint}{blank_hint}): ")
+}
+
+fn prompt_sensitive_line_with<FHidden, FVisible>(
+    prompt: &str,
+    hide_sensitive_input: bool,
+    prompt_hidden: FHidden,
+    prompt_visible: FVisible,
+) -> Result<String, Box<dyn std::error::Error>>
+where
+    FHidden: FnOnce(&str) -> Result<String, Box<dyn std::error::Error>>,
+    FVisible: FnOnce(&str) -> Result<String, Box<dyn std::error::Error>>,
+{
     if hide_sensitive_input {
-        prompt_hidden_line(&prompt)
+        prompt_hidden(prompt)
     } else {
-        prompt_line(&prompt)
+        prompt_visible(prompt)
     }
+}
+
+fn prompt_sensitive_line(
+    label: &str,
+    hide_sensitive_input: bool,
+    allow_blank: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let prompt = sensitive_prompt_text(label, hide_sensitive_input, allow_blank);
+    prompt_sensitive_line_with(
+        &prompt,
+        hide_sensitive_input,
+        prompt_hidden_line,
+        prompt_line,
+    )
 }
 
 fn prompt_with_default(prompt: &str, default: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -2004,14 +2026,18 @@ fn map_channel_validation_error(
     channel_name: &str,
     err: crate::channels::ChannelAuthError,
 ) -> String {
-    if err.is_auth() {
-        format!("{channel_name} credential check failed: {}", err.message())
+    let detail = err.message();
+    let mut message = if err.is_auth() {
+        format!("{channel_name} credential check failed.")
     } else {
-        format!(
-            "{channel_name} credential check hit a transient error: {}",
-            err.message()
-        )
+        format!("{channel_name} credential check hit a transient error.")
+    };
+
+    if !detail.trim().is_empty() {
+        message.push_str(" Details are hidden because they may contain sensitive information.");
     }
+
+    message
 }
 
 fn prompt_and_configure_bot_channel(
@@ -2022,12 +2048,8 @@ fn prompt_and_configure_bot_channel(
     hide_sensitive_input: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let token_label = format!("{channel_label} bot token");
-    let channel_token = prompt_optional_value_from_env(
-        env_var,
-        &token_label,
-        &format!("{channel_label} bot token"),
-        hide_sensitive_input,
-    )?;
+    let channel_token =
+        prompt_optional_value_from_env(env_var, &token_label, &token_label, hide_sensitive_input)?;
     if let Some(token) = channel_token {
         println!("{channel_label} token captured.");
         validate_channel_credentials_interactive(channel_key, &token)?;
@@ -4562,6 +4584,79 @@ mod tests {
     fn test_parse_setup_outcome_invalid() {
         assert_eq!(parse_setup_outcome(""), None);
         assert_eq!(parse_setup_outcome("unknown"), None);
+    }
+
+    #[test]
+    fn test_sensitive_prompt_text_hidden_with_skip_hint() {
+        let prompt = sensitive_prompt_text("API key", true, true);
+        assert_eq!(
+            prompt,
+            "Enter API key (input hidden; pasted text will not be shown, leave blank to skip for now): "
+        );
+    }
+
+    #[test]
+    fn test_sensitive_prompt_text_visible_warns_without_skip_hint() {
+        let prompt = sensitive_prompt_text("Telegram bot token", false, false);
+        assert_eq!(
+            prompt,
+            "Enter Telegram bot token (input visible (WARNING: secrets will be shown on screen)): "
+        );
+    }
+
+    #[test]
+    fn test_prompt_sensitive_line_with_uses_hidden_reader() {
+        let expected_prompt = "Enter gateway token (input hidden; pasted text will not be shown): ";
+        let value = prompt_sensitive_line_with(
+            expected_prompt,
+            true,
+            |prompt| {
+                assert_eq!(prompt, expected_prompt);
+                Ok("hidden-value".to_string())
+            },
+            |_prompt| panic!("visible reader should not be called when hide_sensitive_input=true"),
+        )
+        .expect("hidden prompt should succeed");
+
+        assert_eq!(value, "hidden-value");
+    }
+
+    #[test]
+    fn test_prompt_sensitive_line_with_uses_visible_reader() {
+        let expected_prompt =
+            "Enter gateway token (input visible (WARNING: secrets will be shown on screen)): ";
+        let value = prompt_sensitive_line_with(
+            expected_prompt,
+            false,
+            |_prompt| panic!("hidden reader should not be called when hide_sensitive_input=false"),
+            |prompt| {
+                assert_eq!(prompt, expected_prompt);
+                Ok("visible-value".to_string())
+            },
+        )
+        .expect("visible prompt should succeed");
+
+        assert_eq!(value, "visible-value");
+    }
+
+    #[test]
+    fn test_map_channel_validation_error_redacts_auth_detail() {
+        let err = crate::channels::ChannelAuthError::auth("token abc123 rejected");
+        let message = map_channel_validation_error("Telegram", err);
+        assert_eq!(
+            message,
+            "Telegram credential check failed. Details are hidden because they may contain sensitive information."
+        );
+    }
+
+    #[test]
+    fn test_map_channel_validation_error_redacts_transient_detail() {
+        let err = crate::channels::ChannelAuthError::transient("upstream returned HTML body");
+        let message = map_channel_validation_error("Discord", err);
+        assert_eq!(
+            message,
+            "Discord credential check hit a transient error. Details are hidden because they may contain sensitive information."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a setup-wide sensitive-input preference (`Hide sensitive input while typing?`) so users can choose hidden vs visible entry
- apply that preference across all sensitive setup inputs:
  - provider API key
  - gateway token/password manual entry
  - hooks token manual entry
  - Discord and Telegram bot tokens
- clarify token flow messaging:
  - when provided: `<Channel> token captured.`
  - when blank: explicit skip message (`No <Channel> token entered; skipping credential validation.`)
- remove `Recommended.` wording from setup prompts for cleaner, neutral UX

## Why
- addresses confusion from hidden token entry where pasted input appears "not accepted" because it is intentionally not echoed
- makes setup behavior consistent across channels and secret prompts, not just Telegram
- reduces onboarding friction without weakening secret masking defaults

## Validation
- `cargo fmt`
- `cargo nextest run -p carapace test_handle_setup_force_creates_config test_handle_setup_creates_valid_json5_config test_handle_setup_default_values test_validate_channel_credentials_bridge_inside_current_thread_runtime_is_panic_free test_setup_post_checks_bridge_inside_current_thread_runtime_does_not_panic`
- full pre-push suite run on branch update: `5175 passed`
- Linux smoke in local container (existing built binary, no rebuild required): scripted interactive Telegram path with real token returned `TG_VALIDATE_SUCCESS` and no runtime panic

## Scope
- setup UX only (`src/cli/mod.rs`)
