### PR TITLE
test: harden watcher env-mutating tests against host leakage

### DIFF
--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_perform_reload_with_no_config_file() {
-        let _lock = ENV_VAR_TEST_LOCK.lock().expect("env var test lock");
+        let _lock = ENV_VAR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let temp_dir = tempfile::TempDir::new().unwrap();
         let missing_config_path = temp_dir.path().join("missing-carapace.json5");
         let _config_path_guard = EnvVarGuard::set(
@@ -601,7 +601,7 @@ mod tests {
     #[tokio::test]
     async fn test_reload_validation_with_temp_config() {
         use std::io::Write;
-        let _lock = ENV_VAR_TEST_LOCK.lock().expect("env var test lock");
+        let _lock = ENV_VAR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::TempDir::new().unwrap();
         let config_path = dir.path().join("carapace.json5");
 
@@ -621,7 +621,7 @@ mod tests {
     #[tokio::test]
     async fn test_reload_invalid_config_fails() {
         use std::io::Write;
-        let _lock = ENV_VAR_TEST_LOCK.lock().expect("env var test lock");
+        let _lock = ENV_VAR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::TempDir::new().unwrap();
         let config_path = dir.path().join("carapace.json5");
 


### PR DESCRIPTION
## Summary
- add serialization lock for env-mutating tests in `src/config/watcher.rs`
- make `test_perform_reload_with_no_config_file` hermetic by forcing `CARAPACE_CONFIG_PATH` to a temp missing path
- explicitly disable config cache and clear cache around env-sensitive watcher tests

## Why
Watcher tests could read ambient local config paths/state and fail nondeterministically. This hardens env-mutating tests against host-machine leakage.

## Validation
- `cargo nextest run config::watcher::tests:: --all-targets`
