### PR TITLE
docs: clarify production hooks sender secret guidance

### DIFF
--- a/docs/protocol/http.md
+++ b/docs/protocol/http.md
@@ -34,7 +34,6 @@ Hooks require a **hooks token** (not service auth). Accepted forms:
 
 - `Authorization: Bearer ${CARAPACE_HOOKS_TOKEN}`
 - `X-Carapace-Token: ${CARAPACE_HOOKS_TOKEN}`
-- `?token=${CARAPACE_HOOKS_TOKEN}` (deprecated; logs a warning)
 
 ### Common behavior
 - Method: **POST** only
@@ -52,6 +51,12 @@ Error body format for JSON parse/validation errors:
 ```json
 { "ok": false, "error": "{message}" }
 ```
+
+### Production secret hygiene
+
+For production deployments, set `CARAPACE_SERVER_SECRET`.
+When this is unset, hooks sender-scoping key derivation falls back to a built-in
+constant intended for local/dev use, not long-lived production environments.
 
 #### POST `{basePath}/wake`
 Trigger a wake event.

--- a/docs/site/ops.md
+++ b/docs/site/ops.md
@@ -25,7 +25,18 @@ For deeper troubleshooting, use:
 - [Get Unstuck](get-unstuck.md)
 - [CLI guide](../cli.md)
 
-## 3) Backup and restore
+## 3) Production secret baseline
+
+Set a deployment-specific server secret in production:
+
+```bash
+export CARAPACE_SERVER_SECRET='<long-random-secret>'
+```
+
+This avoids hooks sender-scoping fallback behavior that is acceptable for local
+development but not ideal for long-lived production deployments.
+
+## 4) Backup and restore
 
 Create a backup before major config/channel changes:
 
@@ -39,7 +50,7 @@ Restore from backup:
 cara restore --path ./carapace-backup.tar.gz
 ```
 
-## 4) Update flow
+## 5) Update flow
 
 Check/update the local binary:
 
@@ -51,7 +62,7 @@ For pinned or reproducible installs, use the install guide:
 
 - [Install](install.md)
 
-## 5) First-response recovery checklist
+## 6) First-response recovery checklist
 
 1. Confirm service health and port/bind settings.
 2. Capture recent logs and isolate the first failing component (provider/channel/auth).
@@ -59,7 +70,7 @@ For pinned or reproducible installs, use the install guide:
 4. Restore from latest known-good backup if needed.
 5. Open an issue with logs + exact steps if still blocked.
 
-## 6) Next paths
+## 7) Next paths
 
 - [First Run](first-run.md)
 - [Cookbook](../cookbook/README.md)


### PR DESCRIPTION
## Summary
- document production guidance to set `CARAPACE_SERVER_SECRET`
- add hooks sender-scoping fallback warning for local/dev-only fallback behavior
- remove stale hooks `?token=` auth mention from HTTP protocol docs (header auth only)

## Why
Keeps hooks documentation aligned with current behavior and makes production secret hygiene explicit.

## Validation
- docs-only change
