### PR TITLE
perf: avoid unnecessary ws auth secret cloning

### DIFF
--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -1003,10 +1003,20 @@ fn resolve_session_integrity_secret(
     if let Some(secret) = env_server_secret.filter(|value| !value.is_empty()) {
         return Some((secret, "CARAPACE_SERVER_SECRET"));
     }
-    if let Some(secret) = auth.token.clone().filter(|value| !value.is_empty()) {
+    if let Some(secret) = auth
+        .token
+        .as_ref()
+        .filter(|value| !value.is_empty())
+        .cloned()
+    {
         return Some((secret, "gateway token"));
     }
-    if let Some(secret) = auth.password.clone().filter(|value| !value.is_empty()) {
+    if let Some(secret) = auth
+        .password
+        .as_ref()
+        .filter(|value| !value.is_empty())
+        .cloned()
+    {
         return Some((secret, "gateway password"));
     }
     None


### PR DESCRIPTION
## Summary
- update `resolve_session_integrity_secret` in `src/server/ws/mod.rs` to use `as_ref().filter(...).cloned()`
- avoid cloning `auth.token` / `auth.password` when values are empty

## Why
Small hot-path cleanup with no behavior change; avoids unnecessary allocations when auth fields are empty.

## Validation
- pre-commit checks (`cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`)
