### PR TITLE
ci(release): fix cosign v4 signing step by emitting bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           for artifact in artifacts/*; do
             if [ -f "$artifact" ]; then
               cosign sign-blob --yes \
+                --bundle "${artifact}.bundle" \
                 --output-signature "${artifact}.sig" \
                 --output-certificate "${artifact}.pem" \
                 "$artifact"


### PR DESCRIPTION
## Summary
- Fix release workflow failure in `Sign release artifacts` after cosign installer v4.
- Add `--bundle "${artifact}.bundle"` to `cosign sign-blob` so signing config requirements are satisfied.

## Root cause
Release run for `v0.1.0-preview11` failed with:
- `must provide --bundle with --signing-config or --use-signing-config`

## Validation
- Workflow YAML updated only (`.github/workflows/release.yml`).
- No runtime code changes.

## Follow-up
- Merge this PR, then cut `v0.1.0-preview12` to publish artifacts successfully (existing `preview11` run won't pick up workflow changes retroactively).
