### PR TITLE
ci: align claude review trigger coverage with taisr

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
@@ -20,6 +20,7 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
+      actions: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- add `ready_for_review` and `reopened` to `claude-code-review.yml` triggers so review runs when a draft is marked ready and when PRs are reopened
- add `actions: read` to Claude review job permissions for parity with robust usage in `taisr`

## Why these changes
- `taisr` review workflow runs on more PR lifecycle events; this closes that gap
- `actions: read` is a safe permission addition and useful when Claude needs to inspect CI/job context

## Intentionally not ported from `taisr`
- `paths-ignore` for docs/markdown-only PRs: kept disabled in `carapace` so Claude can still review docs-heavy PRs
- `skip workflow-change PRs`: kept current `carapace` behavior (run Claude, tolerate expected failure only for workflow-self-change)
