### PR TITLE
chore: make pre-commit rust checks conditional and progress-visible

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -4,10 +4,18 @@
 
 set -euo pipefail
 
-staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"
-if echo "${staged_files}" | grep -Eq '(^|/)(Cargo\.toml|Cargo\.lock|rust-toolchain(\.toml)?|clippy\.toml)$|(^|/)\.cargo/|\.rs$'; then
-    # Force visible progress output so long builds don't look stalled.
-    export CARGO_TERM_PROGRESS_WHEN=always
+if ! git diff --cached --quiet --diff-filter=ACMRD -- \
+    ':(glob)**/*.rs' \
+    ':(glob)**/Cargo.toml' \
+    ':(glob)**/Cargo.lock' \
+    ':(glob)**/rust-toolchain' \
+    ':(glob)**/rust-toolchain.toml' \
+    ':(glob)**/clippy.toml' \
+    ':(glob).cargo/**' \
+    ':(glob)**/.cargo/**'; then
+    # Force visible progress output so long builds don't look stalled,
+    # while respecting an explicit user preference if one is already set.
+    export CARGO_TERM_PROGRESS_WHEN="${CARGO_TERM_PROGRESS_WHEN:-always}"
 
     echo "Rust/Cargo changes detected in staged files; running Rust checks..."
     echo "Running cargo fmt --check..."


### PR DESCRIPTION
## Summary
- update `scripts/hooks/pre-commit` to run `cargo fmt`/`cargo clippy` only when staged files include Rust/Cargo-related paths
- force visible cargo progress output during hook-run Rust checks via `CARGO_TERM_PROGRESS_WHEN=always`
- keep staged-secret scanning (`gitleaks`) unchanged

## Why
- avoids expensive full-Rust checks on docs/workflow/script-only commits
- reduces "looks hung" confusion during long clippy runs by making progress output explicit

## Validation
- `./scripts/hooks/pre-commit` (with non-Rust staged changes) now reports skip for Rust checks and still runs gitleaks
- `./scripts/setup-hooks.sh` applied the updated hook locally
