### PR TITLE
ci(claude): enforce single deterministic review publish

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -254,7 +254,12 @@ jobs:
             const unplaced = [];
 
             for (const finding of inline) {
-              const p = String(finding.path || '');
+              const pRaw = String(finding.path || '');
+              const p = pRaw.trim();
+              if (!p) {
+                unplaced.push(finding);
+                continue;
+              }
               const rawLine = finding.line;
               const parsedLine = Number(rawLine);
               const lineNumber = Number.isInteger(rawLine) ? rawLine : parsedLine;


### PR DESCRIPTION
## Summary
Replace the current Claude PR-review flow (where Claude posts directly) with a deterministic two-phase model:

1. **Analyze (read-only)**
   - Claude writes structured findings JSON to `.claude/review.json`
   - Claude cannot call GH review/comment APIs from allowed tools
   - workflow validates JSON schema and uploads it as an artifact

2. **Publish (single writer)**
   - workflow reads the structured artifact
   - workflow publishes exactly one PR review via `github-script`
   - inline comments are attached only for findings that map to changed diff lines

Also keeps a fallback cleanup job that removes/minimizes stray Claude-authored artifacts from the same run window.

## Why
Current behavior still allows noisy placeholder reviews/comments (`"Blocking findings present."`, empty review bodies, etc.).
This change prevents spam at source by removing direct posting capability from Claude and centralizing posting in deterministic workflow code.

## Key behavior changes
- Claude no longer posts reviews/comments directly.
- Exactly one review is published per run (when publish is eligible).
- Dependabot PRs remain skipped.
- Workflow-change PRs still tolerate expected Claude action failure.

## Validation done
- YAML parses successfully (`ruby` YAML load).
- Workflow logic includes schema validation + publish eligibility gating + fallback cleanup.

## Follow-up validation on merge candidate
Run this workflow on a PR sync and verify:
1. no placeholder Claude top-level reviews/comments appear
2. exactly one review is posted by workflow publisher
3. inline comments only appear for valid diff locations
