### PR TITLE
test(cli): add scripted interactive setup harness coverage

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2530,7 +2530,7 @@ fn stdin_is_interactive() -> bool {
     #[cfg(test)]
     {
         // Keep tests deterministic: default to non-interactive unless explicitly forced.
-        return setup_interactive_test_harness_override_interactive().unwrap_or(false);
+        setup_interactive_test_harness_override_interactive().unwrap_or(false)
     }
 
     #[cfg(not(test))]


### PR DESCRIPTION
## Summary
- add a test-only scripted interactive setup harness in `src/cli/mod.rs` for deterministic prompt and validation control
- route interactive detection through a helper with a test override so `handle_setup` interactive paths can be exercised without a TTY
- add integration-style `handle_setup` tests covering:
  - hidden sensitive-input mode with blank Telegram token (validation skipped)
  - visible sensitive-input mode with Telegram token validation success
  - Telegram validation failure path with explicit setup abort

## Why
This closes the Milestone 5 follow-up to prevent setup-flow regressions by testing real interactive control flow (not only isolated prompt helpers), including validation branches that previously depended on runtime/network behavior.

## Testing
- `cargo fmt`
- `./scripts/run-nextest-guarded.sh --all-targets test_handle_setup_interactive_hidden_input_skips_telegram_validation_on_blank_token test_handle_setup_interactive_visible_input_validates_telegram_token test_handle_setup_interactive_telegram_validation_failure_aborts_when_user_declines_continue`
