### PR TITLE
ci(claude): fix missing review publish by allowing Write

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -78,6 +78,7 @@ jobs:
             - Do NOT call gh APIs for comments/reviews.
             - Output only structured findings JSON to: .claude/review.json
             - Overwrite the file each run.
+            - Use the Write tool to create .claude/review.json; do not use Bash redirection to write files.
 
             Required JSON output (example; must be valid JSON):
             {
@@ -114,7 +115,7 @@ jobs:
             - If inline_findings is non-empty, header MUST be "Blocking findings present.".
             - No markdown/code fences in .claude/review.json; emit valid JSON only.
           claude_args: |
-            --allowedTools "Bash(git:*),Bash(rg:*),Bash(ls:*),Bash(find:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(jq:*),Bash(sed:*),Bash(echo:*),Bash(awk:*),Bash(wc:*),WebSearch"
+            --allowedTools "Bash(git:*),Bash(rg:*),Bash(ls:*),Bash(find:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(jq:*),Bash(sed:*),Bash(echo:*),Bash(awk:*),Bash(wc:*),WebSearch,Write"
 
       - name: Validate Claude review output JSON
         id: validate-review-json


### PR DESCRIPTION
## Summary
- fix Claude review publish path by allowing the `Write` tool in `claude_args`
- add explicit prompt instruction requiring `Write` for `.claude/review.json` (no Bash redirection writes)

## Root cause
On PR #125, `claude-review` succeeded but produced `permission_denials` for both `Write` and file-writing Bash calls. As a result, `.claude/review.json` was never created, JSON validation failed, and `Publish single PR review` was skipped.

## Validation
- `just workflow-lint`
- inspected run logs for workflow `Claude Code Review` (run `22647506236`) showing denied `Write`/Bash file-write attempts and skipped publish job
