### PR TITLE
build(deps): migrate keyring to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2426,15 +2426,17 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "2.3.3"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
- "lazy_static",
  "linux-keyutils",
+ "log",
  "security-framework 2.11.1",
- "windows-sys 0.52.0",
+ "security-framework 3.5.1",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -3530,7 +3532,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3568,9 +3570,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4006,7 +4008,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4065,7 +4067,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4765,10 +4767,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5942,7 +5944,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dirs = "6"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "time"] }
-keyring = { version = "2.3.3", default-features = false, features = ["platform-macos", "platform-windows", "linux-default-keyutils"] }
+keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "windows-native", "linux-native"] }
 wasmtime = { version = "42", features = ["component-model"] }
 thiserror = "2"
 parking_lot = "0.12"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2411,15 +2411,17 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "2.3.3"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
- "lazy_static",
  "linux-keyutils",
+ "log",
  "security-framework 2.11.1",
- "windows-sys 0.52.0",
+ "security-framework 3.5.1",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]

--- a/src/credentials/linux.rs
+++ b/src/credentials/linux.rs
@@ -139,7 +139,7 @@ impl CredentialBackend for LinuxCredentialBackend {
         let account_key = key.to_account_key();
         let outcome = tokio::task::spawn_blocking(move || {
             let entry = Entry::new(SERVICE_NAME, &account_key).map_err(Self::map_error)?;
-            match entry.delete_password() {
+            match entry.delete_credential() {
                 Ok(()) => Ok(()),
                 // Treat "not found" as success for delete (idempotent)
                 Err(keyring::Error::NoEntry) => Ok(()),

--- a/src/credentials/macos.rs
+++ b/src/credentials/macos.rs
@@ -129,7 +129,7 @@ impl CredentialBackend for MacOsCredentialBackend {
         let account_key = key.to_account_key();
         let outcome = tokio::task::spawn_blocking(move || {
             let entry = Entry::new(SERVICE_NAME, &account_key).map_err(Self::map_error)?;
-            match entry.delete_password() {
+            match entry.delete_credential() {
                 Ok(()) => Ok(()),
                 // Treat "not found" as success for delete (idempotent)
                 Err(keyring::Error::NoEntry) => Ok(()),

--- a/src/credentials/windows.rs
+++ b/src/credentials/windows.rs
@@ -127,7 +127,7 @@ impl CredentialBackend for WindowsCredentialBackend {
         let account_key = key.to_account_key();
         let outcome = tokio::task::spawn_blocking(move || {
             let entry = Entry::new(SERVICE_NAME, &account_key).map_err(Self::map_error)?;
-            match entry.delete_password() {
+            match entry.delete_credential() {
                 Ok(()) => Ok(()),
                 // Treat "not found" as success for delete (idempotent)
                 Err(keyring::Error::NoEntry) => Ok(()),


### PR DESCRIPTION
## Summary
Migrate `keyring` from `2.3.3` to `3.6.3` (major upgrade), including feature-name updates and API call-site adjustments.

### Dependency changes
- `Cargo.toml`
  - `keyring = "2.3.3"` -> `keyring = "3.6.3"`
  - feature migration:
    - `platform-macos` -> `apple-native`
    - `platform-windows` -> `windows-native`
    - `linux-default-keyutils` -> `linux-native`
- lockfiles updated:
  - `Cargo.lock`
  - `fuzz/Cargo.lock`

### Code changes
Keyring v3 removes `Entry::delete_password()` in favor of `Entry::delete_credential()`.
Updated credential backends accordingly:
- `src/credentials/macos.rs`
- `src/credentials/linux.rs`
- `src/credentials/windows.rs`

## Validation
- `cargo check --locked`
- `cargo deny check advisories`
- `cargo outdated -R` now reports root direct dependencies are fully up to date
