### PR TITLE
ci(claude-review): publish review as claude[bot]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -384,18 +384,18 @@ jobs:
                 per_page: 100,
               });
               const marker = process.env.REVIEW_MARKER || '';
-              const publishedReviews = reviews.filter((r) => {
-                const login = r.user?.login || '';
+              const isPublishedReview = (r) => {
                 const body = r.body || '';
-                return login === 'claude[bot]' && marker && body.includes(marker);
+                return isKnownClaudeBotAuthor(r.user) && marker && body.includes(marker);
+              };
+              const publishedReviews = reviews.filter((r) => {
+                return isPublishedReview(r);
               });
               const publishedReviewIds = new Set(publishedReviews.map((r) => r.id));
 
               const strayReviews = reviews.filter((r) => {
                 const submitted = Date.parse(r.submitted_at || '');
-                const body = r.body || '';
-                const isPublishedReview = marker && body.includes(marker);
-                return isKnownClaudeBotAuthor(r.user) && !Number.isNaN(submitted) && submitted >= startedAt && !isPublishedReview;
+                return isKnownClaudeBotAuthor(r.user) && !Number.isNaN(submitted) && submitted >= startedAt && !isPublishedReview(r);
               });
 
               for (const r of strayReviews) {


### PR DESCRIPTION
## Summary
- switch deterministic review publishing to use the Claude action's app token (`steps.claude-review.outputs.github_token`) so review authorship is `claude[bot]`
- fail publish step if authenticated review publisher is not `claude[bot]` (prevents silent fallback to `github-actions`)
- keep single-review contract and update cleanup verification to require exactly one marked `claude[bot]` review
- preserve the published review and its inline comments during cleanup while still minimizing/deleting stray Claude artifacts from the run

## Why
PR review output was being posted by `github-actions` because publishing used workflow-token `actions/github-script`. This aligns author identity with expected Claude-originated review comments.

## Testing
- YAML parse check:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml"); puts "ok"'`
