### PR TITLE
ci: bypass claude app-token exchange for reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,9 +1,9 @@
 name: Claude Code Review
 
 on:
-  # Use pull_request_target so Claude app-token validation uses default-branch workflow content.
-  # This preserves claude[bot] identity even when the PR modifies Claude workflow files.
-  # Review uses GitHub PR context only; do not check out PR head in this job.
+  # Use pull_request_target so workflow-changing PRs still run against
+  # default-branch review logic. Review uses GitHub PR context only; do not
+  # check out PR head in this job.
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
@@ -22,9 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
+      pull-requests: write
+      issues: write
       actions: read
 
     steps:
@@ -45,6 +44,7 @@ jobs:
         uses: anthropics/claude-code-action@220272d38887a1caed373da96a9ffdb0919c26cc # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
           settings: |
             {
               "permissions": {
@@ -198,7 +198,7 @@ jobs:
             should_publish=true
           fi
           echo "should_publish=${should_publish}" >> "$GITHUB_OUTPUT"
-      - name: Publish deterministic single review as claude[bot]
+      - name: Publish deterministic single review
         id: publish-review
         if: steps.publish-decision.outputs.should_publish == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -229,12 +229,6 @@ jobs:
             const repo = context.repo.repo;
             const pull_number = context.payload.pull_request.number;
             const commit_id = context.payload.pull_request.head.sha;
-
-            const me = await github.rest.users.getAuthenticated();
-            if (me.data.login !== 'claude[bot]') {
-              core.setFailed(`Expected claude[bot] token for publishing review, got ${me.data.login}.`);
-              return;
-            }
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner,
@@ -351,7 +345,7 @@ jobs:
             }
 
             await github.rest.pulls.createReview(payload);
-            core.info(`Published one claude[bot] review with ${comments.length} inline comment(s).`);
+            core.info(`Published one deterministic review with ${comments.length} inline comment(s).`);
 
   cleanup-claude-stray-artifacts:
     name: Cleanup stray Claude artifacts from this run
@@ -481,15 +475,14 @@ jobs:
                   pull_number: issue_number,
                   per_page: 100,
                 });
-                const published = refreshed.filter((r) => {
-                  const login = r.user?.login || '';
-                  const body = r.body || '';
-                  return login === 'claude[bot]' && marker && body.includes(marker);
-                });
-                if (published.length !== 1) {
-                  core.setFailed(`Expected exactly one published review from claude[bot] for marker ${marker}, found ${published.length}.`);
+                  const published = refreshed.filter((r) => {
+                    const body = r.body || '';
+                    return marker && body.includes(marker);
+                  });
+                  if (published.length !== 1) {
+                    core.setFailed(`Expected exactly one published review for marker ${marker}, found ${published.length}.`);
+                  }
                 }
-              }
             } catch (err) {
               const status = err?.status || err?.response?.status;
               if ([500, 502, 503, 504].includes(status)) {


### PR DESCRIPTION
## Summary
- stop relying on Anthropic's GitHub app-token OIDC exchange in the review workflow
- pass the workflow token directly into the Claude review action instead
- remove the now-unused `id-token` permission and make publish verification marker-based rather than bot-identity-based

## Why
`pull_request_target` runs the base-branch workflow, so unrelated PRs were failing `claude-review` before Claude analysis even started:

- GitHub OIDC token acquisition succeeded
- Anthropic's app-token exchange then returned `401 Invalid OIDC token`

That failure is in the app-token exchange path, not in the PR contents. This hotfix removes the broken dependency so same-repo PR review can run again.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml")'
