### PR TITLE
ci: drop claude publish token identity probe

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -199,12 +199,6 @@ jobs:
               ].join('\n');
             }
 
-            const me = await github.rest.users.getAuthenticated();
-            if (me.data.login !== 'claude[bot]') {
-              core.setFailed(`Expected claude[bot] token for publishing comment, got ${me.data.login}.`);
-              return;
-            }
-
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- remove the `/user` identity probe from Claude PR-comment publish
- let the actual `issues.createComment` call be the source of truth for whether the returned token can publish
- preserve the existing GitHub-context-only PR review design from `#164`

## Why
The current workflow can successfully complete analysis and obtain `steps.claude.outputs.github_token`, but then fail in the publish step because it probes the token with `github.rest.users.getAuthenticated()`. That endpoint is not a reliable capability check for the token returned by the Claude action in this flow. The real requirement is simpler: can the token post the comment?

This patch removes the misleading identity assertion and relies on the actual publish call instead.
