### PR TITLE
ci: publish claude replies with workflow token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
       id-token: write
     steps:
       - name: Resolve PR context
@@ -163,7 +163,7 @@ jobs:
           REQUEST_COMMENT_URL: ${{ github.event.comment.html_url }}
           REQUEST_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
         with:
-          github-token: ${{ steps.claude.outputs.github_token }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const marker = process.env.REVIEW_MARKER || '';


### PR DESCRIPTION
## Summary
- publish manual `@claude` PR replies with the workflow `github.token`
- grant `issues: write` so the GitHub-context-only reply step can actually create the PR conversation comment

## Context
The current GitHub-context-only Claude workflow can complete analysis, but the final `issues.createComment` call still fails on PR review requests. The previous workflow was trying to publish with `steps.claude.outputs.github_token`, which is not valid for this reply path in the current design.

This keeps the safe PR-comment review model from `#164`, but makes the final reply comment publish reliably.
