### PR TITLE
docs: add dedicated docs feedback issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -45,8 +45,8 @@ body:
   - type: textarea
     id: location
     attributes:
-      label: Current location
-      description: Link the page/file/section if you can.
+      label: Current location (if any)
+      description: Link the page/file/section if this issue is about an existing docs location.
       placeholder: docs/protocol/config.md#vertex or https://getcara.io/getting-started.html
 
   - type: textarea


### PR DESCRIPTION
## Summary
- add a dedicated docs feedback issue template
- route stale, missing, or confusing docs reports into an explicit public form
- keep cookbook-specific requests on the existing cookbook request template

## Validation
- YAML parse for `.github/ISSUE_TEMPLATE/docs-feedback.yml`
