### PR TITLE
docs: clean up contributing references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,9 @@ cargo nextest run -E 'test(my_test_name)'
 
 - Keep each PR focused on a single feature, fix, or refactoring effort.
 - Include tests for all new functionality.
+- Use GitHub Issues for public contributor-facing work tracking.
 - Link any related GitHub issue in the PR description and close it when appropriate.
+- Treat roadmap documents as higher-level planning, not as a one-to-one checklist of GitHub issues.
 - CI must pass before merge. The pipeline checks:
   - `cargo fmt --check`
   - `cargo clippy -- -D warnings`


### PR DESCRIPTION
## Summary
- remove the stale public `TODO.md` reference from `CONTRIBUTING.md`
- update the stale repository placeholder links to `puremachinery/carapace`
- fix the contribution license text to match the current Apache 2.0 license

## Testing
- `rg -n "TODO\\.md|\\.local/TODO\\.md|your-org/carapace|MIT License" CONTRIBUTING.md README.md docs .github src`

Closes #192.
