### PR TITLE
docs: include Linux in planned companion app platforms

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,7 +52,7 @@ For what is already shipped and verified, see:
 ## Next
 
 - Additional channels (WhatsApp, iMessage, Teams, Matrix, WebChat).
-- Companion apps — native macOS, iOS, and Android clients.
+- Companion apps — native macOS, Linux, iOS, and Android clients.
 
 ## Later
 


### PR DESCRIPTION
## Summary

- Add Linux to the list of planned companion app platforms in the roadmap (was macOS, iOS, Android — now includes Linux).

Prompted by [Discussion #206](https://github.com/puremachinery/carapace/discussions/206).