### PR TITLE
fix: preserve plugin loader init failure reporting

### DIFF
--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -87,6 +87,10 @@ pub(crate) struct PluginBootstrapResult {
     pub activation_report: PluginActivationReport,
 }
 
+#[cfg(test)]
+pub(crate) const TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV: &str =
+    "CARAPACE_TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE";
+
 #[derive(Debug, Clone)]
 struct ManagedPluginConfigEntry {
     name: String,
@@ -141,6 +145,39 @@ fn plugin_sandbox_config_from_config(cfg: &Value) -> SandboxConfig {
         .cloned()
         .and_then(|value| serde_json::from_value(value).ok())
         .unwrap_or_default()
+}
+
+fn managed_plugin_activation_entry(entry: &ManagedPluginConfigEntry) -> PluginActivationEntry {
+    PluginActivationEntry {
+        name: entry.name.clone(),
+        plugin_id: None,
+        source: PluginActivationSource::Managed,
+        enabled: entry.enabled,
+        path: None,
+        requested_at: entry.requested_at,
+        install_id: entry.install_id.clone(),
+        state: PluginActivationState::Ignored,
+        reason: None,
+    }
+}
+
+fn push_loader_init_failure_entries(
+    report: &mut PluginActivationReport,
+    managed_entries: &[ManagedPluginConfigEntry],
+    reason: &str,
+) {
+    for entry in managed_entries {
+        let mut activation_entry = managed_plugin_activation_entry(entry);
+        if entry.enabled {
+            activation_entry.state = PluginActivationState::Failed;
+            activation_entry.reason = Some(reason.to_string());
+        } else {
+            activation_entry.state = PluginActivationState::Disabled;
+            activation_entry.reason =
+                Some("managed plugin is disabled in plugins.entries".to_string());
+        }
+        report.entries.push(activation_entry);
+    }
 }
 
 fn managed_plugin_config_entries(cfg: &Value) -> Vec<ManagedPluginConfigEntry> {
@@ -254,6 +291,22 @@ fn resolve_managed_plugin_path(
     }
 
     Ok(canonical_path)
+}
+
+fn initialize_plugin_loader(
+    managed_dir: PathBuf,
+    signature_config: SignatureConfig,
+) -> Result<Arc<PluginLoader>, LoaderError> {
+    #[cfg(test)]
+    if let Some(message) = std::env::var_os(TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV)
+        .filter(|value| !value.is_empty())
+    {
+        return Err(LoaderError::EngineError(
+            message.to_string_lossy().into_owned(),
+        ));
+    }
+
+    PluginLoader::with_signature_config(managed_dir, signature_config).map(Arc::new)
 }
 
 fn discover_config_path_plugins(path: &Path) -> Result<Vec<PathBuf>, String> {
@@ -393,12 +446,12 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
     let signature_config = plugin_signature_config_from_config(&cfg);
     let sandbox_config = plugin_sandbox_config_from_config(&cfg);
     let permission_config = PermissionConfig::default();
-    let loader = match PluginLoader::with_signature_config(managed_dir.clone(), signature_config) {
-        Ok(loader) => Arc::new(loader),
+    let loader = match initialize_plugin_loader(managed_dir.clone(), signature_config) {
+        Ok(loader) => loader,
         Err(error) => {
-            report
-                .errors
-                .push(format!("failed to initialize plugin loader: {error}"));
+            let reason = format!("failed to initialize plugin loader: {error}");
+            report.errors.push(reason.clone());
+            push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
             return BlockingPluginBootstrapResult {
                 report,
                 loader: None,
@@ -438,17 +491,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
         .collect::<HashSet<_>>();
 
     for entry in managed_entries {
-        let mut activation_entry = PluginActivationEntry {
-            name: entry.name.clone(),
-            plugin_id: None,
-            source: PluginActivationSource::Managed,
-            enabled: entry.enabled,
-            path: None,
-            requested_at: entry.requested_at,
-            install_id: entry.install_id.clone(),
-            state: PluginActivationState::Ignored,
-            reason: None,
-        };
+        let mut activation_entry = managed_plugin_activation_entry(&entry);
 
         if !entry.enabled {
             activation_entry.state = PluginActivationState::Disabled;

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -647,7 +647,7 @@ mod tests {
     use crate::server::plugin_bootstrap::{
         bootstrap_plugin_runtime, load_plugin_candidate, start_plugin_services,
         stop_plugin_services, PluginActivationEntry, PluginActivationReport,
-        PluginActivationSource, PluginActivationState,
+        PluginActivationSource, PluginActivationState, TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV,
     };
     use crate::server::ws::WsServerConfig;
     use crate::test_support::{env::ScopedEnv, plugins::tool_plugin_component_bytes};
@@ -1160,6 +1160,73 @@ mod tests {
             alpha.reason.as_deref(),
             Some("managed plugins manifest is invalid; fix plugins-manifest.json and restart")
         );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_plugin_runtime_reports_loader_init_failure_per_managed_plugin() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut env = ScopedEnv::new();
+        env.set(
+            TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV,
+            "forced loader init failure",
+        );
+        let cfg = json!({
+            "plugins": {
+                "entries": {
+                    "alpha": {
+                        "enabled": true,
+                        "installId": "install-alpha",
+                        "requestedAt": 1700000001000u64
+                    },
+                    "beta": {
+                        "enabled": false,
+                        "installId": "install-beta",
+                        "requestedAt": 1700000002000u64
+                    }
+                }
+            }
+        });
+
+        let result = bootstrap_plugin_runtime(&cfg, temp.path()).await;
+        let report = result.activation_report;
+
+        assert!(result.runtime.is_none());
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(
+            report.errors[0],
+            "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"
+        );
+        assert_eq!(report.entries.len(), 2);
+
+        let alpha = report
+            .entries
+            .iter()
+            .find(|entry| entry.name == "alpha")
+            .expect("alpha entry");
+        assert!(alpha.enabled);
+        assert_eq!(alpha.state, PluginActivationState::Failed);
+        assert_eq!(
+            alpha.reason.as_deref(),
+            Some(
+                "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"
+            )
+        );
+        assert_eq!(alpha.install_id.as_ref(), Some(&json!("install-alpha")));
+        assert_eq!(alpha.requested_at, Some(1700000001000u64));
+
+        let beta = report
+            .entries
+            .iter()
+            .find(|entry| entry.name == "beta")
+            .expect("beta entry");
+        assert!(!beta.enabled);
+        assert_eq!(beta.state, PluginActivationState::Disabled);
+        assert_eq!(
+            beta.reason.as_deref(),
+            Some("managed plugin is disabled in plugins.entries")
+        );
+        assert_eq!(beta.install_id.as_ref(), Some(&json!("install-beta")));
+        assert_eq!(beta.requested_at, Some(1700000002000u64));
     }
 
     #[tokio::test]

--- a/src/server/ws/handlers/plugins.rs
+++ b/src/server/ws/handlers/plugins.rs
@@ -1506,6 +1506,104 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_plugins_status_reports_loader_init_failures_per_managed_plugin() {
+        let config_dir = TempDir::new().unwrap();
+        let config_path = config_dir.path().join("carapace.json");
+        std::fs::write(
+            &config_path,
+            json!({
+                "plugins": {
+                    "entries": {
+                        "alpha": {
+                            "enabled": true,
+                            "installId": "install-alpha",
+                            "requestedAt": 1700000001000u64
+                        },
+                        "beta": {
+                            "enabled": false,
+                            "installId": "install-beta",
+                            "requestedAt": 1700000002000u64
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let mut env = ScopedEnv::new();
+        env.set("CARAPACE_CONFIG_PATH", config_path.as_os_str())
+            .set("CARAPACE_DISABLE_CONFIG_CACHE", "1");
+        crate::config::clear_cache();
+
+        let loader_init_reason =
+            "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure";
+        let state = WsServerState::new(WsServerConfig::default()).with_plugin_activation_report(
+            crate::server::plugin_bootstrap::PluginActivationReport {
+                enabled: true,
+                configured_paths: vec![],
+                restart_required_for_changes: true,
+                errors: vec![loader_init_reason.to_string()],
+                entries: vec![
+                    crate::server::plugin_bootstrap::PluginActivationEntry {
+                        name: "alpha".to_string(),
+                        plugin_id: None,
+                        source: crate::server::plugin_bootstrap::PluginActivationSource::Managed,
+                        enabled: true,
+                        path: None,
+                        requested_at: Some(1700000001000u64),
+                        install_id: Some(json!("install-alpha")),
+                        state: crate::server::plugin_bootstrap::PluginActivationState::Failed,
+                        reason: Some(loader_init_reason.to_string()),
+                    },
+                    crate::server::plugin_bootstrap::PluginActivationEntry {
+                        name: "beta".to_string(),
+                        plugin_id: None,
+                        source: crate::server::plugin_bootstrap::PluginActivationSource::Managed,
+                        enabled: false,
+                        path: None,
+                        requested_at: Some(1700000002000u64),
+                        install_id: Some(json!("install-beta")),
+                        state: crate::server::plugin_bootstrap::PluginActivationState::Disabled,
+                        reason: Some("managed plugin is disabled in plugins.entries".to_string()),
+                    },
+                ],
+            },
+        );
+
+        let result = handle_plugins_status(&state).unwrap();
+        assert_eq!(result["activationErrorCount"], 2);
+
+        let alpha = result["plugins"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == "alpha")
+            .unwrap();
+        assert_eq!(alpha["enabled"], true);
+        assert_eq!(alpha["state"], "failed");
+        assert_eq!(alpha["installId"], "install-alpha");
+        assert_eq!(alpha["requestedAt"], 1700000001000u64);
+        assert_eq!(alpha["reason"], loader_init_reason);
+
+        let beta = result["plugins"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == "beta")
+            .unwrap();
+        assert_eq!(beta["enabled"], false);
+        assert_eq!(beta["state"], "disabled");
+        assert_eq!(beta["installId"], "install-beta");
+        assert_eq!(beta["requestedAt"], 1700000002000u64);
+        assert_eq!(
+            beta["reason"],
+            "managed plugin is disabled in plugins.entries"
+        );
+
+        crate::config::clear_cache();
+    }
+
+    #[test]
     fn test_handle_plugins_status_sanitizes_path_bearing_reasons() {
         let state = WsServerState::new(WsServerConfig::default()).with_plugin_activation_report(
             crate::server::plugin_bootstrap::PluginActivationReport {


### PR DESCRIPTION
## Summary
- preserve per-plugin managed activation rows when plugin loader initialization fails early
- keep disabled managed plugins disabled instead of converting them into failed rows
- add bootstrap and `plugins.status` regressions for the early loader-init failure path

## Testing
- cargo fmt --all
- cargo nextest run bootstrap_plugin_runtime_reports_loader_init_failure_per_managed_plugin test_handle_plugins_status_reports_loader_init_failures_per_managed_plugin
- cargo check --tests --message-format short
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

Closes #240
