### PR TITLE
refactor: replace optional_followups with low-severity findings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -309,7 +309,7 @@ jobs:
 
             const blockingSeverities = new Set(['critical', 'high', 'medium']);
             const blocking = inline.filter((f) => blockingSeverities.has(f.severity));
-            const low = inline.filter((f) => !blockingSeverities.has(f.severity));
+            const low = inline.filter((f) => f.severity === 'low');
 
             const comments = [];
             const unplaced = [];


### PR DESCRIPTION
## Summary

- Removes `optional_followups` field from the Claude code review schema, validation, and rendering
- Low-severity items are now structured findings (severity `"low"`) in `inline_findings` or `advisory_findings`, with their own "Low-severity findings" section in the published review
- Removes prescriptive header enum rules — header is now a free-form summary line
- All severity levels (critical/high/medium/low) can produce inline diff comments

The reviewer reports findings at assessed severity. Nothing is labeled "optional" or "non-blocking" — the reader decides what to act on.

## Test plan

- [ ] Trigger a review on a PR with mixed-severity findings and verify the published review renders blocking, low-severity, and advisory sections correctly
- [ ] Verify a clean PR produces a valid review with empty finding arrays