### PR TITLE
refactor: remove blocking language from review output

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -322,7 +322,7 @@ jobs:
                 path: p,
                 line: lineNumber,
                 side: 'RIGHT',
-                body: `[${finding.severity}, in-scope] ${finding.title}\n\n${finding.body}`,
+                body: `[${finding.severity}] ${finding.title}\n\n${finding.body}`,
               });
             }
 


### PR DESCRIPTION
## Summary

- Collapses the separate "Blocking findings" and "Low-severity findings" sections into a single "In-scope findings" section
- Renames "Advisory findings (out-of-scope)" to "Out-of-scope findings"
- Drops redundant scope tags from per-finding lines (section header already conveys scope)
- Removes all "blocking" language — severity tags on each finding do the work

Fixes the contradiction where the header could say "no blockers" while a "Blocking findings" section lists medium findings.

## Test plan

- [ ] Trigger a review on a PR with mixed-severity in-scope and out-of-scope findings; verify the published review uses "In-scope findings" and "Out-of-scope findings" section headers with `[severity]` tags per finding