### PR TITLE
docs: refresh roadmap priorities

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,39 +8,6 @@ For what is already shipped and verified, see:
 - [Feature status](feature-status.yaml)
 - [Feature evidence](feature-evidence.yaml)
 
-## Recently shipped
-
-- Cross-platform subprocess sandbox hardening — macOS, Linux, and Windows
-  enforce OS-level isolation for sandbox-required paths; unsupported platforms
-  fail closed.
-- Control UI foundation — local browser UI for status/channels, safe
-  `gateway.controlUi.*` config patching, device pairing, and task queue
-  operator actions.
-- Long-running assistant MVP — durable task queue with restart recovery,
-  operator task controls (`create/list/get/patch/cancel/retry/resume`),
-  continuation policy budgets, blocked-state handling, and autonomy verification
-  (`cara verify --outcome autonomy`).
-- Outcome-driven setup flow (`cara setup`) with provider credential validation.
-- First-run verifier (`cara verify`) with pass/fail outcome checks.
-- Gemini onboarding — Google sign-in or API-key setup via `cara setup` and the
-  Control UI, backed by shared onboarding flow state and `google.authProfile`
-  runtime support.
-- Codex onboarding — OpenAI subscription-login setup via `cara setup` and the
-  Control UI, backed by `codex.authProfile` runtime support.
-- Managed and local WASM plugins — startup/runtime loading, `plugins.*` API
-  surface, `cara plugins` CLI workflows, and plugin development guidance.
-  Local `cara plugins install/update --file` staging still has a known
-  symlink-swap / TOCTOU hardening gap. Use that workflow only with a trusted,
-  single-user state directory owned by the Carapace user, and do not use it
-  on shared hosts or anywhere other users or services can write to that
-  directory.
-  Tracking open issue: [#250](https://github.com/puremachinery/carapace/issues/250)
-- Filesystem tools — guarded local workspace read/search/stat/list plus opt-in
-  write/move within explicit roots, with config-gated registration and
-  fail-closed validation.
-- Multi-page docs site with install/first-run/security/ops plus docs hubs,
-  capability matrix, and task-oriented CLI index.
-
 ## Next
 
 These items are listed in priority order. The top item is the current focus.


### PR DESCRIPTION
## Summary
- refresh `docs/roadmap.md` to match the actual product priorities after `v0.4.1`
- remove the backward-looking `Recently shipped` section so the roadmap stays forward-looking
- make `Next` and `Later` issue-backed and aligned with the current priority order

## Roadmap Transitions
- the previous `Now` bucket is not carried forward as a separate section
- subscription onboarding, guided provider onboarding, and migration/import work are absorbed into the onboarding and migration groups now listed under `Next`
- model/provider routing clarity is absorbed into the routing group under `Next`
- provider-status parity remains part of `#185`; broader Control UI depth is not in the current near-term priority list
- test-infra hardening remains tracked separately in `#190`
- shipped and verified work now lives behind the existing `feature-status` and `feature-evidence` links instead of a `Recently shipped` section in the roadmap
- `#243` remains ahead of `#250` intentionally: `#243` hardens the managed plugin distribution path itself, while `#250` hardens the local `--file` operator path that remains explicitly scoped to trusted single-user state directories until that work lands
- removed previously unbacked roadmap bullets that do not reflect the current product direction: companion apps, browser control / live canvas, and multi-agent routing / automatic failover

## Testing
- ./scripts/check-docs-state-messaging.sh
