### PR TITLE
[codex] docs: refresh channel activity release surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/channel-smoke-report.yml
+++ b/.github/ISSUE_TEMPLATE/channel-smoke-report.yml
@@ -54,12 +54,14 @@ body:
     id: checks
     attributes:
       label: Smoke checks completed
-      description: Mark each completed check. For a PASS report, all four checks must be completed.
+      description: Mark each completed check. For a PASS report, complete the four core checks and any enabled Signal activity checks below.
       options:
         - label: `cara status` reported healthy
         - label: Channel registration was successful (no repeated auth/signature errors)
         - label: One inbound message triggered an agent run
         - label: One outbound reply was delivered
+        - label: If Signal typing was enabled, the typing indicator appeared while Carapace was generating the reply
+        - label: If Signal read receipts were enabled, the inbound message stayed unread until reply delivery and then became read
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A hardened alternative to openclaw / clawdbot — for when your assistant needs 
 
 - **Multi-provider LLM engine** — Anthropic, OpenAI API key, Codex subscription login, Ollama, Google Gemini, Vertex AI, AWS Bedrock, and Venice AI with streaming, tool dispatch, and cancellation
 - **Multi-channel messaging** — Signal, Telegram, Discord, Slack, console, and webhooks
+- **Channel activity framework** — per-channel typing indicators and after-response read receipts, with Signal as the first activity-enabled built-in channel
 - **Tooling and local workspace access** — built-in agent tools, guarded filesystem tools for explicit roots, and channel-specific tool schemas
 - **Signed plugin runtime** — plugins are signature-verified and run with strict permissions and resource limits
 - **Secure defaults** — local-first binding, locked-down auth behavior, encrypted secret storage, guarded tool execution, root-scoped filesystem access, and OS-level subprocess sandboxing for protected paths
@@ -90,7 +91,8 @@ routine use, while partial and in-progress areas remain explicitly documented.
 - Working now: setup wizard, local chat (`cara chat`), token auth enforcement,
   health/control endpoints (including durable task controls), control UI
   frontend foundation (status/channels/redacted config editor), Codex
-  subscription onboarding, and OpenAI-compatible HTTP endpoints.
+  subscription onboarding, per-channel activity config with Signal
+  typing/read-receipt flows, and OpenAI-compatible HTTP endpoints.
 - In progress: advanced Control UI flows (pairing/workflow UX), broader
   channel smoke evidence, and hardened internet-facing deployment guidance.
 
@@ -108,7 +110,9 @@ of truth.
   (`cara setup`), first-run verifier (`cara verify`), Gemini onboarding
   (Google sign-in or API key via CLI and Control UI), Codex onboarding
   (OpenAI subscription login via CLI and Control UI), Vertex AI provider
-  support, and guarded filesystem tools for explicit workspace roots
+  support, per-channel activity features with Signal typing indicators and
+  after-response read receipts, and guarded filesystem tools for explicit
+  workspace roots
 
 ## Docs
 

--- a/docs/channel-smoke.md
+++ b/docs/channel-smoke.md
@@ -37,6 +37,8 @@ A channel smoke run is considered **pass** when all are true:
 2. Channel registration succeeds at startup (no repeated auth/signature errors).
 3. One inbound message is received and produces an agent run.
 4. One outbound reply is delivered back to the same channel.
+5. If optional channel-activity features are enabled for the target channel,
+   those behaviors also match the configured policy.
 
 If any step fails, capture the first failing step and logs.
 
@@ -52,6 +54,12 @@ Assumes `signal-cli-rest-api` is running and configured in `carapace.json5`
 3. Confirm logs show inbound parsing + agent run dispatch from
    `signal_receive`.
 4. Confirm reply is delivered in Signal.
+5. If `channels.signal.features.typing.enabled` is true, confirm the sending
+   device/account sees a typing indicator while Carapace is generating the
+   reply.
+6. If `channels.signal.features.readReceipts.enabled` is true, confirm the
+   inbound message stays unread until the assistant reply is delivered, then
+   transitions to read shortly after delivery.
 
 Common failure indicators:
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -73,6 +73,9 @@ docker run -d -p 8080:8080 -v $HOME/.local/share/signal-api:/home/.local/share/s
 
 For non-loopback Signal deployments, set `signal.baseUrl` to `https://...`.
 Carapace rejects non-HTTPS non-loopback Signal URLs.
+When `channels.signal.features.typing.enabled` is true, Carapace refreshes the
+Signal typing indicator while the assistant is generating a reply and clears it
+before outbound delivery.
 When `channels.signal.features.readReceipts.enabled` is true, Carapace polls
 Signal with `send_read_receipts=false` and only sends a read receipt after a
 successful assistant response is delivered. When the feature is disabled,

--- a/docs/feature-evidence.yaml
+++ b/docs/feature-evidence.yaml
@@ -2,7 +2,7 @@
 # Keep this focused on audited entries in docs/feature-status.yaml.
 
 version: "1.0"
-updated_at: "2026-03-19"
+updated_at: "2026-03-29"
 
 features:
   - feature: "filesystem tools"
@@ -62,15 +62,33 @@ features:
       - "src/channels/slack.rs::test_slack_get_info"
       - "src/channels/slack_inbound.rs::test_verify_slack_signature"
 
+  - feature: "channels.activity framework"
+    status: "verified_done"
+    runtime_wiring:
+      - "src/channels/activity.rs (per-channel activity policy, dispatcher, shutdown, and durable read-receipt obligations)"
+      - "src/channels/inbound.rs (inbound typing/read-receipt context capture)"
+      - "src/agent/executor.rs (typing lifecycle + receive-time read receipt preservation)"
+      - "src/messages/delivery.rs (after-response receipt activation/withhold behavior)"
+    tests:
+      - "src/channels/activity.rs::test_maybe_start_typing_loop_drives_start_and_stop"
+      - "src/channels/activity.rs::test_send_verified_read_receipt_marks_read"
+      - "src/channels/activity.rs::test_read_receipt_task_executor_respects_max_attempts_budget"
+      - "src/agent/executor.rs::test_execute_run_channel_activity_lifecycle_orders_stop_before_delivery_and_marks_read"
+      - "src/messages/delivery.rs::test_retryable_delivery_failure_preserves_read_receipt_until_success"
+
   - feature: "channels.signal runtime wiring"
     status: "verified_done"
     runtime_wiring:
-      - "src/channels/signal.rs (SignalChannel send_text/send_media)"
+      - "src/channels/signal.rs (SignalChannel send_text/send_media/start_typing/stop_typing/mark_read)"
       - "src/channels/signal_receive.rs (signal-cli receive polling + inbound dispatch)"
       - "src/main.rs (register_signal_channel_if_configured)"
       - "src/main.rs (spawn_signal_receive_loop_if_configured)"
     tests:
       - "src/channels/signal.rs::test_signal_get_info"
+      - "src/channels/signal.rs::test_signal_get_capabilities"
+      - "src/channels/signal.rs::test_signal_start_typing_connection_failure"
+      - "src/channels/signal.rs::test_signal_mark_read_requires_timestamp"
+      - "src/channels/signal.rs::test_signal_mark_read_connection_failure_strips_phone_number_from_error"
       - "src/channels/signal.rs::test_signal_send_text_connection_failure"
       - "src/channels/signal_receive.rs::test_parse_inbound_message"
       - "src/channels/signal_receive.rs::test_parse_group_message"
@@ -79,7 +97,7 @@ features:
     status: "partial"
     notes:
       - "Evidence artifacts: docs/channel-smoke.md; .github/ISSUE_TEMPLATE/channel-smoke-report.yml"
-      - "Pending published pass/fail evidence from a live signal-cli-rest-api deployment."
+      - "Pending published pass/fail evidence from a live signal-cli-rest-api deployment, including typing/read-receipt checks when those features are enabled."
 
   - feature: "channels.slack live smoke"
     status: "partial"

--- a/docs/feature-status.yaml
+++ b/docs/feature-status.yaml
@@ -55,8 +55,10 @@ feature_inventory_markdown: |
 
   - [x] **Channel registry** — thread-safe channel tracking, status enum
   - [x] **Console channel** — built-in testing channel
+  - [x] **Channel activity framework** — per-channel typing/read-receipt policy, runtime dispatch, and durable after-response receipt obligations.
   - [x] **Telegram/Discord/Slack runtime wiring** — outbound + inbound (Telegram webhook/long-polling, Slack Events API, Discord Gateway).
   - [x] **Signal runtime wiring** — outbound via signal-cli REST + inbound polling receive loop.
+  - [x] **Signal activity features** — typing indicators + explicit after-response read receipts on the built-in Signal channel.
   - [~] **Signal real-world smoke** — pending reproducible pass/fail evidence from a live Signal deployment.
   - [~] **Slack real-world smoke** — pending reproducible pass/fail evidence from a live Slack Events API deployment.
 

--- a/docs/security-comparison.md
+++ b/docs/security-comparison.md
@@ -120,7 +120,7 @@ remain partial or incomplete. Verified-vs-partial feature state is tracked in
 
 - **Platform backend coverage.** Seatbelt/Landlock/Windows AppContainer+Job subprocess wiring is implemented across probe/tailscale/whois/SSH tunnel callsites. Unsupported targets still fail closed. On Windows, deny-network execution is supported through command-output helpers, while spawned deny-network subprocess requests fail closed.
 - **Control UI.** Foundation is shipped (`/ui` auth/session handling, status/channels, redacted config read + safe patch path, task operator actions, pairing flow). Richer operator workflows and UX refinements remain in-progress.
-- **Channels.** Discord is verified end-to-end. Telegram supports webhook and localhost long-polling fallback. Signal and Slack are implemented but not yet smoke-tested in real environments.
+- **Channels.** Discord is verified end-to-end. Telegram supports webhook and localhost long-polling fallback. Signal now includes inbound polling plus optional typing indicators and after-response read receipts, but still lacks published live smoke evidence. Slack is implemented but not yet smoke-tested in real environments.
 - **Smoke evidence process.** Live channel validation criteria and report template are tracked in `docs/channel-smoke.md`.
 - **Audit log emission.** The audit log module is implemented (append-only JSONL, 19 event types, 50 MB rotation) but event emission is not yet wired into all runtime paths.
 

--- a/docs/site/capability-matrix.md
+++ b/docs/site/capability-matrix.md
@@ -11,7 +11,7 @@ See what works today across channels, providers, and platforms, including caveat
 | Telegram | Verified | Webhook mode + long-polling fallback supported. |
 | Discord | Verified | Gateway + outbound flows supported. |
 | Slack | Implemented (smoke pending) | Runtime wiring present; live smoke evidence pending. |
-| Signal | Implemented (smoke pending) | Runtime wiring present; live smoke evidence pending. |
+| Signal | Implemented (smoke pending) | Inbound polling, typing indicators, and after-response read receipts are implemented; live smoke evidence pending. |
 | Hooks (automation) | Verified | Token-authenticated wake/agent/mapping endpoints. |
 
 ## Providers


### PR DESCRIPTION
## Summary

Refresh the release-facing docs and site surfaces for the post-`v0.4.1` channel-activity work.

This updates:
- top-level summary pages to mention the channel activity framework and Signal typing/read-receipt support
- feature status/evidence inventories so they reflect the shipped runtime and tests
- the Signal smoke playbook and report template so future live evidence covers typing/read-receipt behavior when enabled

## Why

PR #254 added a new per-channel activity framework plus Signal typing and after-response read receipts, but several public summary surfaces still described Signal as generic runtime wiring only. That would leave the next release docs stale even though the config and runtime already support these behaviors.

## User impact

Users can now find the Signal activity behavior and enablement path more directly in the release-facing docs, while the smoke/evidence process now matches the actual shipped feature surface.

## Validation

- `./scripts/check-docs-state-messaging.sh`
- `just docs-check`
- local Pages-style render and internal-link validation via `./scripts/build-pages-content.sh` and `./scripts/check-pages-links.sh`
