### PR TITLE
chore: prep v0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "carapace"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carapace"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.93"
 description = "A security-focused personal AI assistant — hardened alternative to openclaw/clawdbot"

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,47 @@
+## Summary
+- Added a per-channel activity framework for typing indicators and explicit after-response read receipts.
+- Enabled Signal typing indicators and explicit after-response read receipts behind `channels.*.features.*` policy controls, with bounded ownership, retry, and shutdown semantics.
+- Refreshed release-facing docs, capability/status inventories, and the Signal smoke playbook to match the shipped channel-activity surface.
+
+## Breaking Changes
+- None.
+
+## Migration Steps
+- No manual migration is required for the stable path from `v0.4.x` to `v0.5.0`.
+- Before upgrading, create a backup:
+  - `cara backup --output ./carapace-backup.tar.gz`
+- Optional: if you want Signal typing indicators or explicit after-response read receipts, configure them under:
+  - `channels.signal.features.typing.enabled`
+  - `channels.signal.features.readReceipts.enabled`
+- After upgrade, verify the install:
+  - `cara verify --outcome auto`
+  - `cara verify --outcome autonomy`
+
+## Rollback Steps
+- Reinstall the previous known-good binary, for example `v0.4.1`.
+- Restore the backup created before upgrade:
+  - `cara restore --path ./carapace-backup.tar.gz`
+- Re-run:
+  - `cara status --port 18789`
+  - `cara verify --outcome auto --port 18789`
+  - `cara verify --outcome autonomy --port 18789`
+
+## Security
+- Signal read-receipt handling now uses bounded receive-time ownership plus durable after-response obligations so successful delivery does not depend on unbounded background side effects.
+- Signal receive-loop startup now fails cleanly into channel error state when HTTP client initialization fails instead of panicking the process.
+- Signal activity diagnostics keep sensitive response details redacted while preserving safe timestamp-oriented troubleshooting data.
+- No new public advisories are introduced by this release.
+
+## Verification
+- Verify published artifacts and Sigstore bundles:
+  - `RELEASE_TAG=v0.5.0 ./scripts/smoke/verify-release-artifacts.sh`
+- After upgrading, verify runtime behavior:
+  - `cara verify --outcome auto`
+  - `cara verify --outcome autonomy`
+- If you enable Signal activity features, validate one real thread against the Signal smoke playbook:
+  - `docs/channel-smoke.md`
+
+## Known Caveats
+- Signal and Slack still do not have published live smoke evidence in the repo; their real-world validation process remains tracked through `docs/channel-smoke.md`.
+- Channel activity settings are currently implemented for built-in native channels; plugin channel entries are accepted for forward compatibility but may be ignored until plugin activity capabilities are added.
+- Signal outbound remains direct-message only; unsupported group messages are still ignored rather than partially delivered.


### PR DESCRIPTION
## Summary

Prepare `v0.5.0` on top of the now-green `master` line.

This PR:
- bumps the packaged/binary version from `0.4.0` to `0.5.0`
- adds curated release notes at `docs/releases/v0.5.0.md`
- updates `Cargo.lock` root-package metadata to the new version

## Why

The current `master` line is release-worthy after the channel-activity and Signal work, but we cannot tag it correctly yet because:
- `Cargo.toml` still reports `0.4.0`
- the required curated release note file for `v0.5.0` does not exist

Once this PR merges and that new `master` head is green, the release path is to create and push the annotated `v0.5.0` tag from `master`.

## Validation

- `./scripts/check-docs-state-messaging.sh`
- `just docs-check`
- `scripts/cargo-serial check --message-format short`

## Release note scope

The curated notes summarize the user-facing work since `v0.4.1`, centered on:
- the per-channel activity framework
- Signal typing indicators and after-response read receipts
- the corresponding release-surface and smoke/evidence documentation refresh
