### PR TITLE
Clean up task worker wakeup abstraction

### DIFF
--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -999,7 +999,6 @@ async fn run_task_worker_cycle(queue: Arc<TaskQueue>, executor: Arc<dyn TaskExec
                 tokio::task::spawn_blocking({
                     let queue = queue.clone();
                     let task_id = task_id.clone();
-                    let error = error.clone();
                     move || queue.mark_retry_wait(&task_id, delay_ms, &error)
                 })
                 .await,
@@ -1009,7 +1008,6 @@ async fn run_task_worker_cycle(queue: Arc<TaskQueue>, executor: Arc<dyn TaskExec
                 tokio::task::spawn_blocking({
                     let queue = queue.clone();
                     let task_id = task_id.clone();
-                    let reason = reason.clone();
                     move || queue.mark_blocked(&task_id, &reason, category)
                 })
                 .await,
@@ -1019,7 +1017,6 @@ async fn run_task_worker_cycle(queue: Arc<TaskQueue>, executor: Arc<dyn TaskExec
                 tokio::task::spawn_blocking({
                     let queue = queue.clone();
                     let task_id = task_id.clone();
-                    let error = error.clone();
                     move || queue.mark_failed(&task_id, &error)
                 })
                 .await,


### PR DESCRIPTION
## Summary

This cleans up the durable task worker wakeup seam in `src/tasks/mod.rs` without changing user-visible behavior.

## What Changed

- split the worker path into explicit helpers for ticker creation, wake registration, trigger waiting, and one claim/execute cycle
- moved deterministic startup synchronization for the wakeup test behind a `#[cfg(test)]` wrapper instead of threading a test-only `oneshot` through production control flow
- made the wake registration semantics explicit with a dedicated helper that uses `Notify::notified()`, pins it, and calls `enable()` before awaiting
- kept batching, shutdown handling, and worker behavior unchanged while making the control flow easier to reason about

## Why

The production private helper was still carrying a test-only startup hook, and the wake arm relied on less explicit `Notify` registration than the defensive pattern already used elsewhere in the same module. This was not a correctness bug, but it made the worker abstraction harder to understand and easier to churn.

Closes #271

## Validation

- `../carapace/scripts/cargo-serial fmt --all`
- `../carapace/scripts/cargo-serial check --message-format short`
- `../carapace/scripts/cargo-serial nextest run --all-targets test_task_worker_loop_processes_due_tasks test_task_worker_loop_with_wakeup_processes_due_tasks_without_waiting_for_tick test_task_worker_loop_retry_wait_outcome_branch test_task_worker_loop_blocked_outcome_branch test_task_worker_loop_failed_outcome_branch test_task_worker_loop_cancelled_outcome_branch`
