### PR TITLE
Process dependency PRs 277, 278, and 279

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run actionlint
-        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
         with:
           args: -color -shellcheck=
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
  "glob",
  "hex",
  "hickory-resolver",
- "hkdf",
+ "hkdf 0.13.0",
  "hmac 0.13.0",
  "insta",
  "json5",
@@ -1436,7 +1436,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -1969,6 +1969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.1"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99322078b2c076829a1db959d49da554fabc4342257fc0ba5a070a1eb3a01cd8"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,11 @@ bytes = "1"
 getrandom = "0.4"
 hex = "0.4"
 sha2 = "0.11"
+# Retain the legacy digest stack only for dependencies that still require it
+# (`pbkdf2 0.12` and the current `sigstore` verifier surface). New hashing and
+# HKDF call sites should use `sha2`.
 sha2_10 = { package = "sha2", version = "0.10" }
-hkdf = "0.12"
+hkdf = "0.13"
 hmac = "0.13"
 pbkdf2 = "0.12"
 mdns-sd = "0.18"

--- a/src/sessions/integrity.rs
+++ b/src/sessions/integrity.rs
@@ -12,9 +12,6 @@ use hkdf::Hkdf;
 use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-// `hkdf 0.12` is still on the legacy `digest 0.10` stack, so key derivation
-// must stay on `sha2_10` until the KDF dependencies can move in lockstep.
-use sha2_10::Sha256 as Sha256Legacy;
 
 type HmacSha256 = Hmac<Sha256>;
 const HMAC_DIGEST_SIZE: usize = 32;
@@ -78,9 +75,7 @@ pub enum IntegrityError {
 ///
 /// Uses `KEY_DERIVATION_TAG` as the salt and `b"hmac-key"` as the info parameter.
 pub fn derive_hmac_key(server_secret: &[u8]) -> [u8; 32] {
-    // `hkdf 0.12` still requires the legacy `digest 0.10` stack here; the
-    // derived SHA-256 output bytes are identical to the newer digest stack.
-    let hk = Hkdf::<Sha256Legacy>::new(Some(KEY_DERIVATION_TAG), server_secret);
+    let hk = Hkdf::<Sha256>::new(Some(KEY_DERIVATION_TAG), server_secret);
     let mut key: [u8; 32] = Default::default();
     hk.expand(b"hmac-key", &mut key)
         .expect("32-byte output is valid for HKDF-SHA256");


### PR DESCRIPTION
Supersedes #277, #278, and #279.

What changed:
- bump `rhysd/actionlint` from `1.7.11` to `1.7.12`
- bump `insta` from `1.47.1` to `1.47.2`
- bump direct `hkdf` from `0.12` to `0.13`

Why this is grouped:
- `#277` and `#278` are straightforward dependency bumps
- `#279` is not just a lockfile change: after moving `hkdf` to `0.13`, the session-integrity HKDF path can stop using the legacy `sha2_10` compatibility type

Crypto cleanup in scope:
- `src/sessions/integrity.rs` now derives the session HMAC key with `Hkdf::<sha2::Sha256>`
- the stale `hkdf 0.12` / legacy-digest compatibility comments are removed
- the repo still keeps `sha2_10` for the remaining real owners: `pbkdf2 0.12` call sites and the current `sigstore` verifier surface

Validation:
- `scripts/cargo-serial check --tests`
- `scripts/cargo-serial nextest run test_derive_hmac_key_deterministic test_derive_hmac_key_different_secrets test_derive_hmac_key_length test_derive_hmac_key_uses_hkdf test_verify_hmac_path_roundtrip test_verify_accepts_and_migrates_legacy_sidecar test_verify_checksum_accepts_gnu_format test_verify_checksum_rejects_mismatch test_apply_staged_update_success_for_paths test_apply_staged_update_copy_failure_restores_original test_apply_staged_update_copy_and_restore_failure_surfaces_critical_error test_verify_bundle_signature_missing_bundle_is_rejected test_verify_bundle_signature_malformed_bundle_is_rejected`