### PR TITLE
refactor: make OAuthProvider::default_config type-safe for non-OAuth providers

### DIFF
--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -198,11 +198,13 @@ mod tests {
     }
 
     fn sample_profile(id: &str) -> AuthProfile {
-        let provider_config = OAuthProvider::OpenAI.default_config(
-            "client-id",
-            "client-secret",
-            "http://127.0.0.1:3000/auth/callback",
-        );
+        let provider_config = OAuthProvider::OpenAI
+            .default_config(
+                "client-id",
+                "client-secret",
+                "http://127.0.0.1:3000/auth/callback",
+            )
+            .unwrap();
         AuthProfile {
             id: id.to_string(),
             name: "Codex (user@example.com)".to_string(),
@@ -262,11 +264,13 @@ mod tests {
         let provider = CodexProvider::with_oauth_profile(
             store,
             "missing-profile".to_string(),
-            OAuthProvider::OpenAI.default_config(
-                "client-id",
-                "client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            OAuthProvider::OpenAI
+                .default_config(
+                    "client-id",
+                    "client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
         )
         .expect("provider");
 
@@ -282,11 +286,13 @@ mod tests {
     #[tokio::test]
     async fn test_codex_provider_empty_token_errors() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let provider_config = OAuthProvider::OpenAI.default_config(
-            "client-id",
-            "client-secret",
-            "http://127.0.0.1:3000/auth/callback",
-        );
+        let provider_config = OAuthProvider::OpenAI
+            .default_config(
+                "client-id",
+                "client-secret",
+                "http://127.0.0.1:3000/auth/callback",
+            )
+            .unwrap();
         let profile = AuthProfile {
             tokens: Some(OAuthTokens {
                 access_token: "   ".to_string(),
@@ -315,11 +321,13 @@ mod tests {
     #[tokio::test]
     async fn test_codex_provider_wrong_credential_kind_errors() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let provider_config = OAuthProvider::OpenAI.default_config(
-            "client-id",
-            "client-secret",
-            "http://127.0.0.1:3000/auth/callback",
-        );
+        let provider_config = OAuthProvider::OpenAI
+            .default_config(
+                "client-id",
+                "client-secret",
+                "http://127.0.0.1:3000/auth/callback",
+            )
+            .unwrap();
         let mut profile = sample_profile("openai-token-kind");
         profile.credential_kind = AuthProfileCredentialKind::Token;
         profile.tokens = None;
@@ -346,11 +354,13 @@ mod tests {
     #[tokio::test]
     async fn test_codex_provider_updates_last_used_after_access() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let provider_config = OAuthProvider::OpenAI.default_config(
-            "client-id",
-            "client-secret",
-            "http://127.0.0.1:3000/auth/callback",
-        );
+        let provider_config = OAuthProvider::OpenAI
+            .default_config(
+                "client-id",
+                "client-secret",
+                "http://127.0.0.1:3000/auth/callback",
+            )
+            .unwrap();
         let mut profile = sample_profile("openai-last-used");
         profile.last_used_ms = None;
         let store = Arc::new(ProfileStore::from_env(temp.path().to_path_buf()).expect("store"));

--- a/src/agent/factory.rs
+++ b/src/agent/factory.rs
@@ -1027,11 +1027,13 @@ mod tests {
                 "CARAPACE_STATE_DIR",
                 temp.path().to_str().expect("state dir path"),
             );
-            let provider_config = OAuthProvider::Google.default_config(
-                "google-client-id",
-                "google-client-secret",
-                "https://gateway.example.com/control/onboarding/gemini/callback",
-            );
+            let provider_config = OAuthProvider::Google
+                .default_config(
+                    "google-client-id",
+                    "google-client-secret",
+                    "https://gateway.example.com/control/onboarding/gemini/callback",
+                )
+                .unwrap();
             let profile = crate::auth::profiles::AuthProfile {
                 id: "google-abc123".to_string(),
                 name: "Google user@example.com".to_string(),
@@ -1111,11 +1113,13 @@ mod tests {
                 "CARAPACE_STATE_DIR",
                 temp.path().to_str().expect("state dir path"),
             );
-            let provider_config = OAuthProvider::OpenAI.default_config(
-                "openai-client-id",
-                "openai-client-secret",
-                "https://gateway.example.com/control/onboarding/codex/callback",
-            );
+            let provider_config = OAuthProvider::OpenAI
+                .default_config(
+                    "openai-client-id",
+                    "openai-client-secret",
+                    "https://gateway.example.com/control/onboarding/codex/callback",
+                )
+                .unwrap();
             let profile = crate::auth::profiles::AuthProfile {
                 id: "openai-abc123".to_string(),
                 name: "Codex user@example.com".to_string(),
@@ -1159,11 +1163,13 @@ mod tests {
                 temp.path().to_str().expect("state dir path"),
             );
             let _blank_key = set_env_var_scoped("GOOGLE_API_KEY", "   ");
-            let provider_config = OAuthProvider::Google.default_config(
-                "google-client-id",
-                "google-client-secret",
-                "https://gateway.example.com/control/onboarding/gemini/callback",
-            );
+            let provider_config = OAuthProvider::Google
+                .default_config(
+                    "google-client-id",
+                    "google-client-secret",
+                    "https://gateway.example.com/control/onboarding/gemini/callback",
+                )
+                .unwrap();
             let profile = crate::auth::profiles::AuthProfile {
                 id: "google-abc123".to_string(),
                 name: "Google user@example.com".to_string(),
@@ -1291,11 +1297,13 @@ mod tests {
                 "CARAPACE_STATE_DIR",
                 temp.path().to_str().expect("state dir path"),
             );
-            let provider_config = OAuthProvider::Google.default_config(
-                "google-client-id",
-                "google-client-secret",
-                "https://gateway.example.com/control/onboarding/gemini/callback",
-            );
+            let provider_config = OAuthProvider::Google
+                .default_config(
+                    "google-client-id",
+                    "google-client-secret",
+                    "https://gateway.example.com/control/onboarding/gemini/callback",
+                )
+                .unwrap();
             let profile = crate::auth::profiles::AuthProfile {
                 id: "google-abc123".to_string(),
                 name: "Google user@example.com".to_string(),
@@ -1356,11 +1364,13 @@ mod tests {
             );
             let _blank_key = set_env_var_scoped("GOOGLE_API_KEY", "   ");
 
-            let provider_config = OAuthProvider::Google.default_config(
-                "google-client-id",
-                "google-client-secret",
-                "https://gateway.example.com/control/onboarding/gemini/callback",
-            );
+            let provider_config = OAuthProvider::Google
+                .default_config(
+                    "google-client-id",
+                    "google-client-secret",
+                    "https://gateway.example.com/control/onboarding/gemini/callback",
+                )
+                .unwrap();
             let profile = crate::auth::profiles::AuthProfile {
                 id: "google-abc123".to_string(),
                 name: "Google user@example.com".to_string(),
@@ -1408,11 +1418,13 @@ mod tests {
                 temp.path().to_str().expect("state dir path"),
             );
 
-            let provider_config = OAuthProvider::OpenAI.default_config(
-                "openai-client-id",
-                "openai-client-secret",
-                "https://gateway.example.com/control/onboarding/codex/callback",
-            );
+            let provider_config = OAuthProvider::OpenAI
+                .default_config(
+                    "openai-client-id",
+                    "openai-client-secret",
+                    "https://gateway.example.com/control/onboarding/codex/callback",
+                )
+                .unwrap();
             let profile = crate::auth::profiles::AuthProfile {
                 id: "openai-abc123".to_string(),
                 name: "Codex user@example.com".to_string(),
@@ -1705,11 +1717,13 @@ mod tests {
     fn test_resolve_google_oauth_runtime_config_uses_stored_redirect_uri_when_missing() {
         with_clean_provider_env(|| {
             let temp = tempfile::tempdir().expect("tempdir");
-            let provider_config = OAuthProvider::Google.default_config(
-                "google-client-id",
-                "google-client-secret",
-                "https://gateway.example.com/control/onboarding/gemini/callback",
-            );
+            let provider_config = OAuthProvider::Google
+                .default_config(
+                    "google-client-id",
+                    "google-client-secret",
+                    "https://gateway.example.com/control/onboarding/gemini/callback",
+                )
+                .unwrap();
             let profile = crate::auth::profiles::AuthProfile {
                 id: "google-abc123".to_string(),
                 name: "Google user@example.com".to_string(),

--- a/src/agent/gemini.rs
+++ b/src/agent/gemini.rs
@@ -731,11 +731,13 @@ mod tests {
         let provider = GeminiProvider::with_oauth_profile(
             Arc::new(store),
             "google-test".to_string(),
-            OAuthProvider::Google.default_config(
-                "client-id",
-                "client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            OAuthProvider::Google
+                .default_config(
+                    "client-id",
+                    "client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
         )
         .expect("oauth-backed provider");
 
@@ -753,11 +755,13 @@ mod tests {
         let provider = GeminiProvider::with_oauth_profile(
             Arc::new(store),
             "missing-profile".to_string(),
-            OAuthProvider::Google.default_config(
-                "client-id",
-                "client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            OAuthProvider::Google
+                .default_config(
+                    "client-id",
+                    "client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
         )
         .expect("oauth-backed provider");
 
@@ -805,11 +809,13 @@ mod tests {
         let provider = GeminiProvider::with_oauth_profile(
             Arc::new(store),
             "google-empty-token".to_string(),
-            OAuthProvider::Google.default_config(
-                "client-id",
-                "client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            OAuthProvider::Google
+                .default_config(
+                    "client-id",
+                    "client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
         )
         .expect("oauth-backed provider");
 
@@ -851,11 +857,13 @@ mod tests {
         let provider = GeminiProvider::with_oauth_profile(
             Arc::new(store),
             "google-token-kind".to_string(),
-            OAuthProvider::Google.default_config(
-                "client-id",
-                "client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            OAuthProvider::Google
+                .default_config(
+                    "client-id",
+                    "client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
         )
         .expect("oauth-backed provider");
 

--- a/src/agent/provider.rs
+++ b/src/agent/provider.rs
@@ -655,11 +655,13 @@ mod tests {
         let provider = crate::agent::codex::CodexProvider::with_oauth_profile(
             profile_store,
             "openai-abc123".to_string(),
-            crate::auth::profiles::OAuthProvider::OpenAI.default_config(
-                "client-id",
-                "client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            crate::auth::profiles::OAuthProvider::OpenAI
+                .default_config(
+                    "client-id",
+                    "client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
         )
         .unwrap();
         let multi = MultiProvider::new(None, None).with_codex(Some(std::sync::Arc::new(provider)));

--- a/src/auth/profiles.rs
+++ b/src/auth/profiles.rs
@@ -449,17 +449,18 @@ impl fmt::Debug for OAuthProviderConfig {
 
 impl OAuthProvider {
     /// Build a provider config with default endpoints for this provider.
+    ///
+    /// Returns `None` for providers that do not use OAuth (e.g., Anthropic
+    /// uses direct token-backed auth profiles instead of OAuth flows).
     pub fn default_config(
         &self,
         client_id: &str,
         client_secret: &str,
         redirect_uri: &str,
-    ) -> OAuthProviderConfig {
+    ) -> Option<OAuthProviderConfig> {
         match self {
-            OAuthProvider::Anthropic => {
-                unreachable!("Anthropic auth profiles do not use OAuth provider config")
-            }
-            OAuthProvider::Google => OAuthProviderConfig {
+            OAuthProvider::Anthropic => None,
+            OAuthProvider::Google => Some(OAuthProviderConfig {
                 client_id: client_id.to_string(),
                 client_secret: client_secret.to_string(),
                 redirect_uri: redirect_uri.to_string(),
@@ -471,8 +472,8 @@ impl OAuthProvider {
                     "email".to_string(),
                     "profile".to_string(),
                 ],
-            },
-            OAuthProvider::GitHub => OAuthProviderConfig {
+            }),
+            OAuthProvider::GitHub => Some(OAuthProviderConfig {
                 client_id: client_id.to_string(),
                 client_secret: client_secret.to_string(),
                 redirect_uri: redirect_uri.to_string(),
@@ -480,8 +481,8 @@ impl OAuthProvider {
                 token_url: "https://github.com/login/oauth/access_token".to_string(),
                 userinfo_url: "https://api.github.com/user".to_string(),
                 scopes: vec!["read:user".to_string(), "user:email".to_string()],
-            },
-            OAuthProvider::Discord => OAuthProviderConfig {
+            }),
+            OAuthProvider::Discord => Some(OAuthProviderConfig {
                 client_id: client_id.to_string(),
                 client_secret: client_secret.to_string(),
                 redirect_uri: redirect_uri.to_string(),
@@ -489,8 +490,8 @@ impl OAuthProvider {
                 token_url: "https://discord.com/api/oauth2/token".to_string(),
                 userinfo_url: "https://discord.com/api/users/@me".to_string(),
                 scopes: vec!["identify".to_string(), "email".to_string()],
-            },
-            OAuthProvider::OpenAI => OAuthProviderConfig {
+            }),
+            OAuthProvider::OpenAI => Some(OAuthProviderConfig {
                 client_id: client_id.to_string(),
                 client_secret: client_secret.to_string(),
                 redirect_uri: redirect_uri.to_string(),
@@ -503,7 +504,7 @@ impl OAuthProvider {
                     "email".to_string(),
                     "offline_access".to_string(),
                 ],
-            },
+            }),
         }
     }
 }
@@ -1479,10 +1480,11 @@ pub fn build_auth_profiles_config(cfg: &Value) -> AuthProfilesConfig {
                     .unwrap_or_else(|| default_redirect.clone());
 
                 if !client_id.is_empty() && !client_secret.is_empty() {
-                    providers.insert(
-                        provider,
-                        provider.default_config(&client_id, &client_secret, &redirect_uri),
-                    );
+                    if let Some(config) =
+                        provider.default_config(&client_id, &client_secret, &redirect_uri)
+                    {
+                        providers.insert(provider, config);
+                    }
                 }
             }
         }
@@ -1588,19 +1590,27 @@ mod tests {
     }
 
     fn google_config() -> OAuthProviderConfig {
-        OAuthProvider::Google.default_config("cid", "csecret", "https://example.com/cb")
+        OAuthProvider::Google
+            .default_config("cid", "csecret", "https://example.com/cb")
+            .unwrap()
     }
 
     fn github_config() -> OAuthProviderConfig {
-        OAuthProvider::GitHub.default_config("cid", "csecret", "https://example.com/cb")
+        OAuthProvider::GitHub
+            .default_config("cid", "csecret", "https://example.com/cb")
+            .unwrap()
     }
 
     fn discord_config() -> OAuthProviderConfig {
-        OAuthProvider::Discord.default_config("cid", "csecret", "https://example.com/cb")
+        OAuthProvider::Discord
+            .default_config("cid", "csecret", "https://example.com/cb")
+            .unwrap()
     }
 
     fn openai_config() -> OAuthProviderConfig {
-        OAuthProvider::OpenAI.default_config("cid", "csecret", "https://example.com/cb")
+        OAuthProvider::OpenAI
+            .default_config("cid", "csecret", "https://example.com/cb")
+            .unwrap()
     }
 
     fn random_password() -> Vec<u8> {
@@ -1629,6 +1639,16 @@ mod tests {
         assert!(gh.client_secret == "csecret");
         assert_eq!(d.redirect_uri, "https://example.com/cb");
         assert_eq!(o.redirect_uri, "https://example.com/cb");
+    }
+
+    #[test]
+    fn test_anthropic_default_config_returns_none() {
+        assert!(
+            OAuthProvider::Anthropic
+                .default_config("cid", "csecret", "https://example.com/cb")
+                .is_none(),
+            "Anthropic does not use OAuth; default_config should return None"
+        );
     }
 
     #[test]
@@ -2111,11 +2131,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_user_info_openai_uses_token_claims_without_http_request() {
-        let mut provider_config = OAuthProvider::OpenAI.default_config(
-            "client-id",
-            "client-secret",
-            "http://127.0.0.1:3000/auth/callback",
-        );
+        let mut provider_config = OAuthProvider::OpenAI
+            .default_config(
+                "client-id",
+                "client-secret",
+                "http://127.0.0.1:3000/auth/callback",
+            )
+            .unwrap();
         let payload = serde_json::json!({
             "sub": "user-123",
             "https://api.openai.com/profile": {

--- a/src/onboarding/codex.rs
+++ b/src/onboarding/codex.rs
@@ -113,8 +113,9 @@ pub fn resolve_openai_oauth_provider_config(
         return Err("Codex sign-in requires OpenAI OAuth clientId and clientSecret.".to_string());
     }
 
-    let mut provider_config =
-        OAuthProvider::OpenAI.default_config(client_id.trim(), client_secret.trim(), &redirect_uri);
+    let mut provider_config = OAuthProvider::OpenAI
+        .default_config(client_id.trim(), client_secret.trim(), &redirect_uri)
+        .expect("OpenAI is an OAuth provider");
     if let Some(stored) = stored_provider_config {
         provider_config.auth_url = stored.auth_url;
         provider_config.token_url = stored.token_url;
@@ -635,11 +636,13 @@ fn insert_openai_oauth_flow(flow: PendingCodexOAuthFlow) -> Result<(), String> {
 #[cfg(test)]
 pub(crate) fn insert_completed_control_openai_oauth_flow_for_test() -> String {
     let flow_id = format!("codex-test-flow-{}", uuid::Uuid::new_v4());
-    let provider_config = OAuthProvider::OpenAI.default_config(
-        "openai-client-id",
-        "openai-client-secret",
-        "https://gateway.example.com/control/onboarding/codex/callback",
-    );
+    let provider_config = OAuthProvider::OpenAI
+        .default_config(
+            "openai-client-id",
+            "openai-client-secret",
+            "https://gateway.example.com/control/onboarding/codex/callback",
+        )
+        .unwrap();
     let tokens = OAuthTokens {
         access_token: "header.eyJzdWIiOiJ1c2VyLTEyMyJ9.sig".to_string(),
         refresh_token: Some("refresh-token".to_string()),
@@ -858,11 +861,13 @@ mod tests {
         let completion = CodexOAuthCompletion {
             client_id: "openai-client-id".to_string(),
             auth_profile: build_openai_auth_profile(
-                &OAuthProvider::OpenAI.default_config(
-                    "openai-client-id",
-                    "openai-client-secret",
-                    "http://127.0.0.1:3000/auth/callback",
-                ),
+                &OAuthProvider::OpenAI
+                    .default_config(
+                        "openai-client-id",
+                        "openai-client-secret",
+                        "http://127.0.0.1:3000/auth/callback",
+                    )
+                    .unwrap(),
                 sample_tokens(),
                 sample_user_info(),
             ),
@@ -970,20 +975,24 @@ mod tests {
                 id: flow_id.clone(),
                 state: "codex-state-completed".to_string(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::OpenAI.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/codex/callback",
-                ),
+                provider_config: OAuthProvider::OpenAI
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/codex/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms(),
                 flow_state: CodexOAuthFlowState::Completed(Box::new(CodexOAuthCompletion {
                     client_id: "client-id".to_string(),
                     auth_profile: build_openai_auth_profile(
-                        &OAuthProvider::OpenAI.default_config(
-                            "client-id",
-                            "client-secret",
-                            "https://gateway.example.com/control/onboarding/codex/callback",
-                        ),
+                        &OAuthProvider::OpenAI
+                            .default_config(
+                                "client-id",
+                                "client-secret",
+                                "https://gateway.example.com/control/onboarding/codex/callback",
+                            )
+                            .unwrap(),
                         sample_tokens(),
                         sample_user_info(),
                     ),
@@ -1010,11 +1019,13 @@ mod tests {
                 id: flow_id.clone(),
                 state: state.clone(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::OpenAI.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/codex/callback",
-                ),
+                provider_config: OAuthProvider::OpenAI
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/codex/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms(),
                 flow_state: CodexOAuthFlowState::InProgress,
             },
@@ -1042,11 +1053,13 @@ mod tests {
                 id: flow_id.clone(),
                 state: "codex-stale-state".to_string(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::OpenAI.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/codex/callback",
-                ),
+                provider_config: OAuthProvider::OpenAI
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/codex/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms() - FLOW_TTL.as_millis() as u64 - 1,
                 flow_state: CodexOAuthFlowState::InProgress,
             },
@@ -1080,11 +1093,13 @@ mod tests {
                     id: id.clone(),
                     state: format!("codex-state-{i}"),
                     code_verifier: "verifier".to_string(),
-                    provider_config: OAuthProvider::OpenAI.default_config(
-                        "client-id",
-                        "client-secret",
-                        "https://gateway.example.com/control/onboarding/codex/callback",
-                    ),
+                    provider_config: OAuthProvider::OpenAI
+                        .default_config(
+                            "client-id",
+                            "client-secret",
+                            "https://gateway.example.com/control/onboarding/codex/callback",
+                        )
+                        .unwrap(),
                     created_at_ms: now_ms(),
                     flow_state: CodexOAuthFlowState::Pending,
                 },

--- a/src/onboarding/gemini.rs
+++ b/src/onboarding/gemini.rs
@@ -123,8 +123,9 @@ pub fn resolve_google_oauth_provider_config(
         );
     }
 
-    let mut provider_config =
-        OAuthProvider::Google.default_config(client_id.trim(), client_secret.trim(), &redirect_uri);
+    let mut provider_config = OAuthProvider::Google
+        .default_config(client_id.trim(), client_secret.trim(), &redirect_uri)
+        .expect("Google is an OAuth provider");
     if let Some(stored) = stored_provider_config {
         provider_config.auth_url = stored.auth_url;
         provider_config.token_url = stored.token_url;
@@ -658,11 +659,13 @@ fn insert_google_oauth_flow(flow: PendingGeminiOAuthFlow) -> Result<(), String> 
 #[cfg(test)]
 pub(crate) fn insert_completed_control_google_oauth_flow_for_test() -> String {
     let flow_id = format!("gemini-test-flow-{}", uuid::Uuid::new_v4());
-    let provider_config = OAuthProvider::Google.default_config(
-        "google-client-id",
-        "google-client-secret",
-        "https://gateway.example.com/control/onboarding/gemini/callback",
-    );
+    let provider_config = OAuthProvider::Google
+        .default_config(
+            "google-client-id",
+            "google-client-secret",
+            "https://gateway.example.com/control/onboarding/gemini/callback",
+        )
+        .unwrap();
     let tokens = OAuthTokens {
         access_token: "google-access-token".to_string(),
         refresh_token: Some("google-refresh-token".to_string()),
@@ -962,11 +965,13 @@ mod tests {
         let state_dir = temp.path().to_path_buf();
         let _password_guard = set_temp_env_var("CARAPACE_CONFIG_PASSWORD", "test-config-password");
         let profile = build_google_auth_profile(
-            &OAuthProvider::Google.default_config(
-                "stored-client-id",
-                "stored-client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            &OAuthProvider::Google
+                .default_config(
+                    "stored-client-id",
+                    "stored-client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
             sample_tokens(),
             sample_user_info(),
         );
@@ -1000,11 +1005,13 @@ mod tests {
         let state_dir = temp.path().to_path_buf();
         let _password_guard = set_temp_env_var("CARAPACE_CONFIG_PASSWORD", "test-config-password");
         let profile = build_google_auth_profile(
-            &OAuthProvider::Google.default_config(
-                "stored-client-id",
-                "stored-client-secret",
-                "http://127.0.0.1:3000/auth/callback",
-            ),
+            &OAuthProvider::Google
+                .default_config(
+                    "stored-client-id",
+                    "stored-client-secret",
+                    "http://127.0.0.1:3000/auth/callback",
+                )
+                .unwrap(),
             sample_tokens(),
             sample_user_info(),
         );
@@ -1089,11 +1096,13 @@ mod tests {
         let completion = GeminiOAuthCompletion {
             client_id: "google-client-id".to_string(),
             auth_profile: build_google_auth_profile(
-                &OAuthProvider::Google.default_config(
-                    "google-client-id",
-                    "google-client-secret",
-                    "http://127.0.0.1:3000/auth/callback",
-                ),
+                &OAuthProvider::Google
+                    .default_config(
+                        "google-client-id",
+                        "google-client-secret",
+                        "http://127.0.0.1:3000/auth/callback",
+                    )
+                    .unwrap(),
                 sample_tokens(),
                 sample_user_info(),
             ),
@@ -1234,11 +1243,13 @@ mod tests {
                 id: flow_id.clone(),
                 state: "state-completed".to_string(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::Google.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/gemini/callback",
-                ),
+                provider_config: OAuthProvider::Google
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/gemini/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms(),
                 flow_state: GeminiOAuthFlowState::Completed(Box::new(GeminiOAuthCompletion {
                     client_id: "client-id".to_string(),
@@ -1262,11 +1273,13 @@ mod tests {
                         }),
                         token: None,
                         oauth_provider_config: Some(StoredOAuthProviderConfig::from(
-                            &OAuthProvider::Google.default_config(
-                                "client-id",
-                                "client-secret",
-                                "https://gateway.example.com/control/onboarding/gemini/callback",
-                            ),
+                            &OAuthProvider::Google
+                                .default_config(
+                                    "client-id",
+                                    "client-secret",
+                                    "https://gateway.example.com/control/onboarding/gemini/callback",
+                                )
+                                .unwrap(),
                         )),
                     },
                 })),
@@ -1297,11 +1310,13 @@ mod tests {
                 id: flow_id.clone(),
                 state: "state-failure".to_string(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::Google.default_config(
-                    "client-id",
-                    "client-secret",
-                    "http://127.0.0.1:3000/auth/callback",
-                ),
+                provider_config: OAuthProvider::Google
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "http://127.0.0.1:3000/auth/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms(),
                 flow_state: GeminiOAuthFlowState::Pending,
             },
@@ -1327,20 +1342,24 @@ mod tests {
                 id: flow_id.clone(),
                 state: "state-preserve-completed".to_string(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::Google.default_config(
-                    "client-id",
-                    "client-secret",
-                    "http://127.0.0.1:3000/auth/callback",
-                ),
+                provider_config: OAuthProvider::Google
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "http://127.0.0.1:3000/auth/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms(),
                 flow_state: GeminiOAuthFlowState::Completed(Box::new(GeminiOAuthCompletion {
                     client_id: "client-id".to_string(),
                     auth_profile: build_google_auth_profile(
-                        &OAuthProvider::Google.default_config(
-                            "client-id",
-                            "client-secret",
-                            "http://127.0.0.1:3000/auth/callback",
-                        ),
+                        &OAuthProvider::Google
+                            .default_config(
+                                "client-id",
+                                "client-secret",
+                                "http://127.0.0.1:3000/auth/callback",
+                            )
+                            .unwrap(),
                         sample_tokens(),
                         sample_user_info(),
                     ),
@@ -1367,11 +1386,13 @@ mod tests {
                 id: flow_id.clone(),
                 state: state.clone(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::Google.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/gemini/callback",
-                ),
+                provider_config: OAuthProvider::Google
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/gemini/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms(),
                 flow_state: GeminiOAuthFlowState::InProgress,
             },
@@ -1398,11 +1419,13 @@ mod tests {
                 id: flow_id.clone(),
                 state: "gemini-stale-state".to_string(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::Google.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/gemini/callback",
-                ),
+                provider_config: OAuthProvider::Google
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/gemini/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms() - FLOW_TTL.as_millis() as u64 - 1,
                 flow_state: GeminiOAuthFlowState::InProgress,
             },
@@ -1432,11 +1455,13 @@ mod tests {
                 id: flow_id.clone(),
                 state: state.clone(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::Google.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/gemini/callback",
-                ),
+                provider_config: OAuthProvider::Google
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/gemini/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms() - FLOW_TTL.as_millis() as u64 - 1,
                 flow_state: GeminiOAuthFlowState::Pending,
             },
@@ -1462,11 +1487,13 @@ mod tests {
                     id: id.clone(),
                     state: format!("state-{i}"),
                     code_verifier: "verifier".to_string(),
-                    provider_config: OAuthProvider::Google.default_config(
-                        "client-id",
-                        "client-secret",
-                        "https://gateway.example.com/control/onboarding/gemini/callback",
-                    ),
+                    provider_config: OAuthProvider::Google
+                        .default_config(
+                            "client-id",
+                            "client-secret",
+                            "https://gateway.example.com/control/onboarding/gemini/callback",
+                        )
+                        .unwrap(),
                     created_at_ms: now_ms(),
                     flow_state: GeminiOAuthFlowState::Pending,
                 },
@@ -1496,20 +1523,24 @@ mod tests {
                 id: flow_id.clone(),
                 state: "expired-apply-state".to_string(),
                 code_verifier: "verifier".to_string(),
-                provider_config: OAuthProvider::Google.default_config(
-                    "client-id",
-                    "client-secret",
-                    "https://gateway.example.com/control/onboarding/gemini/callback",
-                ),
+                provider_config: OAuthProvider::Google
+                    .default_config(
+                        "client-id",
+                        "client-secret",
+                        "https://gateway.example.com/control/onboarding/gemini/callback",
+                    )
+                    .unwrap(),
                 created_at_ms: now_ms() - FLOW_TTL.as_millis() as u64 - 1,
                 flow_state: GeminiOAuthFlowState::Completed(Box::new(GeminiOAuthCompletion {
                     client_id: "client-id".to_string(),
                     auth_profile: build_google_auth_profile(
-                        &OAuthProvider::Google.default_config(
-                            "client-id",
-                            "client-secret",
-                            "https://gateway.example.com/control/onboarding/gemini/callback",
-                        ),
+                        &OAuthProvider::Google
+                            .default_config(
+                                "client-id",
+                                "client-secret",
+                                "https://gateway.example.com/control/onboarding/gemini/callback",
+                            )
+                            .unwrap(),
                         sample_tokens(),
                         sample_user_info(),
                     ),


### PR DESCRIPTION
## Summary

`OAuthProvider::default_config()` previously panicked via `unreachable!()` when called on `OAuthProvider::Anthropic`. The invariant was true at all current call sites, but enforced only by caller discipline — a future generic iterator over `OAuthProvider` variants would panic at runtime.

### Changes

- Changed return type from `OAuthProviderConfig` to `Option<OAuthProviderConfig>`
- Anthropic returns `None` instead of panicking
- All 41 call sites updated:
  - Production onboarding: `.expect("{Provider} is an OAuth provider")`
  - `build_auth_profiles_config`: `if let Some(config) = ...` pattern (already excluded Anthropic from its iteration list)
  - Test helpers and test code: `.unwrap()`
- New test: `test_anthropic_default_config_returns_none`

The compiler now enforces the non-OAuth contract at every call site instead of relying on caller discipline to avoid the `unreachable!()`.

Fixes #287

## Test plan

- [ ] `cargo nextest run -p carapace auth::profiles::tests` — all profile tests pass
- [ ] `cargo nextest run -p carapace` — full test suite passes (41 call sites compile with new return type)
- [ ] `test_anthropic_default_config_returns_none` — verifies Anthropic returns None