### PR TITLE
fix: make managed plugin install/update writes transactional

### DIFF
--- a/src/server/ws/handlers/plugins.rs
+++ b/src/server/ws/handlers/plugins.rs
@@ -933,8 +933,8 @@ impl PluginWriteTransaction {
         let name = &self.plugin_name;
         let artifact = self.plugins_dir.join(format!("{name}.wasm"));
         if let Some(ref backup) = self.artifact_backup {
-            // Restore from backup (update case).
-            let _ = std::fs::remove_file(&artifact);
+            // Restore from backup (update case). rename atomically replaces
+            // the destination on Unix — no need to remove_file first.
             if let Err(e) = std::fs::rename(backup, &artifact) {
                 tracing::warn!(
                     error = %e,


### PR DESCRIPTION
## Summary

`plugins.install` and `plugins.update` write three separate persistence surfaces (artifact, manifest, config) without transactional coordination. If a later write fails after an earlier one commits, the system is left in an inconsistent state.

### Changes

- **`PluginWriteTransaction` struct**: backup/rollback support for the multi-file write sequence. Backs up existing artifact and manifest before overwriting, rolls back from backups on failure, cleans up backups on success.
- **Restructured both handlers into two phases**:
  - **Phase 1 (prepare)**: resolve artifact bytes, prepare manifest and config payloads, validate config — all before any disk writes. Config validation failures are caught early with zero side effects.
  - **Phase 2 (commit)**: write artifact → manifest → config with backup-based rollback. If any write fails, all previously committed writes are restored from backups.

### Failure model

| Failure point | Behavior |
|---|---|
| Config validation | No writes at all (fail fast) |
| Artifact write | Nothing to roll back |
| Manifest write | Artifact rolled back from `.txn-bak` |
| Config write | Manifest + artifact rolled back from `.txn-bak` |

### What this doesn't provide

- Full ACID (no WAL) — process crash mid-commit may leave `.txn-bak` files
- Config file locking (broader concern for all config writes)
- Startup cleanup of stale `.txn-bak` files (follow-up)

All 341 existing plugin tests pass.

Fixes #243

## Test plan

- [ ] `cargo nextest run -p carapace plugins` — 341 tests pass
- [ ] Install a plugin via URL, then simulate manifest write failure (e.g., read-only dir) → artifact should be rolled back
- [ ] Update a plugin, simulate config write failure → both manifest and artifact should be rolled back to previous state