### PR TITLE
refactor: consolidate SetupCheck factory methods (#201 slice 2)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5121,7 +5121,7 @@ fn validate_provider_credentials_interactive(
     if provider == SetupProvider::Anthropic
         && requested_auth_mode == Some(SetupAuthModeSelection::SetupToken)
     {
-        return Ok(crate::onboarding::setup::SetupCheck::validation_skip_generic(
+        return Ok(crate::onboarding::setup::SetupCheck::validation_skip(
             "Live provider validation",
             "Anthropic setup-token live validation was skipped because setup-tokens do not use the API-key validation probe."
                 .to_string(),
@@ -5129,21 +5129,21 @@ fn validate_provider_credentials_interactive(
                 "run `cara verify --outcome local-chat` after setup to exercise the configured Anthropic setup-token path"
                     .to_string(),
             ),
+            None,
         ));
     }
 
     let validate_now = prompt_yes_no("Validate provider credentials now?", true)?;
     if !validate_now {
-        return Ok(
-            crate::onboarding::setup::SetupCheck::validation_skip_generic(
-                "Live provider validation",
-                format!("{} credential validation was skipped", provider.label()),
-                Some(
-                    "run `cara verify` after setup to exercise the configured provider path"
-                        .to_string(),
-                ),
+        return Ok(crate::onboarding::setup::SetupCheck::validation_skip(
+            "Live provider validation",
+            format!("{} credential validation was skipped", provider.label()),
+            Some(
+                "run `cara verify` after setup to exercise the configured provider path"
+                    .to_string(),
             ),
-        );
+            None,
+        ));
     }
 
     let provider_key = provider.prompt_key().to_string();
@@ -5154,24 +5154,24 @@ fn validate_provider_credentials_interactive(
     {
         Ok(()) => {
             println!("Credential check succeeded.");
-            Ok(
-                crate::onboarding::setup::SetupCheck::validation_pass_generic(
-                    "Live provider validation",
-                    format!("{} credential validation succeeded", provider.label()),
-                ),
-            )
+            Ok(crate::onboarding::setup::SetupCheck::validation_pass(
+                "Live provider validation",
+                format!("{} credential validation succeeded", provider.label()),
+                None,
+            ))
         }
         Err(err) => {
             eprintln!("Credential check failed: {}", err);
             if prompt_yes_no("Continue setup and write config anyway?", false)? {
                 let rerun_command = setup_rerun_command(provider, requested_auth_mode);
-                Ok(crate::onboarding::setup::SetupCheck::validation_fail_generic(
+                Ok(crate::onboarding::setup::SetupCheck::validation_fail(
                     "Live provider validation",
                     err,
                     format!(
                         "fix the credential and rerun `{}` or run `cara verify` after updating config",
                         rerun_command
                     ),
+                    None,
                 ))
             } else {
                 Err("setup aborted after credential validation failure".into())
@@ -5189,16 +5189,15 @@ fn validate_bedrock_credentials_interactive(
 ) -> Result<Vec<crate::onboarding::setup::SetupCheck>, Box<dyn std::error::Error>> {
     let validate_now = prompt_yes_no("Validate Bedrock credentials now?", true)?;
     if !validate_now {
-        return Ok(vec![
-            crate::onboarding::setup::SetupCheck::validation_skip_generic(
-                "Live Bedrock validation",
-                "Bedrock credential validation was skipped".to_string(),
-                Some(
-                    "run `cara verify` after setup to exercise the configured provider path"
-                        .to_string(),
-                ),
+        return Ok(vec![crate::onboarding::setup::SetupCheck::validation_skip(
+            "Live Bedrock validation",
+            "Bedrock credential validation was skipped".to_string(),
+            Some(
+                "run `cara verify` after setup to exercise the configured provider path"
+                    .to_string(),
             ),
-        ]);
+            None,
+        )]);
     }
 
     let mut checks = Vec::new();
@@ -5321,34 +5320,32 @@ fn validate_vertex_provider_interactive(
 ) -> Result<crate::onboarding::setup::SetupCheck, Box<dyn std::error::Error>> {
     let validate_now = prompt_yes_no("Validate Vertex configuration now?", true)?;
     if !validate_now {
-        return Ok(
-            crate::onboarding::setup::SetupCheck::validation_skip_generic(
-                "Live provider validation",
-                "Vertex live validation was skipped",
-                Some(
-                    "run `cara verify` after setup to exercise the configured Vertex path"
-                        .to_string(),
-                ),
+        return Ok(crate::onboarding::setup::SetupCheck::validation_skip(
+            "Live provider validation",
+            "Vertex live validation was skipped",
+            Some(
+                "run `cara verify` after setup to exercise the configured Vertex path".to_string(),
             ),
-        );
+            None,
+        ));
     }
 
     #[cfg(test)]
     if let Some(result) = setup_interactive_test_harness_take_provider_validation_result() {
         return match result {
-            Ok(()) => Ok(
-                crate::onboarding::setup::SetupCheck::validation_pass_generic(
-                    "Live provider validation",
-                    "Vertex auth, project, location, and model access validated",
-                ),
-            ),
+            Ok(()) => Ok(crate::onboarding::setup::SetupCheck::validation_pass(
+                "Live provider validation",
+                "Vertex auth, project, location, and model access validated",
+                None,
+            )),
             Err(detail) => {
                 eprintln!("Credential check failed: {detail}");
                 if prompt_yes_no("Continue setup and write config anyway?", false)? {
-                    Ok(crate::onboarding::setup::SetupCheck::validation_fail_generic(
+                    Ok(crate::onboarding::setup::SetupCheck::validation_fail(
                         "Live provider validation",
                         detail,
                         "check Vertex auth, project, location, and model access, then rerun `cara setup --force --provider vertex`".to_string(),
+                        None,
                     ))
                 } else {
                     Err("setup aborted after provider configuration validation failure".into())
@@ -5367,24 +5364,22 @@ fn validate_vertex_provider_interactive(
     )) {
         Ok(()) => {
             println!("Credential check succeeded.");
-            Ok(
-                crate::onboarding::setup::SetupCheck::validation_pass_generic(
-                    "Live provider validation",
-                    "Vertex auth, project, location, and model access validated",
-                ),
-            )
+            Ok(crate::onboarding::setup::SetupCheck::validation_pass(
+                "Live provider validation",
+                "Vertex auth, project, location, and model access validated",
+                None,
+            ))
         }
         Err(crate::runtime_bridge::BridgeError::Inner(err)) => {
             let detail = err.to_string();
             eprintln!("Credential check failed: {detail}");
             if prompt_yes_no("Continue setup and write config anyway?", false)? {
-                Ok(
-                    crate::onboarding::setup::SetupCheck::validation_fail_generic(
-                        "Live provider validation",
-                        detail,
-                        vertex_validation_failure_remediation(&err),
-                    ),
-                )
+                Ok(crate::onboarding::setup::SetupCheck::validation_fail(
+                    "Live provider validation",
+                    detail,
+                    vertex_validation_failure_remediation(&err),
+                    None,
+                ))
             } else {
                 Err("setup aborted after provider configuration validation failure".into())
             }
@@ -5393,11 +5388,12 @@ fn validate_vertex_provider_interactive(
             let detail = format!("Vertex validation runtime failed: {err}");
             eprintln!("Credential check failed: {detail}");
             if prompt_yes_no("Continue setup and write config anyway?", false)? {
-                Ok(crate::onboarding::setup::SetupCheck::validation_fail_generic(
+                Ok(crate::onboarding::setup::SetupCheck::validation_fail(
                     "Live provider validation",
                     detail,
                     "check local runtime availability and rerun `cara setup --force --provider vertex`"
                         .to_string(),
+                    None,
                 ))
             } else {
                 Err("setup aborted after provider configuration validation failure".into())
@@ -6885,12 +6881,13 @@ fn configure_gemini_provider_interactive(
                 None => "stored Gemini auth profile".to_string(),
             };
             crate::onboarding::gemini::persist_cli_google_oauth(state_dir, config, completion)?;
-            result.observed_checks.push(
-                crate::onboarding::setup::SetupCheck::validation_pass_generic(
+            result
+                .observed_checks
+                .push(crate::onboarding::setup::SetupCheck::validation_pass(
                     "Live provider validation",
                     profile_detail,
-                ),
-            );
+                    None,
+                ));
 
             if let Some(base_url) = base_url {
                 config["google"]["baseUrl"] = serde_json::json!(base_url.config_value);
@@ -6939,12 +6936,11 @@ fn configure_codex_provider_interactive(
     crate::onboarding::codex::persist_cli_openai_oauth(state_dir, config, completion)?;
 
     Ok(ProviderSetupResult {
-        observed_checks: vec![
-            crate::onboarding::setup::SetupCheck::validation_pass_generic(
-                "Live provider validation",
-                profile_detail,
-            ),
-        ],
+        observed_checks: vec![crate::onboarding::setup::SetupCheck::validation_pass(
+            "Live provider validation",
+            profile_detail,
+            None,
+        )],
     })
 }
 
@@ -7056,13 +7052,14 @@ fn configure_vertex_provider_interactive(
                 ),
             ),
         };
-        result.observed_checks.push(
-            crate::onboarding::setup::SetupCheck::validation_skip_generic(
+        result
+            .observed_checks
+            .push(crate::onboarding::setup::SetupCheck::validation_skip(
                 "Live provider validation",
                 detail,
                 Some(remediation),
-            ),
-        );
+                None,
+            ));
     }
 
     crate::onboarding::vertex::write_vertex_config(config, &config_input)?;
@@ -7078,13 +7075,12 @@ fn handle_setup_validation_failure(
     let rerun = setup_rerun_command(provider, requested_auth_mode);
     eprintln!("Next step: fix the value and rerun `{rerun}`.");
     if prompt_yes_no("Continue setup and write config anyway?", false)? {
-        Ok(
-            crate::onboarding::setup::SetupCheck::validation_fail_generic(
-                "Provider configuration validation",
-                render_setup_validation_failure(&err),
-                format!("fix the value and rerun `{rerun}`"),
-            ),
-        )
+        Ok(crate::onboarding::setup::SetupCheck::validation_fail(
+            "Provider configuration validation",
+            render_setup_validation_failure(&err),
+            format!("fix the value and rerun `{rerun}`"),
+            None,
+        ))
     } else {
         Err("setup aborted after provider configuration validation failure".into())
     }
@@ -7599,10 +7595,11 @@ fn configure_provider_noninteractive(
                     }
                     Err(err) => {
                         result.observed_checks.push(
-                            crate::onboarding::setup::SetupCheck::validation_fail_generic(
+                            crate::onboarding::setup::SetupCheck::validation_fail(
                                 "Live Bedrock validation",
                                 format!("Credential validation runtime failed: {err}"),
                                 "run `cara verify` after setup to exercise the configured provider path".to_string(),
+                                None,
                             ),
                         );
                     }

--- a/src/onboarding/bedrock.rs
+++ b/src/onboarding/bedrock.rs
@@ -109,12 +109,13 @@ pub fn detect_credential_sources() -> BedrockCredentialSources {
 /// Validate that a region is known to support Bedrock.
 pub fn validate_region(region: &str) -> SetupCheck {
     if BEDROCK_REGIONS.contains(&region) {
-        SetupCheck::validation_pass_generic(
+        SetupCheck::validation_pass(
             "Bedrock region",
             format!("Region `{region}` supports Bedrock"),
+            None,
         )
     } else {
-        SetupCheck::validation_skip_generic(
+        SetupCheck::validation_skip(
             "Bedrock region",
             format!(
                 "Region `{region}` is not in the known Bedrock region list; \
@@ -125,6 +126,7 @@ pub fn validate_region(region: &str) -> SetupCheck {
                  If `{region}` was recently added, this is safe to ignore.",
                 BEDROCK_REGIONS.join(", ")
             )),
+            None,
         )
     }
 }
@@ -159,10 +161,11 @@ pub async fn validate_bedrock_credentials(
         Ok(c) => c,
         Err(e) => {
             return (
-                SetupCheck::validation_fail_generic(
+                SetupCheck::validation_fail(
                     "Bedrock credentials",
                     format!("Failed to build HTTP client: {e}"),
                     "This is unexpected. Check your system TLS/network configuration.".to_string(),
+                    None,
                 ),
                 None,
             );
@@ -194,10 +197,11 @@ pub async fn validate_bedrock_credentials(
                 )
             };
             return (
-                SetupCheck::validation_fail_generic(
+                SetupCheck::validation_fail(
                     "Bedrock credentials",
                     format!("{e}"),
                     remediation,
+                    None,
                 ),
                 None,
             );
@@ -208,19 +212,21 @@ pub async fn validate_bedrock_credentials(
     if status.is_success() {
         match response.json::<serde_json::Value>().await {
             Ok(body) => (
-                SetupCheck::validation_pass_generic(
+                SetupCheck::validation_pass(
                     "Bedrock credentials",
                     format!("AWS credentials are valid and authorized for Bedrock in `{region}`"),
+                    None,
                 ),
                 Some(body),
             ),
             Err(e) => (
-                SetupCheck::validation_skip_generic(
+                SetupCheck::validation_skip(
                     "Bedrock credentials",
                     format!(
                         "AWS credentials are valid (HTTP 200) but response parsing failed: {e}"
                     ),
                     Some("Run `cara verify` after setup to confirm model access.".to_string()),
+                    None,
                 ),
                 None,
             ),
@@ -232,7 +238,7 @@ pub async fn validate_bedrock_credentials(
         // bedrock:InvokeModel, so this is not a setup failure.
         if status.as_u16() == 403 && body_text.contains("AccessDeniedException") {
             return (
-                SetupCheck::validation_skip_generic(
+                SetupCheck::validation_skip(
                     "Bedrock credentials",
                     "AWS credentials are valid but lack `bedrock:ListFoundationModels` \
                      permission; cannot verify model access during setup"
@@ -243,13 +249,14 @@ pub async fn validate_bedrock_credentials(
                          your IAM user/role."
                             .to_string(),
                     ),
+                    None,
                 ),
                 None,
             );
         }
         let (detail, remediation) = classify_api_error(status.as_u16(), &body_text, region);
         (
-            SetupCheck::validation_fail_generic("Bedrock credentials", detail, remediation),
+            SetupCheck::validation_fail("Bedrock credentials", detail, remediation, None),
             None,
         )
     }
@@ -262,10 +269,11 @@ pub fn check_model_access(model_id: &str, foundation_models: &serde_json::Value)
     let models = match foundation_models.get("modelSummaries") {
         Some(serde_json::Value::Array(arr)) => arr,
         _ => {
-            return SetupCheck::validation_skip_generic(
+            return SetupCheck::validation_skip(
                 "Model access",
                 "Could not parse model list from ListFoundationModels response".to_string(),
                 Some("Run `cara verify` after setup to confirm model access.".to_string()),
+                None,
             );
         }
     };
@@ -279,12 +287,13 @@ pub fn check_model_access(model_id: &str, foundation_models: &serde_json::Value)
                 .and_then(|v| v.as_str())
                 .unwrap_or("UNKNOWN");
             if status != "ACTIVE" {
-                return SetupCheck::validation_fail_generic(
+                return SetupCheck::validation_fail(
                     "Model access",
                     format!("Model `{bare_model}` found but lifecycle status is `{status}`"),
                     "The model may be deprecated or not yet available. \
                      Check the AWS console for model status in your region."
                         .to_string(),
+                    None,
                 );
             }
 
@@ -294,7 +303,7 @@ pub fn check_model_access(model_id: &str, foundation_models: &serde_json::Value)
                 .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("ON_DEMAND")));
 
             if !supports_on_demand {
-                return SetupCheck::validation_fail_generic(
+                return SetupCheck::validation_fail(
                     "Model access",
                     format!(
                         "Model `{bare_model}` is active but does not support on-demand inference"
@@ -303,17 +312,19 @@ pub fn check_model_access(model_id: &str, foundation_models: &serde_json::Value)
                      that supports on-demand inference, or provision throughput \
                      in the AWS console."
                         .to_string(),
+                    None,
                 );
             }
 
-            return SetupCheck::validation_pass_generic(
+            return SetupCheck::validation_pass(
                 "Model access",
                 format!("Model `{bare_model}` is active and supports on-demand inference"),
+                None,
             );
         }
     }
 
-    SetupCheck::validation_fail_generic(
+    SetupCheck::validation_fail(
         "Model access",
         format!(
             "Model `{bare_model}` not found in the ListFoundationModels response for this region"
@@ -323,6 +334,7 @@ pub fn check_model_access(model_id: &str, foundation_models: &serde_json::Value)
              you have requested access in the AWS console \
              (Bedrock → Model access → Request access)."
         ),
+        None,
     )
 }
 

--- a/src/onboarding/setup.rs
+++ b/src/onboarding/setup.rs
@@ -284,6 +284,13 @@ pub struct SetupCheck {
     pub projection: SetupCheckProjection,
 }
 
+fn projection_from(code: Option<SetupCheckCode>) -> SetupCheckProjection {
+    match code {
+        Some(c) => SetupCheckProjection::Code(c),
+        None => SetupCheckProjection::GenericStatus,
+    }
+}
+
 impl SetupCheck {
     fn new(
         name: impl Into<String>,
@@ -303,21 +310,10 @@ impl SetupCheck {
         }
     }
 
-    pub fn pass_generic(name: impl Into<String>, detail: impl Into<String>) -> Self {
-        Self::new(
-            name,
-            SetupCheckStatus::Pass,
-            SetupCheckKind::Requirement,
-            detail,
-            None,
-            SetupCheckProjection::GenericStatus,
-        )
-    }
-
-    pub fn pass_code(
+    pub fn pass(
         name: impl Into<String>,
         detail: impl Into<String>,
-        code: SetupCheckCode,
+        code: Option<SetupCheckCode>,
     ) -> Self {
         Self::new(
             name,
@@ -325,25 +321,14 @@ impl SetupCheck {
             SetupCheckKind::Requirement,
             detail,
             None,
-            SetupCheckProjection::Code(code),
+            projection_from(code),
         )
     }
 
-    pub fn validation_pass_generic(name: impl Into<String>, detail: impl Into<String>) -> Self {
-        Self::new(
-            name,
-            SetupCheckStatus::Pass,
-            SetupCheckKind::Validation,
-            detail,
-            None,
-            SetupCheckProjection::GenericStatus,
-        )
-    }
-
-    pub fn validation_pass_code(
+    pub fn validation_pass(
         name: impl Into<String>,
         detail: impl Into<String>,
-        code: SetupCheckCode,
+        code: Option<SetupCheckCode>,
     ) -> Self {
         Self::new(
             name,
@@ -351,14 +336,15 @@ impl SetupCheck {
             SetupCheckKind::Validation,
             detail,
             None,
-            SetupCheckProjection::Code(code),
+            projection_from(code),
         )
     }
 
-    pub fn fail_generic(
+    pub fn fail(
         name: impl Into<String>,
         detail: impl Into<String>,
         remediation: impl Into<String>,
+        code: Option<SetupCheckCode>,
     ) -> Self {
         Self::new(
             name,
@@ -366,30 +352,15 @@ impl SetupCheck {
             SetupCheckKind::Requirement,
             detail,
             Some(remediation.into()),
-            SetupCheckProjection::GenericStatus,
+            projection_from(code),
         )
     }
 
-    pub fn fail_code(
-        name: impl Into<String>,
-        detail: impl Into<String>,
-        remediation: impl Into<String>,
-        code: SetupCheckCode,
-    ) -> Self {
-        Self::new(
-            name,
-            SetupCheckStatus::Fail,
-            SetupCheckKind::Requirement,
-            detail,
-            Some(remediation.into()),
-            SetupCheckProjection::Code(code),
-        )
-    }
-
-    pub fn skip_generic(
+    pub fn skip(
         name: impl Into<String>,
         detail: impl Into<String>,
         remediation: Option<String>,
+        code: Option<SetupCheckCode>,
     ) -> Self {
         Self::new(
             name,
@@ -397,30 +368,15 @@ impl SetupCheck {
             SetupCheckKind::Requirement,
             detail,
             remediation,
-            SetupCheckProjection::GenericStatus,
+            projection_from(code),
         )
     }
 
-    pub fn skip_code(
+    pub fn validation_skip(
         name: impl Into<String>,
         detail: impl Into<String>,
         remediation: Option<String>,
-        code: SetupCheckCode,
-    ) -> Self {
-        Self::new(
-            name,
-            SetupCheckStatus::Skip,
-            SetupCheckKind::Requirement,
-            detail,
-            remediation,
-            SetupCheckProjection::Code(code),
-        )
-    }
-
-    pub fn validation_skip_generic(
-        name: impl Into<String>,
-        detail: impl Into<String>,
-        remediation: Option<String>,
+        code: Option<SetupCheckCode>,
     ) -> Self {
         Self::new(
             name,
@@ -428,30 +384,15 @@ impl SetupCheck {
             SetupCheckKind::Validation,
             detail,
             remediation,
-            SetupCheckProjection::GenericStatus,
+            projection_from(code),
         )
     }
 
-    pub fn validation_skip_code(
-        name: impl Into<String>,
-        detail: impl Into<String>,
-        remediation: Option<String>,
-        code: SetupCheckCode,
-    ) -> Self {
-        Self::new(
-            name,
-            SetupCheckStatus::Skip,
-            SetupCheckKind::Validation,
-            detail,
-            remediation,
-            SetupCheckProjection::Code(code),
-        )
-    }
-
-    pub fn validation_fail_generic(
+    pub fn validation_fail(
         name: impl Into<String>,
         detail: impl Into<String>,
         remediation: impl Into<String>,
+        code: Option<SetupCheckCode>,
     ) -> Self {
         Self::new(
             name,
@@ -459,23 +400,7 @@ impl SetupCheck {
             SetupCheckKind::Validation,
             detail,
             Some(remediation.into()),
-            SetupCheckProjection::GenericStatus,
-        )
-    }
-
-    pub fn validation_fail_code(
-        name: impl Into<String>,
-        detail: impl Into<String>,
-        remediation: impl Into<String>,
-        code: SetupCheckCode,
-    ) -> Self {
-        Self::new(
-            name,
-            SetupCheckStatus::Fail,
-            SetupCheckKind::Validation,
-            detail,
-            Some(remediation.into()),
-            SetupCheckProjection::Code(code),
+            projection_from(code),
         )
     }
 
@@ -565,7 +490,7 @@ pub fn assess_provider_setup(
             let profile_id = config_string(cfg, &["anthropic", "authProfile"]);
             match (api_key, profile_id) {
                 (Some(_), Some(profile_id)) => {
-                    checks.push(SetupCheck::skip_generic(
+                    checks.push(SetupCheck::skip(
                         "Anthropic auth path",
                         format!(
                             "both `anthropic.apiKey` and `anthropic.authProfile` (`{profile_id}`) are configured; runtime will prefer `anthropic.apiKey`"
@@ -574,6 +499,7 @@ pub fn assess_provider_setup(
                             "remove one of `anthropic.apiKey` or `anthropic.authProfile` to keep the Anthropic auth path explicit"
                                 .to_string(),
                         ),
+                        None,
                     ));
                     checks.push(configured_value_check(
                         cfg,
@@ -628,7 +554,7 @@ pub fn assess_provider_setup(
                         checks.push(check);
                     }
                 }
-                (None, None) => checks.push(SetupCheck::fail_generic(
+                (None, None) => checks.push(SetupCheck::fail(
                     "Anthropic credential",
                     "Neither `anthropic.apiKey` nor `anthropic.authProfile` is configured",
                     setup_follow_up(provider_setup_follow_up(
@@ -637,6 +563,7 @@ pub fn assess_provider_setup(
                         "write `anthropic.apiKey` or `anthropic.authProfile` into config"
                             .to_string(),
                     )),
+                    None,
                 )),
             }
         }
@@ -855,9 +782,10 @@ pub fn assess_provider_setup(
         check.status == SetupCheckStatus::Pass && check.kind == SetupCheckKind::Validation
     });
     if !has_fail && !has_validation_check {
-        checks.push(SetupCheck::validation_skip_generic(
+        checks.push(SetupCheck::validation_skip(
             "Live provider validation",
             "setup completed without a live provider-side validation step",
+            None,
             None,
         ));
     }
@@ -987,7 +915,7 @@ fn vertex_default_model_check(cfg: &Value, setup_command: Option<&str>) -> Setup
             let missing = missing_env_var_references(&references);
             if !missing.is_empty() {
                 let env_vars = format_env_var_list(&missing);
-                SetupCheck::fail_generic(
+                SetupCheck::fail(
                     "Vertex default model",
                     format!("Vertex default model references {env_vars}, but they are not set"),
                     setup_follow_up(provider_setup_follow_up(
@@ -995,23 +923,26 @@ fn vertex_default_model_check(cfg: &Value, setup_command: Option<&str>) -> Setup
                         format!("after setting {env_vars} or rewriting `vertex.model`"),
                         format!("set {env_vars} in the same shell or write `vertex.model` into config"),
                     )),
+                    None,
                 )
             } else if !references.is_empty() {
-                SetupCheck::pass_generic(
+                SetupCheck::pass(
                     "Vertex default model",
                     format!(
                         "Vertex default model resolves from {}",
                         format_env_var_list(&references)
                     ),
+                    None,
                 )
             } else {
-                SetupCheck::pass_generic(
+                SetupCheck::pass(
                     "Vertex default model",
                     "Vertex default model is written in config",
+                    None,
                 )
             }
         }
-        None => SetupCheck::fail_generic(
+        None => SetupCheck::fail(
             "Vertex default model",
             "`agents.defaults.model` routes to `vertex:default`, but `vertex.model` is not configured",
             setup_follow_up(provider_setup_follow_up(
@@ -1019,6 +950,7 @@ fn vertex_default_model_check(cfg: &Value, setup_command: Option<&str>) -> Setup
                 "after setting `vertex.model` or choosing an explicit Vertex model route".to_string(),
                 "set `vertex.model`, or switch `agents.defaults.model` to an explicit Vertex model such as `vertex:gemini-2.5-flash`".to_string(),
             )),
+            None,
         ),
     }
 }
@@ -1029,18 +961,20 @@ fn model_route_check(
     setup_command: Option<&str>,
 ) -> SetupCheck {
     let Some(model) = config_string(cfg, &["agents", "defaults", "model"]) else {
-        return SetupCheck::fail_generic(
+        return SetupCheck::fail(
             "Default model route",
             "`agents.defaults.model` is not configured".to_string(),
             default_model_route_follow_up(provider, setup_command),
+            None,
         );
     };
     match model_provider_for_local_chat(&model) {
-        Some(actual_provider) if actual_provider == provider => SetupCheck::pass_generic(
+        Some(actual_provider) if actual_provider == provider => SetupCheck::pass(
             "Default model route",
             format!("`agents.defaults.model` routes to {}", provider.label()),
+            None,
         ),
-        Some(actual_provider) => SetupCheck::fail_generic(
+        Some(actual_provider) => SetupCheck::fail(
             "Default model route",
             format!(
                 "`agents.defaults.model` currently routes to {}, not {}",
@@ -1048,11 +982,13 @@ fn model_route_check(
                 provider.label()
             ),
             default_model_route_follow_up(provider, setup_command),
+            None,
         ),
-        None => SetupCheck::fail_generic(
+        None => SetupCheck::fail(
             "Default model route",
             format!("`agents.defaults.model` uses an unrecognized provider route: `{model}`"),
             default_model_route_follow_up(provider, setup_command),
+            None,
         ),
     }
 }
@@ -1063,9 +999,9 @@ fn auth_profiles_enabled_check(cfg: &Value, setup_command: Option<&str>) -> Setu
         .and_then(Value::as_bool)
         .unwrap_or(false);
     if enabled {
-        SetupCheck::pass_generic("Auth profiles", "`auth.profiles.enabled` is true")
+        SetupCheck::pass("Auth profiles", "`auth.profiles.enabled` is true", None)
     } else {
-        SetupCheck::fail_generic(
+        SetupCheck::fail(
             "Auth profiles",
             "`auth.profiles.enabled` is false",
             setup_follow_up(provider_setup_follow_up(
@@ -1073,6 +1009,7 @@ fn auth_profiles_enabled_check(cfg: &Value, setup_command: Option<&str>) -> Setu
                 "to enable auth profiles",
                 "enable `auth.profiles.enabled` in config",
             )),
+            None,
         )
     }
 }
@@ -1084,12 +1021,12 @@ fn auth_profile_id_check(
     setup_command: Option<&str>,
 ) -> SetupCheck {
     match config_string(cfg, path) {
-        Some(profile_id) => SetupCheck::pass_code(
+        Some(profile_id) => SetupCheck::pass(
             label,
             format!("configured profile id: `{profile_id}`"),
-            SetupCheckCode::AuthProfileConfigured,
+            Some(SetupCheckCode::AuthProfileConfigured),
         ),
-        None => SetupCheck::fail_code(
+        None => SetupCheck::fail(
             label,
             format!("{label} is not configured"),
             setup_follow_up(provider_setup_follow_up(
@@ -1097,16 +1034,17 @@ fn auth_profile_id_check(
                 "to store a sign-in profile",
                 format!("write {label} into config"),
             )),
-            SetupCheckCode::AuthProfileNotConfigured,
+            Some(SetupCheckCode::AuthProfileNotConfigured),
         ),
     }
 }
 
 fn config_password_check(setup_command: Option<&str>) -> SetupCheck {
     if env_var_present("CARAPACE_CONFIG_PASSWORD") {
-        SetupCheck::pass_generic(
+        SetupCheck::pass(
             "Encrypted profile store",
             "`CARAPACE_CONFIG_PASSWORD` is set in the current shell",
+            None,
         )
     } else {
         let remediation = match setup_command {
@@ -1117,10 +1055,11 @@ fn config_password_check(setup_command: Option<&str>) -> SetupCheck {
                 "set `CARAPACE_CONFIG_PASSWORD` before running Carapace, then rerun `{LOCAL_CHAT_VERIFY_COMMAND}`"
             ),
         };
-        SetupCheck::fail_generic(
+        SetupCheck::fail(
             "Encrypted profile store",
             "`CARAPACE_CONFIG_PASSWORD` is not set in the current shell",
             remediation,
+            None,
         )
     }
 }
@@ -1137,7 +1076,7 @@ fn auth_profile_summary_check(
         Ok(Some(loaded)) => {
             if loaded.summary.provider != expected_provider {
                 (
-                    SetupCheck::fail_code(
+                    SetupCheck::fail(
                         label,
                         format!(
                             "stored profile `{profile_id}` belongs to {}, not {}",
@@ -1148,13 +1087,13 @@ fn auth_profile_summary_check(
                             "to store the correct auth profile",
                             format!("write the correct {label} into config"),
                         )),
-                        SetupCheckCode::AuthProfileWrongProvider,
+                        Some(SetupCheckCode::AuthProfileWrongProvider),
                     ),
                     None,
                 )
             } else if loaded.summary.credential_kind != expected_credential_kind {
                 (
-                    SetupCheck::fail_code(
+                    SetupCheck::fail(
                         label,
                         format!(
                             "stored profile `{profile_id}` uses {} credentials, not {}",
@@ -1165,7 +1104,7 @@ fn auth_profile_summary_check(
                             "to store the correct auth profile credential type",
                             format!("write the correct {label} into config"),
                         )),
-                        SetupCheckCode::AuthProfileWrongCredentialType,
+                        Some(SetupCheckCode::AuthProfileWrongCredentialType),
                     ),
                     None,
                 )
@@ -1180,7 +1119,7 @@ fn auth_profile_summary_check(
                     format!("stored profile `{profile_id}` has no usable token")
                 };
                 (
-                    SetupCheck::fail_code(
+                    SetupCheck::fail(
                         label,
                         detail,
                         setup_follow_up(provider_setup_follow_up(
@@ -1188,11 +1127,13 @@ fn auth_profile_summary_check(
                             "to store a fresh auth profile token",
                             format!("write a fresh {label} into config"),
                         )),
-                        if loaded.token_still_encrypted && profile_store_password_present() {
-                            SetupCheckCode::AuthProfileTokenDecryptFailed
-                        } else {
-                            SetupCheckCode::AuthProfileTokenMissing
-                        },
+                        Some(
+                            if loaded.token_still_encrypted && profile_store_password_present() {
+                                SetupCheckCode::AuthProfileTokenDecryptFailed
+                            } else {
+                                SetupCheckCode::AuthProfileTokenMissing
+                            },
+                        ),
                     ),
                     None,
                 )
@@ -1202,17 +1143,17 @@ fn auth_profile_summary_check(
                     None => format!("loaded `{}`", loaded.summary.name),
                 };
                 (
-                    SetupCheck::validation_pass_code(
+                    SetupCheck::validation_pass(
                         label,
                         detail,
-                        SetupCheckCode::AuthProfileLoaded,
+                        Some(SetupCheckCode::AuthProfileLoaded),
                     ),
                     Some(loaded.summary),
                 )
             }
         }
         Ok(None) => (
-            SetupCheck::fail_code(
+            SetupCheck::fail(
                 label,
                 format!("stored profile `{profile_id}` was not found in the profile store"),
                 setup_follow_up(provider_setup_follow_up(
@@ -1220,7 +1161,7 @@ fn auth_profile_summary_check(
                     "to store a fresh auth profile",
                     format!("write a fresh {label} into config"),
                 )),
-                SetupCheckCode::AuthProfileMissing,
+                Some(SetupCheckCode::AuthProfileMissing),
             ),
             None,
         ),
@@ -1230,11 +1171,11 @@ fn auth_profile_summary_check(
                 None => format!("check the profile store and rerun `{LOCAL_CHAT_VERIFY_COMMAND}`"),
             };
             (
-                SetupCheck::fail_code(
+                SetupCheck::fail(
                     label,
                     format!("failed to read the profile store: {err}"),
                     remediation,
-                    SetupCheckCode::AuthProfileStoreReadFailed,
+                    Some(SetupCheckCode::AuthProfileStoreReadFailed),
                 ),
                 None,
             )
@@ -1267,21 +1208,23 @@ fn configured_value_check(
                         "set {env_vars} in the same shell or write {label} into config, then rerun `{LOCAL_CHAT_VERIFY_COMMAND}`"
                     ),
                 };
-                SetupCheck::fail_generic(
+                SetupCheck::fail(
                     label,
                     format!("{label} references {env_vars}, but they are not set"),
                     remediation,
+                    None,
                 )
             } else if !references.is_empty() {
-                SetupCheck::pass_generic(
+                SetupCheck::pass(
                     label,
                     format!("{label} resolves from {}", format_env_var_list(&references)),
+                    None,
                 )
             } else {
-                SetupCheck::pass_generic(label, format!("{label} is written in config"))
+                SetupCheck::pass(label, format!("{label} is written in config"), None)
             }
         }
-        None => SetupCheck::fail_generic(
+        None => SetupCheck::fail(
             label,
             format!("{label} is not configured"),
             setup_follow_up(provider_setup_follow_up(
@@ -1289,6 +1232,7 @@ fn configured_value_check(
                 format!("to configure {label}"),
                 format!("write {label} into config"),
             )),
+            None,
         ),
     }
 }
@@ -1300,21 +1244,23 @@ fn optional_configured_value_check(cfg: &Value, path: &[&str], label: &str) -> S
             let missing = missing_env_var_references(&references);
             if !missing.is_empty() {
                 let env_vars = format_env_var_list(&missing);
-                SetupCheck::fail_generic(
+                SetupCheck::fail(
                     label,
                     format!("{label} references {env_vars}, but they are not set"),
                     format!("set {env_vars} before starting Carapace"),
+                    None,
                 )
             } else if !references.is_empty() {
-                SetupCheck::pass_generic(
+                SetupCheck::pass(
                     label,
                     format!("{label} resolves from {}", format_env_var_list(&references)),
+                    None,
                 )
             } else {
-                SetupCheck::pass_generic(label, format!("{label} is written in config"))
+                SetupCheck::pass(label, format!("{label} is written in config"), None)
             }
         }
-        None => SetupCheck::skip_generic(label, format!("{label} is not configured"), None),
+        None => SetupCheck::skip(label, format!("{label} is not configured"), None, None),
     }
 }
 
@@ -1329,7 +1275,7 @@ where
     F: FnOnce(&str) -> Result<(), String>,
 {
     let Some(value) = config_string(cfg, path) else {
-        return SetupCheck::skip_generic(label, "no custom base URL configured", None);
+        return SetupCheck::skip(label, "no custom base URL configured", None, None);
     };
     let references = env_var_references(&value);
     let missing = missing_env_var_references(&references);
@@ -1343,17 +1289,18 @@ where
                 "set {env_vars} in the same shell or write a valid {label} into config, then rerun `{LOCAL_CHAT_VERIFY_COMMAND}`"
             ),
         };
-        return SetupCheck::fail_generic(
+        return SetupCheck::fail(
             label,
             format!("{label} references {env_vars}, but they are not set"),
             remediation,
+            None,
         );
     }
 
     let effective = effective_config_value(&value).unwrap_or_else(|| value.clone());
     match validator(&effective) {
-        Ok(()) => SetupCheck::pass_generic(label, format!("{label} passed local validation")),
-        Err(err) => SetupCheck::validation_fail_code(
+        Ok(()) => SetupCheck::pass(label, format!("{label} passed local validation"), None),
+        Err(err) => SetupCheck::validation_fail(
             label,
             format!("{label} failed local validation: {err}"),
             setup_follow_up(provider_setup_follow_up(
@@ -1361,7 +1308,7 @@ where
                 "and correct the base URL",
                 format!("write a valid {label} into config"),
             )),
-            SetupCheckCode::LocalValidationFailed,
+            Some(SetupCheckCode::LocalValidationFailed),
         ),
     }
 }
@@ -1773,11 +1720,11 @@ mod tests {
 
     #[test]
     fn test_setup_check_code_constructors_preserve_kind_and_code() {
-        let requirement_skip = SetupCheck::skip_code(
+        let requirement_skip = SetupCheck::skip(
             "Req skip",
             "detail",
             Some("fix it".to_string()),
-            SetupCheckCode::AuthProfileMissing,
+            Some(SetupCheckCode::AuthProfileMissing),
         );
         assert_eq!(requirement_skip.status, SetupCheckStatus::Skip);
         assert_eq!(requirement_skip.kind, SetupCheckKind::Requirement);
@@ -1786,11 +1733,11 @@ mod tests {
             Some(SetupCheckCode::AuthProfileMissing)
         );
 
-        let validation_skip = SetupCheck::validation_skip_code(
+        let validation_skip = SetupCheck::validation_skip(
             "Val skip",
             "detail",
             Some("fix it".to_string()),
-            SetupCheckCode::AuthProfileStoreReadFailed,
+            Some(SetupCheckCode::AuthProfileStoreReadFailed),
         );
         assert_eq!(validation_skip.status, SetupCheckStatus::Skip);
         assert_eq!(validation_skip.kind, SetupCheckKind::Validation);
@@ -1799,11 +1746,11 @@ mod tests {
             Some(SetupCheckCode::AuthProfileStoreReadFailed)
         );
 
-        let validation_fail = SetupCheck::validation_fail_code(
+        let validation_fail = SetupCheck::validation_fail(
             "Val fail",
             "detail",
             "fix it",
-            SetupCheckCode::LocalValidationFailed,
+            Some(SetupCheckCode::LocalValidationFailed),
         );
         assert_eq!(validation_fail.status, SetupCheckStatus::Fail);
         assert_eq!(validation_fail.kind, SetupCheckKind::Validation);
@@ -2180,9 +2127,10 @@ mod tests {
             &cfg,
             temp.path(),
             SetupProvider::Vertex,
-            vec![SetupCheck::validation_pass_generic(
+            vec![SetupCheck::validation_pass(
                 "Vertex model access",
                 "validated access to `gemini-2.5-flash`",
+                None,
             )],
         );
 
@@ -2242,10 +2190,11 @@ mod tests {
             &cfg,
             temp.path(),
             SetupProvider::OpenAi,
-            vec![SetupCheck::validation_fail_generic(
+            vec![SetupCheck::validation_fail(
                 "Provider configuration validation",
                 "provider config failed local validation",
                 "fix the value and rerun setup",
+                None,
             )],
         );
 
@@ -2272,10 +2221,11 @@ mod tests {
             &cfg,
             temp.path(),
             SetupProvider::OpenAi,
-            vec![SetupCheck::validation_skip_generic(
+            vec![SetupCheck::validation_skip(
                 "Live provider validation",
                 "OpenAI credential validation was skipped",
                 Some("run `cara verify` after setup".to_string()),
+                None,
             )],
         );
 
@@ -2340,10 +2290,11 @@ mod tests {
 
     #[test]
     fn test_setup_check_serializes_with_control_facing_field_names() {
-        let check = SetupCheck::validation_skip_generic(
+        let check = SetupCheck::validation_skip(
             "Live provider validation",
             "setup completed without a live provider-side validation step",
             Some("run `cara verify --outcome local-chat`".to_string()),
+            None,
         );
 
         let value = serde_json::to_value(&check).expect("check should serialize");

--- a/src/server/control.rs
+++ b/src/server/control.rs
@@ -2626,26 +2626,27 @@ mod tests {
             status: onboarding::setup::SetupAssessmentStatus::Ready,
             summary: "loaded `Google Profile` (user@example.com)".to_string(),
             checks: vec![
-                onboarding::setup::SetupCheck::pass_code(
+                onboarding::setup::SetupCheck::pass(
                     "Gemini auth profile",
                     "opaque internal configured profile detail",
-                    onboarding::setup::SetupCheckCode::AuthProfileConfigured,
+                    Some(onboarding::setup::SetupCheckCode::AuthProfileConfigured),
                 ),
-                onboarding::setup::SetupCheck::validation_pass_code(
+                onboarding::setup::SetupCheck::validation_pass(
                     "Gemini account identity",
                     "opaque internal loaded profile detail",
-                    onboarding::setup::SetupCheckCode::AuthProfileLoaded,
+                    Some(onboarding::setup::SetupCheckCode::AuthProfileLoaded),
                 ),
-                onboarding::setup::SetupCheck::validation_fail_generic(
+                onboarding::setup::SetupCheck::validation_fail(
                     "Gemini credential validation",
                     "stored profile `google-123` future auth detail with `internal-profile-id`",
                     "Re-run setup for Gemini credential validation.",
+                    None,
                 ),
-                onboarding::setup::SetupCheck::validation_fail_code(
+                onboarding::setup::SetupCheck::validation_fail(
                     "Gemini base URL validation",
                     "opaque invalid URL detail with https://user:secret@proxy.example.com/",
                     "Write a valid Gemini base URL into config.",
-                    onboarding::setup::SetupCheckCode::LocalValidationFailed,
+                    Some(onboarding::setup::SetupCheckCode::LocalValidationFailed),
                 ),
             ],
             profile_name: Some("Google Profile".to_string()),
@@ -2689,10 +2690,11 @@ mod tests {
             auth_mode: Some(onboarding::setup::SetupAuthMode::OAuth),
             status: onboarding::setup::SetupAssessmentStatus::Invalid,
             summary: "opaque setup summary".to_string(),
-            checks: vec![onboarding::setup::SetupCheck::fail_generic(
+            checks: vec![onboarding::setup::SetupCheck::fail(
                 "Gemini auth profile",
                 "stored profile `google-123` future sensitive detail",
                 "Re-run setup for Gemini.",
+                None,
             )],
             profile_name: None,
             email: None,


### PR DESCRIPTION
## Summary

Consolidate 12 `SetupCheck` factory constructors into 6 by merging each `_generic`/`_code` pair. The `code` parameter becomes `Option<SetupCheckCode>` — `_generic` callers pass `None`, `_code` callers pass `Some(code)`.

Before: `pass_generic`, `pass_code`, `fail_generic`, `fail_code`, `skip_generic`, `skip_code`, `validation_pass_generic`, `validation_pass_code`, `validation_fail_generic`, `validation_fail_code`, `validation_skip_generic`, `validation_skip_code`

After: `pass`, `fail`, `skip`, `validation_pass`, `validation_fail`, `validation_skip`

55 call sites updated across `setup.rs`, `bedrock.rs`, `cli/mod.rs`, and `control.rs`. Net -38 lines.

Issue #201 (slice 2 of 3: setup-check factory cleanup)

## Test plan

- [ ] All 508 affected tests pass
- [ ] Zero compilation errors across all targets
- [ ] Business rules preserved: Pass=no remediation, Fail=required remediation, Skip=optional
