### PR TITLE
refactor: unify startup thread spawn errors

### DIFF
--- a/src/channels/activity.rs
+++ b/src/channels/activity.rs
@@ -48,9 +48,8 @@ use crate::plugins::{
 use crate::runtime_bridge::run_sync_blocking_send;
 use crate::server::ws::WsServerState;
 use crate::tasks::{TaskBlockedReason, TaskExecutionOutcome, TaskExecutor, TaskQueue};
-use crate::thread_util::{
-    spawn_startup_named_thread_with_spawner, NamedThreadSpawner, StartupThreadSpawnError,
-};
+use crate::thread_util::{spawn_startup_named_thread_with_spawner, NamedThreadSpawner};
+use crate::StartupThreadSpawnError;
 
 const DEFAULT_TYPING_INTERVAL_SECONDS: u32 = 3;
 const MAX_TYPING_REFRESH_BACKOFF_SECONDS: u64 = 30;
@@ -2009,6 +2008,7 @@ fn panic_payload_to_string(payload: Box<dyn Any + Send + 'static>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
     use std::fs;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -2850,7 +2850,13 @@ mod tests {
         };
 
         let ActivityStartupError::ThreadSpawn { source: err } = err;
-        assert_eq!(err.source.kind(), io::ErrorKind::Other);
+        let io_source = err
+            .source()
+            .expect("thread spawn error should preserve the original io::Error source");
+        let io_error = io_source
+            .downcast_ref::<io::Error>()
+            .expect("thread spawn error source should remain an io::Error");
+        assert_eq!(io_error.kind(), io::ErrorKind::Other);
         assert!(err.to_string().contains("failed to spawn startup thread"));
     }
 
@@ -2859,8 +2865,15 @@ mod tests {
         let err =
             StartupThreadSpawnError::new(STOP_TYPING_THREAD_NAME, io::Error::from_raw_os_error(11));
 
-        assert_eq!(err.thread_name, STOP_TYPING_THREAD_NAME);
-        assert_eq!(err.source.raw_os_error(), Some(11));
+        let io_source = err
+            .source()
+            .expect("thread spawn error should preserve the original io::Error source");
+        let io_error = io_source
+            .downcast_ref::<io::Error>()
+            .expect("thread spawn error source should remain an io::Error");
+
+        assert_eq!(err.thread_name(), STOP_TYPING_THREAD_NAME);
+        assert_eq!(io_error.raw_os_error(), Some(11));
     }
 
     #[test]

--- a/src/channels/activity.rs
+++ b/src/channels/activity.rs
@@ -23,6 +23,7 @@
 
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
+#[cfg(test)]
 use std::io;
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
@@ -35,6 +36,7 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use thiserror::Error;
 use tokio::runtime::{Handle, RuntimeFlavor};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -46,7 +48,9 @@ use crate::plugins::{
 use crate::runtime_bridge::run_sync_blocking_send;
 use crate::server::ws::WsServerState;
 use crate::tasks::{TaskBlockedReason, TaskExecutionOutcome, TaskExecutor, TaskQueue};
-use crate::thread_util::{spawn_named_thread, NamedThreadSpawner};
+use crate::thread_util::{
+    spawn_startup_named_thread_with_spawner, NamedThreadSpawner, StartupThreadSpawnError,
+};
 
 const DEFAULT_TYPING_INTERVAL_SECONDS: u32 = 3;
 const MAX_TYPING_REFRESH_BACKOFF_SECONDS: u64 = 30;
@@ -111,36 +115,19 @@ const STOP_STATE_TASK_RUNNING: u8 = 3;
 const STOP_STATE_FALLBACK_RESERVED: u8 = 4;
 const STOP_STATE_COMPLETED: u8 = 5;
 
-#[derive(Debug)]
-struct ThreadSpawnContext {
-    thread_name: &'static str,
-    source: io::Error,
+#[derive(Debug, Error)]
+pub enum ActivityStartupError {
+    #[error("{source}")]
+    ThreadSpawn {
+        #[source]
+        source: StartupThreadSpawnError,
+    },
 }
 
-impl std::fmt::Display for ThreadSpawnContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "failed to spawn background thread '{}': {}",
-            self.thread_name, self.source
-        )
+impl From<StartupThreadSpawnError> for ActivityStartupError {
+    fn from(source: StartupThreadSpawnError) -> Self {
+        Self::ThreadSpawn { source }
     }
-}
-
-impl std::error::Error for ThreadSpawnContext {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.source)
-    }
-}
-
-fn stop_typing_thread_spawn_error(err: io::Error) -> io::Error {
-    io::Error::new(
-        err.kind(),
-        ThreadSpawnContext {
-            thread_name: STOP_TYPING_THREAD_NAME,
-            source: err,
-        },
-    )
 }
 
 struct UnsupportedActivityWarningRegistry {
@@ -458,7 +445,7 @@ impl ActivityService {
         Self::try_new().expect("failed to initialize in-memory activity service startup helpers")
     }
 
-    pub fn try_new() -> io::Result<Self> {
+    pub fn try_new() -> Result<Self, ActivityStartupError> {
         Self::try_with_read_receipt_queue(Arc::new(TaskQueue::with_capacity_limit(
             None,
             Some(READ_RECEIPT_OWNERSHIP_HIGH_WATERMARK),
@@ -470,14 +457,16 @@ impl ActivityService {
             .expect("failed to initialize persistent activity service startup helpers")
     }
 
-    pub fn try_new_persistent(state_dir: PathBuf) -> io::Result<Self> {
+    pub fn try_new_persistent(state_dir: PathBuf) -> Result<Self, ActivityStartupError> {
         Self::try_with_read_receipt_queue(Arc::new(TaskQueue::with_capacity_limit(
             Some(state_dir.join("activity").join("read_receipts.json")),
             Some(READ_RECEIPT_OWNERSHIP_HIGH_WATERMARK),
         )))
     }
 
-    fn try_with_read_receipt_queue(read_receipt_queue: Arc<TaskQueue>) -> io::Result<Self> {
+    fn try_with_read_receipt_queue(
+        read_receipt_queue: Arc<TaskQueue>,
+    ) -> Result<Self, ActivityStartupError> {
         Ok(Self {
             dispatcher: Arc::new(ActivityDispatcher::try_new()?),
             read_receipt_queue,
@@ -936,7 +925,7 @@ impl ActivityDispatcher {
         Self::try_new().expect("failed to initialize activity dispatcher startup thread")
     }
 
-    pub fn try_new() -> io::Result<Self> {
+    pub fn try_new() -> Result<Self, ActivityStartupError> {
         Self::try_with_options(ACTIVITY_DISPATCH_BACKLOG_WARNING_THRESHOLD)
     }
 
@@ -950,18 +939,19 @@ impl ActivityDispatcher {
     pub(crate) fn try_with_options_and_spawner_for_test(
         backlog_warning_threshold: usize,
         spawner: NamedThreadSpawner,
-    ) -> io::Result<Self> {
+    ) -> Result<Self, ActivityStartupError> {
         Self::try_with_options_and_spawner(backlog_warning_threshold, spawner)
     }
 
-    fn try_with_options(backlog_warning_threshold: usize) -> io::Result<Self> {
-        Self::try_with_options_and_spawner(backlog_warning_threshold, spawn_named_thread)
+    fn try_with_options(backlog_warning_threshold: usize) -> Result<Self, ActivityStartupError> {
+        let spawn_default: NamedThreadSpawner = crate::thread_util::spawn_named_thread;
+        Self::try_with_options_and_spawner(backlog_warning_threshold, spawn_default)
     }
 
     fn try_with_options_and_spawner(
         backlog_warning_threshold: usize,
         spawner: NamedThreadSpawner,
-    ) -> io::Result<Self> {
+    ) -> Result<Self, ActivityStartupError> {
         let stop_typing_backlog = Arc::new(AtomicUsize::new(0));
         let shutting_down = Arc::new(AtomicBool::new(false));
         let shutdown_deadline = Arc::new(Mutex::new(None));
@@ -976,8 +966,8 @@ impl ActivityDispatcher {
         let stop_typing_backlog_worker = stop_typing_backlog.clone();
         let stop_typing_shutdown = shutting_down.clone();
         let stop_typing_deadline = shutdown_deadline.clone();
-        let stop_typing_worker = spawner(
-            thread::Builder::new().name(STOP_TYPING_THREAD_NAME.to_string()),
+        let stop_typing_worker = spawn_startup_named_thread_with_spawner(
+            STOP_TYPING_THREAD_NAME,
             Box::new(move || {
                 // Stop-typing is cleanup, not optional side work. Keep this
                 // path non-lossy, but coalesce requests per channel/recipient
@@ -1092,8 +1082,8 @@ impl ActivityDispatcher {
                     }
                 }
             }),
-        )
-        .map_err(stop_typing_thread_spawn_error)?;
+            spawner,
+        )?;
 
         Ok(Self {
             stop_typing_tx,
@@ -2859,23 +2849,18 @@ mod tests {
             Err(err) => err,
         };
 
-        assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert!(err
-            .to_string()
-            .contains("failed to spawn background thread"));
+        let ActivityStartupError::ThreadSpawn { source: err } = err;
+        assert_eq!(err.source.kind(), io::ErrorKind::Other);
+        assert!(err.to_string().contains("failed to spawn startup thread"));
     }
 
     #[test]
     fn test_stop_typing_thread_spawn_error_preserves_source_error() {
-        let err = stop_typing_thread_spawn_error(io::Error::from_raw_os_error(11));
-        let context = err
-            .get_ref()
-            .and_then(|source| source.downcast_ref::<ThreadSpawnContext>())
-            .expect("thread spawn context should be preserved as the io::Error source");
+        let err =
+            StartupThreadSpawnError::new(STOP_TYPING_THREAD_NAME, io::Error::from_raw_os_error(11));
 
-        assert_eq!(err.kind(), context.source.kind());
-        assert_eq!(context.thread_name, STOP_TYPING_THREAD_NAME);
-        assert_eq!(context.source.raw_os_error(), Some(11));
+        assert_eq!(err.thread_name, STOP_TYPING_THREAD_NAME);
+        assert_eq!(err.source.raw_os_error(), Some(11));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,4 @@ pub(crate) mod time;
 pub mod tls;
 pub mod update;
 pub mod usage;
+pub use crate::thread_util::StartupThreadSpawnError;

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -20,6 +20,7 @@
 //! - Execution timeout (30s per call)
 
 use std::collections::HashMap;
+#[cfg(test)]
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
@@ -31,7 +32,9 @@ use wasmtime::component::{Component, ComponentType, Lift, Linker, Lower};
 use wasmtime::{Config, Engine, ResourceLimiter, Store, StoreContextMut};
 
 use crate::credentials::{CredentialBackend, CredentialStore};
-use crate::thread_util::{spawn_named_thread, NamedThreadSpawner};
+use crate::thread_util::{spawn_startup_named_thread, StartupThreadSpawnError};
+#[cfg(test)]
+use crate::thread_util::{spawn_startup_named_thread_with_spawner, NamedThreadSpawner};
 
 use super::bindings::{
     BindingError, ChannelCapabilities, ChannelInfo, ChannelPluginInstance, ChatType,
@@ -83,8 +86,23 @@ struct EpochTicker {
 }
 
 impl EpochTicker {
-    fn start(engine: Engine, interval: Duration) -> io::Result<Self> {
-        Self::start_with_spawner(engine, interval, spawn_named_thread)
+    fn start(engine: Engine, interval: Duration) -> Result<Self, StartupThreadSpawnError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_clone = stop.clone();
+        let handle = spawn_startup_named_thread(
+            EPOCH_TICKER_THREAD_NAME,
+            Box::new(move || {
+                while !stop_clone.load(Ordering::SeqCst) {
+                    std::thread::sleep(interval);
+                    engine.increment_epoch();
+                }
+            }),
+        )?;
+
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
     }
 
     #[cfg(test)]
@@ -92,25 +110,27 @@ impl EpochTicker {
         engine: Engine,
         interval: Duration,
         spawner: NamedThreadSpawner,
-    ) -> io::Result<Self> {
+    ) -> Result<Self, StartupThreadSpawnError> {
         Self::start_with_spawner(engine, interval, spawner)
     }
 
+    #[cfg(test)]
     fn start_with_spawner(
         engine: Engine,
         interval: Duration,
         spawner: NamedThreadSpawner,
-    ) -> io::Result<Self> {
+    ) -> Result<Self, StartupThreadSpawnError> {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = stop.clone();
-        let handle = spawner(
-            std::thread::Builder::new().name(EPOCH_TICKER_THREAD_NAME.to_string()),
+        let handle = spawn_startup_named_thread_with_spawner(
+            EPOCH_TICKER_THREAD_NAME,
             Box::new(move || {
                 while !stop_clone.load(Ordering::SeqCst) {
                     std::thread::sleep(interval);
                     engine.increment_epoch();
                 }
             }),
+            spawner,
         )?;
 
         Ok(Self {
@@ -600,12 +620,17 @@ pub enum RuntimeError {
         capabilities: Vec<String>,
     },
 
-    #[error("Failed to spawn startup thread '{thread_name}': {source}")]
+    #[error("{source}")]
     ThreadSpawn {
-        thread_name: String,
         #[source]
-        source: io::Error,
+        source: StartupThreadSpawnError,
     },
+}
+
+impl From<StartupThreadSpawnError> for RuntimeError {
+    fn from(source: StartupThreadSpawnError) -> Self {
+        Self::ThreadSpawn { source }
+    }
 }
 
 /// State held in each plugin's wasmtime store
@@ -1080,12 +1105,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
             ssrf_config,
             sandbox_config,
             permission_config,
-            |engine, interval| {
-                EpochTicker::start(engine, interval).map_err(|source| RuntimeError::ThreadSpawn {
-                    thread_name: EPOCH_TICKER_THREAD_NAME.to_string(),
-                    source,
-                })
-            },
+            |engine, interval| EpochTicker::start(engine, interval).map_err(RuntimeError::from),
         )
     }
 
@@ -1818,6 +1838,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> HookPluginInstance for HookAd
 mod tests {
     use super::*;
     use crate::credentials::MockCredentialBackend;
+    use std::error::Error as _;
     use tempfile::tempdir;
 
     async fn create_test_runtime() -> PluginRuntime<MockCredentialBackend> {
@@ -1856,7 +1877,8 @@ mod tests {
             Err(err) => err,
         };
 
-        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.source.kind(), io::ErrorKind::Other);
+        assert_eq!(err.thread_name, EPOCH_TICKER_THREAD_NAME);
         assert!(err
             .to_string()
             .contains("simulated epoch ticker thread exhaustion"));
@@ -1891,8 +1913,10 @@ mod tests {
             PermissionConfig::default(),
             |_engine, _interval| {
                 Err(RuntimeError::ThreadSpawn {
-                    thread_name: EPOCH_TICKER_THREAD_NAME.to_string(),
-                    source: io::Error::other("simulated epoch ticker thread exhaustion"),
+                    source: StartupThreadSpawnError::new(
+                        EPOCH_TICKER_THREAD_NAME,
+                        io::Error::other("simulated epoch ticker thread exhaustion"),
+                    ),
                 })
             },
         ) {
@@ -1902,9 +1926,60 @@ mod tests {
 
         assert!(matches!(
             err,
-            RuntimeError::ThreadSpawn { ref thread_name, .. }
-                if thread_name == EPOCH_TICKER_THREAD_NAME
+            RuntimeError::ThreadSpawn { ref source }
+                if source.thread_name == EPOCH_TICKER_THREAD_NAME
         ));
+    }
+
+    #[tokio::test]
+    async fn test_runtime_creation_preserves_epoch_ticker_spawn_error_chain() {
+        let temp_dir = tempdir().unwrap();
+        let plugins_dir = temp_dir.path().join("plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+
+        let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
+        let backend = MockCredentialBackend::new(true);
+        let credential_store = Arc::new(
+            CredentialStore::new(backend, temp_dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
+            loader,
+            credential_store,
+            Arc::new(RateLimiterRegistry::new()),
+            SsrfConfig::default(),
+            crate::plugins::sandbox::SandboxConfig::default(),
+            PermissionConfig::default(),
+            |_engine, _interval| {
+                Err(RuntimeError::ThreadSpawn {
+                    source: StartupThreadSpawnError::new(
+                        EPOCH_TICKER_THREAD_NAME,
+                        io::Error::from_raw_os_error(11),
+                    ),
+                })
+            },
+        ) {
+            Ok(_) => panic!("runtime startup should preserve epoch ticker spawn error chain"),
+            Err(err) => err,
+        };
+
+        let runtime_source = err
+            .source()
+            .expect("runtime error should expose startup thread spawn source");
+        let spawn_error = runtime_source
+            .downcast_ref::<StartupThreadSpawnError>()
+            .expect("startup thread spawn error should remain in the source chain");
+        let io_source = spawn_error
+            .source()
+            .expect("startup thread spawn error should preserve the original io::Error source");
+        let io_error = io_source
+            .downcast_ref::<io::Error>()
+            .expect("original io::Error should remain at the end of the source chain");
+
+        assert_eq!(spawn_error.thread_name, EPOCH_TICKER_THREAD_NAME);
+        assert_eq!(io_error.raw_os_error(), Some(11));
     }
 
     #[tokio::test]

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -32,9 +32,9 @@ use wasmtime::component::{Component, ComponentType, Lift, Linker, Lower};
 use wasmtime::{Config, Engine, ResourceLimiter, Store, StoreContextMut};
 
 use crate::credentials::{CredentialBackend, CredentialStore};
-use crate::thread_util::spawn_startup_named_thread;
-#[cfg(test)]
-use crate::thread_util::{spawn_startup_named_thread_with_spawner, NamedThreadSpawner};
+use crate::thread_util::{
+    spawn_named_thread, spawn_startup_named_thread_with_spawner, NamedThreadSpawner,
+};
 
 use super::bindings::{
     BindingError, ChannelCapabilities, ChannelInfo, ChannelPluginInstance, ChatType,
@@ -101,28 +101,9 @@ impl EpochTicker {
     }
 
     fn start(engine: Engine, interval: Duration) -> Result<Self, StartupThreadSpawnError> {
-        let stop = Arc::new(AtomicBool::new(false));
-        let handle = spawn_startup_named_thread(
-            EPOCH_TICKER_THREAD_NAME,
-            Self::routine(engine, interval, Arc::clone(&stop)),
-        )?;
-
-        Ok(Self {
-            stop,
-            handle: Some(handle),
-        })
+        Self::start_with_spawner(engine, interval, spawn_named_thread)
     }
 
-    #[cfg(test)]
-    fn start_with_spawner_for_test(
-        engine: Engine,
-        interval: Duration,
-        spawner: NamedThreadSpawner,
-    ) -> Result<Self, StartupThreadSpawnError> {
-        Self::start_with_spawner(engine, interval, spawner)
-    }
-
-    #[cfg(test)]
     fn start_with_spawner(
         engine: Engine,
         interval: Duration,
@@ -1870,7 +1851,7 @@ mod tests {
         }
 
         let engine = Engine::default();
-        let err = match EpochTicker::start_with_spawner_for_test(
+        let err = match EpochTicker::start_with_spawner(
             engine,
             DEFAULT_EPOCH_TICK_INTERVAL,
             fail_spawner,

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -32,7 +32,7 @@ use wasmtime::component::{Component, ComponentType, Lift, Linker, Lower};
 use wasmtime::{Config, Engine, ResourceLimiter, Store, StoreContextMut};
 
 use crate::credentials::{CredentialBackend, CredentialStore};
-use crate::thread_util::{spawn_startup_named_thread, StartupThreadSpawnError};
+use crate::thread_util::spawn_startup_named_thread;
 #[cfg(test)]
 use crate::thread_util::{spawn_startup_named_thread_with_spawner, NamedThreadSpawner};
 
@@ -49,6 +49,7 @@ use super::permissions::{
     compute_effective_permissions, validate_declared_permissions, PermissionConfig,
     PermissionEnforcer,
 };
+use crate::StartupThreadSpawnError;
 
 /// Maximum memory per plugin instance (64MB)
 pub const MAX_PLUGIN_MEMORY_BYTES: u64 = 64 * 1024 * 1024;
@@ -86,17 +87,24 @@ struct EpochTicker {
 }
 
 impl EpochTicker {
+    fn routine(
+        engine: Engine,
+        interval: Duration,
+        stop: Arc<AtomicBool>,
+    ) -> crate::thread_util::NamedThreadRoutine {
+        Box::new(move || {
+            while !stop.load(Ordering::SeqCst) {
+                std::thread::sleep(interval);
+                engine.increment_epoch();
+            }
+        })
+    }
+
     fn start(engine: Engine, interval: Duration) -> Result<Self, StartupThreadSpawnError> {
         let stop = Arc::new(AtomicBool::new(false));
-        let stop_clone = stop.clone();
         let handle = spawn_startup_named_thread(
             EPOCH_TICKER_THREAD_NAME,
-            Box::new(move || {
-                while !stop_clone.load(Ordering::SeqCst) {
-                    std::thread::sleep(interval);
-                    engine.increment_epoch();
-                }
-            }),
+            Self::routine(engine, interval, Arc::clone(&stop)),
         )?;
 
         Ok(Self {
@@ -121,15 +129,9 @@ impl EpochTicker {
         spawner: NamedThreadSpawner,
     ) -> Result<Self, StartupThreadSpawnError> {
         let stop = Arc::new(AtomicBool::new(false));
-        let stop_clone = stop.clone();
         let handle = spawn_startup_named_thread_with_spawner(
             EPOCH_TICKER_THREAD_NAME,
-            Box::new(move || {
-                while !stop_clone.load(Ordering::SeqCst) {
-                    std::thread::sleep(interval);
-                    engine.increment_epoch();
-                }
-            }),
+            Self::routine(engine, interval, Arc::clone(&stop)),
             spawner,
         )?;
 
@@ -1877,8 +1879,15 @@ mod tests {
             Err(err) => err,
         };
 
-        assert_eq!(err.source.kind(), io::ErrorKind::Other);
-        assert_eq!(err.thread_name, EPOCH_TICKER_THREAD_NAME);
+        let io_source = err
+            .source()
+            .expect("thread spawn error should preserve the original io::Error source");
+        let io_error = io_source
+            .downcast_ref::<io::Error>()
+            .expect("thread spawn error source should remain an io::Error");
+
+        assert_eq!(io_error.kind(), io::ErrorKind::Other);
+        assert_eq!(err.thread_name(), EPOCH_TICKER_THREAD_NAME);
         assert!(err
             .to_string()
             .contains("simulated epoch ticker thread exhaustion"));
@@ -1927,7 +1936,7 @@ mod tests {
         assert!(matches!(
             err,
             RuntimeError::ThreadSpawn { ref source }
-                if source.thread_name == EPOCH_TICKER_THREAD_NAME
+                if source.thread_name() == EPOCH_TICKER_THREAD_NAME
         ));
     }
 
@@ -1978,7 +1987,7 @@ mod tests {
             .downcast_ref::<io::Error>()
             .expect("original io::Error should remain at the end of the source chain");
 
-        assert_eq!(spawn_error.thread_name, EPOCH_TICKER_THREAD_NAME);
+        assert_eq!(spawn_error.thread_name(), EPOCH_TICKER_THREAD_NAME);
         assert_eq!(io_error.raw_os_error(), Some(11));
     }
 

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -806,8 +806,10 @@ mod tests {
     fn test_plugin_runtime_thread_spawn_errors_are_fatal() {
         assert!(plugin_runtime_init_error_is_fatal(
             &RuntimeError::ThreadSpawn {
-                thread_name: "plugin-epoch-ticker".to_string(),
-                source: std::io::Error::other("simulated thread exhaustion"),
+                source: crate::thread_util::StartupThreadSpawnError::new(
+                    "plugin-epoch-ticker",
+                    std::io::Error::other("simulated thread exhaustion"),
+                ),
             }
         ));
         assert!(!plugin_runtime_init_error_is_fatal(

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -806,7 +806,7 @@ mod tests {
     fn test_plugin_runtime_thread_spawn_errors_are_fatal() {
         assert!(plugin_runtime_init_error_is_fatal(
             &RuntimeError::ThreadSpawn {
-                source: crate::thread_util::StartupThreadSpawnError::new(
+                source: crate::StartupThreadSpawnError::new(
                     "plugin-epoch-ticker",
                     std::io::Error::other("simulated thread exhaustion"),
                 ),

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -520,12 +520,6 @@ impl WsServerState {
         })
     }
 
-    fn map_activity_service_startup_error(
-        err: channels::activity::ActivityStartupError,
-    ) -> WsConfigError {
-        WsConfigError::ActivityStartup(err)
-    }
-
     fn build_in_memory_with_activity_service_factory<F>(
         config: WsServerConfig,
         activity_service_factory: F,
@@ -577,9 +571,7 @@ impl WsServerState {
             llm_provider: parking_lot::RwLock::new(None),
             tools_registry: None,
             plugin_registry: None,
-            activity_service: Arc::new(
-                activity_service_factory().map_err(Self::map_activity_service_startup_error)?,
-            ),
+            activity_service: Arc::new(activity_service_factory()?),
             plugin_runtime: None,
             plugin_activation_report: None,
             connection_tracker,
@@ -622,8 +614,7 @@ impl WsServerState {
             config.max_ws_per_ip.unwrap_or(limits::DEFAULT_MAX_PER_IP),
         );
         let activity_state_dir = state_dir.clone();
-        let activity_service = activity_service_factory(activity_state_dir)
-            .map_err(Self::map_activity_service_startup_error)?;
+        let activity_service = activity_service_factory(activity_state_dir)?;
         Ok(Self {
             config,
             start_time: Instant::now(),
@@ -1195,7 +1186,7 @@ pub enum WsConfigError {
     #[error(transparent)]
     Devices(#[from] devices::DevicePairingError),
     #[error("failed to initialize activity service: {0}")]
-    ActivityStartup(#[source] channels::activity::ActivityStartupError),
+    ActivityStartup(#[from] channels::activity::ActivityStartupError),
     #[error("{0}")]
     Runtime(String),
 }

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -15,7 +15,6 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -521,8 +520,10 @@ impl WsServerState {
         })
     }
 
-    fn map_activity_service_startup_error(err: io::Error) -> WsConfigError {
-        WsConfigError::Runtime(format!("failed to initialize activity service: {err}"))
+    fn map_activity_service_startup_error(
+        err: channels::activity::ActivityStartupError,
+    ) -> WsConfigError {
+        WsConfigError::ActivityStartup(err)
     }
 
     fn build_in_memory_with_activity_service_factory<F>(
@@ -530,7 +531,10 @@ impl WsServerState {
         activity_service_factory: F,
     ) -> Result<Self, WsConfigError>
     where
-        F: FnOnce() -> io::Result<channels::activity::ActivityService>,
+        F: FnOnce() -> Result<
+            channels::activity::ActivityService,
+            channels::activity::ActivityStartupError,
+        >,
     {
         let connection_tracker = limits::ConnectionTracker::with_limits(
             config
@@ -588,7 +592,10 @@ impl WsServerState {
         activity_service_factory: F,
     ) -> Result<Self, WsConfigError>
     where
-        F: FnOnce() -> io::Result<channels::activity::ActivityService>,
+        F: FnOnce() -> Result<
+            channels::activity::ActivityService,
+            channels::activity::ActivityStartupError,
+        >,
     {
         Self::build_in_memory_with_activity_service_factory(config, activity_service_factory)
     }
@@ -599,7 +606,12 @@ impl WsServerState {
         activity_service_factory: F,
     ) -> Result<Self, WsConfigError>
     where
-        F: FnOnce(PathBuf) -> io::Result<channels::activity::ActivityService>,
+        F: FnOnce(
+            PathBuf,
+        ) -> Result<
+            channels::activity::ActivityService,
+            channels::activity::ActivityStartupError,
+        >,
     {
         let node_pairing = nodes::create_registry(state_dir.clone())?;
         let device_registry = devices::create_registry(state_dir.clone())?;
@@ -678,7 +690,12 @@ impl WsServerState {
         activity_service_factory: F,
     ) -> Result<Self, WsConfigError>
     where
-        F: FnOnce(PathBuf) -> io::Result<channels::activity::ActivityService>,
+        F: FnOnce(
+            PathBuf,
+        ) -> Result<
+            channels::activity::ActivityService,
+            channels::activity::ActivityStartupError,
+        >,
     {
         Self::build_persistent_unloaded_with_activity_service_factory(
             config,
@@ -1177,6 +1194,8 @@ pub enum WsConfigError {
     Nodes(#[from] nodes::NodePairingError),
     #[error(transparent)]
     Devices(#[from] devices::DevicePairingError),
+    #[error("failed to initialize activity service: {0}")]
+    ActivityStartup(#[source] channels::activity::ActivityStartupError),
     #[error("{0}")]
     Runtime(String),
 }

--- a/src/server/ws/tests.rs
+++ b/src/server/ws/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::error::Error as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -8,19 +9,23 @@ fn test_try_new_reports_activity_service_startup_error() {
     let err = WsServerState::try_new_with_activity_service_factory_for_test(
         WsServerConfig::default(),
         || {
-            Err(std::io::Error::other(
-                "simulated activity thread exhaustion",
-            ))
+            Err(channels::activity::ActivityStartupError::ThreadSpawn {
+                source: crate::thread_util::StartupThreadSpawnError::new(
+                    "activity-test-thread",
+                    std::io::Error::other("simulated activity thread exhaustion"),
+                ),
+            })
         },
     )
     .expect_err("startup should report activity service initialization failure");
 
     match err {
-        WsConfigError::Runtime(message) => {
-            assert!(message.contains("failed to initialize activity service"));
-            assert!(message.contains("simulated activity thread exhaustion"));
+        WsConfigError::ActivityStartup(error) => {
+            assert!(error
+                .to_string()
+                .contains("simulated activity thread exhaustion"));
         }
-        other => panic!("expected runtime startup error, got {other:?}"),
+        other => panic!("expected typed activity startup error, got {other:?}"),
     }
 }
 
@@ -31,20 +36,62 @@ fn test_try_new_persistent_unloaded_reports_activity_service_startup_error() {
         WsServerConfig::default(),
         temp.path().to_path_buf(),
         |_state_dir| {
-            Err(std::io::Error::other(
-                "simulated persistent activity thread exhaustion",
-            ))
+            Err(channels::activity::ActivityStartupError::ThreadSpawn {
+                source: crate::thread_util::StartupThreadSpawnError::new(
+                    "activity-persistent-test-thread",
+                    std::io::Error::other("simulated persistent activity thread exhaustion"),
+                ),
+            })
         },
     )
     .expect_err("persistent startup should report activity service initialization failure");
 
     match err {
-        WsConfigError::Runtime(message) => {
-            assert!(message.contains("failed to initialize activity service"));
-            assert!(message.contains("simulated persistent activity thread exhaustion"));
+        WsConfigError::ActivityStartup(error) => {
+            assert!(error
+                .to_string()
+                .contains("simulated persistent activity thread exhaustion"));
         }
-        other => panic!("expected runtime startup error, got {other:?}"),
+        other => panic!("expected typed activity startup error, got {other:?}"),
     }
+}
+
+#[test]
+fn test_try_new_preserves_activity_startup_error_chain() {
+    let err = WsServerState::try_new_with_activity_service_factory_for_test(
+        WsServerConfig::default(),
+        || {
+            Err(channels::activity::ActivityStartupError::ThreadSpawn {
+                source: crate::thread_util::StartupThreadSpawnError::new(
+                    "activity-chain-test-thread",
+                    std::io::Error::from_raw_os_error(11),
+                ),
+            })
+        },
+    )
+    .expect_err("startup should preserve activity service error chain");
+
+    let activity_source = err
+        .source()
+        .expect("ws startup error should expose activity startup source");
+    let activity_error = activity_source
+        .downcast_ref::<channels::activity::ActivityStartupError>()
+        .expect("activity startup error should remain in the source chain");
+    let spawn_source = activity_error
+        .source()
+        .expect("activity startup error should expose startup thread spawn source");
+    let spawn_error = spawn_source
+        .downcast_ref::<crate::thread_util::StartupThreadSpawnError>()
+        .expect("startup thread spawn error should remain in the source chain");
+    let io_source = spawn_error
+        .source()
+        .expect("startup thread spawn error should preserve the original io::Error source");
+    let io_error = io_source
+        .downcast_ref::<std::io::Error>()
+        .expect("original io::Error should remain at the end of the source chain");
+
+    assert_eq!(spawn_error.thread_name, "activity-chain-test-thread");
+    assert_eq!(io_error.raw_os_error(), Some(11));
 }
 
 #[test]
@@ -65,9 +112,14 @@ fn test_try_new_persistent_unloaded_builds_registries_before_activity_service() 
         invalid_state_dir,
         move |_state_dir| {
             activity_factory_called_for_closure.store(true, Ordering::SeqCst);
-            Err(std::io::Error::other(
-                "activity service factory should not run before registry setup",
-            ))
+            Err(channels::activity::ActivityStartupError::ThreadSpawn {
+                source: crate::thread_util::StartupThreadSpawnError::new(
+                    "activity-ordering-test-thread",
+                    std::io::Error::other(
+                        "activity service factory should not run before registry setup",
+                    ),
+                ),
+            })
         },
     )
     .expect_err("persistent startup should fail on registry initialization first");

--- a/src/server/ws/tests.rs
+++ b/src/server/ws/tests.rs
@@ -10,7 +10,7 @@ fn test_try_new_reports_activity_service_startup_error() {
         WsServerConfig::default(),
         || {
             Err(channels::activity::ActivityStartupError::ThreadSpawn {
-                source: crate::thread_util::StartupThreadSpawnError::new(
+                source: crate::StartupThreadSpawnError::new(
                     "activity-test-thread",
                     std::io::Error::other("simulated activity thread exhaustion"),
                 ),
@@ -37,7 +37,7 @@ fn test_try_new_persistent_unloaded_reports_activity_service_startup_error() {
         temp.path().to_path_buf(),
         |_state_dir| {
             Err(channels::activity::ActivityStartupError::ThreadSpawn {
-                source: crate::thread_util::StartupThreadSpawnError::new(
+                source: crate::StartupThreadSpawnError::new(
                     "activity-persistent-test-thread",
                     std::io::Error::other("simulated persistent activity thread exhaustion"),
                 ),
@@ -62,7 +62,7 @@ fn test_try_new_preserves_activity_startup_error_chain() {
         WsServerConfig::default(),
         || {
             Err(channels::activity::ActivityStartupError::ThreadSpawn {
-                source: crate::thread_util::StartupThreadSpawnError::new(
+                source: crate::StartupThreadSpawnError::new(
                     "activity-chain-test-thread",
                     std::io::Error::from_raw_os_error(11),
                 ),
@@ -81,7 +81,7 @@ fn test_try_new_preserves_activity_startup_error_chain() {
         .source()
         .expect("activity startup error should expose startup thread spawn source");
     let spawn_error = spawn_source
-        .downcast_ref::<crate::thread_util::StartupThreadSpawnError>()
+        .downcast_ref::<crate::StartupThreadSpawnError>()
         .expect("startup thread spawn error should remain in the source chain");
     let io_source = spawn_error
         .source()
@@ -90,7 +90,7 @@ fn test_try_new_preserves_activity_startup_error_chain() {
         .downcast_ref::<std::io::Error>()
         .expect("original io::Error should remain at the end of the source chain");
 
-    assert_eq!(spawn_error.thread_name, "activity-chain-test-thread");
+    assert_eq!(spawn_error.thread_name(), "activity-chain-test-thread");
     assert_eq!(io_error.raw_os_error(), Some(11));
 }
 
@@ -113,7 +113,7 @@ fn test_try_new_persistent_unloaded_builds_registries_before_activity_service() 
         move |_state_dir| {
             activity_factory_called_for_closure.store(true, Ordering::SeqCst);
             Err(channels::activity::ActivityStartupError::ThreadSpawn {
-                source: crate::thread_util::StartupThreadSpawnError::new(
+                source: crate::StartupThreadSpawnError::new(
                     "activity-ordering-test-thread",
                     std::io::Error::other(
                         "activity service factory should not run before registry setup",

--- a/src/thread_util.rs
+++ b/src/thread_util.rs
@@ -17,9 +17,9 @@ pub(crate) fn spawn_named_thread(
 #[derive(Debug, Error)]
 #[error("failed to spawn startup thread '{thread_name}': {source}")]
 pub struct StartupThreadSpawnError {
-    pub(crate) thread_name: &'static str,
+    thread_name: &'static str,
     #[source]
-    pub(crate) source: io::Error,
+    source: io::Error,
 }
 
 impl StartupThreadSpawnError {
@@ -28,6 +28,10 @@ impl StartupThreadSpawnError {
             thread_name,
             source,
         }
+    }
+
+    pub fn thread_name(&self) -> &'static str {
+        self.thread_name
     }
 }
 

--- a/src/thread_util.rs
+++ b/src/thread_util.rs
@@ -1,6 +1,8 @@
 use std::io;
 use std::thread;
 
+use thiserror::Error;
+
 pub(crate) type NamedThreadRoutine = Box<dyn FnOnce() + Send + 'static>;
 pub(crate) type NamedThreadSpawner =
     fn(thread::Builder, NamedThreadRoutine) -> io::Result<thread::JoinHandle<()>>;
@@ -10,4 +12,40 @@ pub(crate) fn spawn_named_thread(
     routine: NamedThreadRoutine,
 ) -> io::Result<thread::JoinHandle<()>> {
     builder.spawn(routine)
+}
+
+#[derive(Debug, Error)]
+#[error("failed to spawn startup thread '{thread_name}': {source}")]
+pub struct StartupThreadSpawnError {
+    pub(crate) thread_name: &'static str,
+    #[source]
+    pub(crate) source: io::Error,
+}
+
+impl StartupThreadSpawnError {
+    pub(crate) fn new(thread_name: &'static str, source: io::Error) -> Self {
+        Self {
+            thread_name,
+            source,
+        }
+    }
+}
+
+pub(crate) fn spawn_startup_named_thread(
+    thread_name: &'static str,
+    routine: NamedThreadRoutine,
+) -> Result<thread::JoinHandle<()>, StartupThreadSpawnError> {
+    spawn_startup_named_thread_with_spawner(thread_name, routine, spawn_named_thread)
+}
+
+pub(crate) fn spawn_startup_named_thread_with_spawner(
+    thread_name: &'static str,
+    routine: NamedThreadRoutine,
+    spawner: NamedThreadSpawner,
+) -> Result<thread::JoinHandle<()>, StartupThreadSpawnError> {
+    spawner(
+        thread::Builder::new().name(thread_name.to_string()),
+        routine,
+    )
+    .map_err(|source| StartupThreadSpawnError::new(thread_name, source))
 }

--- a/src/thread_util.rs
+++ b/src/thread_util.rs
@@ -35,13 +35,6 @@ impl StartupThreadSpawnError {
     }
 }
 
-pub(crate) fn spawn_startup_named_thread(
-    thread_name: &'static str,
-    routine: NamedThreadRoutine,
-) -> Result<thread::JoinHandle<()>, StartupThreadSpawnError> {
-    spawn_startup_named_thread_with_spawner(thread_name, routine, spawn_named_thread)
-}
-
 pub(crate) fn spawn_startup_named_thread_with_spawner(
     thread_name: &'static str,
     routine: NamedThreadRoutine,


### PR DESCRIPTION
## Summary
- add a shared `StartupThreadSpawnError` and startup-thread spawn helper in `thread_util`
- move the activity startup path onto a typed `ActivityStartupError` instead of wrapping thread-spawn failures back into `io::Error` and then flattening them into strings
- make plugin runtime `RuntimeError::ThreadSpawn` wrap the shared startup thread-spawn error directly so the standard source chain stays intact

## Details
This keeps one explicit startup-owned thread-spawn error contract across the activity and plugin-runtime seams while preserving the original `io::Error` and thread name in the normal error chain.

The websocket startup boundary now carries a typed activity startup error instead of erasing the failure into `WsConfigError::Runtime(String)`, and both startup paths have regression tests that verify the source chain remains:
- `WsConfigError -> ActivityStartupError -> StartupThreadSpawnError -> io::Error`
- `RuntimeError::ThreadSpawn -> StartupThreadSpawnError -> io::Error`

Closes #280

## Validation
- `../carapace/scripts/cargo-serial fmt --all`
- `../carapace/scripts/cargo-serial nextest run test_activity_dispatcher_try_with_options_reports_thread_spawn_error test_stop_typing_thread_spawn_error_preserves_source_error test_epoch_ticker_start_reports_thread_spawn_error test_runtime_creation_reports_epoch_ticker_spawn_error test_runtime_creation_preserves_epoch_ticker_spawn_error_chain test_plugin_runtime_thread_spawn_errors_are_fatal test_try_new_reports_activity_service_startup_error test_try_new_persistent_unloaded_reports_activity_service_startup_error test_try_new_preserves_activity_startup_error_chain test_try_new_persistent_unloaded_builds_registries_before_activity_service`
- `../carapace/scripts/cargo-serial check --tests`