### PR TITLE
Compile plugin components once on a shared engine

### DIFF
--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
 use std::time::Duration;
@@ -60,7 +60,9 @@ where
     let engine = init()?;
     match engine_cell.set(engine) {
         Ok(()) => {}
-        Err(engine) => drop(engine),
+        Err(_) => unreachable!(
+            "OnceLock::set cannot fail while init_lock is held and cell is confirmed empty"
+        ),
     }
 
     Ok(engine_cell
@@ -82,9 +84,15 @@ struct EpochTickerState {
     ticker: Weak<EpochTicker>,
 }
 
+enum EpochTickerSlot {
+    Starting { interval: Duration },
+    Ready(EpochTickerState),
+}
+
 pub(crate) struct PluginEngine {
     engine: Engine,
-    epoch_ticker: Mutex<Option<EpochTickerState>>,
+    epoch_ticker: Mutex<Option<EpochTickerSlot>>,
+    epoch_ticker_ready: Condvar,
 }
 
 impl PluginEngine {
@@ -92,6 +100,7 @@ impl PluginEngine {
         Ok(Arc::new(Self {
             engine: build_plugin_engine()?,
             epoch_ticker: Mutex::new(None),
+            epoch_ticker_ready: Condvar::new(),
         }))
     }
 
@@ -115,25 +124,57 @@ impl PluginEngine {
     {
         let interval = normalize_epoch_ticker_interval(interval);
         let mut ticker = self.epoch_ticker.lock();
-        if let Some(existing) = ticker.as_ref() {
-            if let Some(ticker) = existing.ticker.upgrade() {
-                if existing.interval != interval {
-                    return Err(EnsureEpochTickerError::IntervalMismatch {
-                        existing: existing.interval,
-                        requested: interval,
-                    });
+        loop {
+            match ticker.as_ref() {
+                Some(EpochTickerSlot::Ready(existing)) => {
+                    let existing_interval = existing.interval;
+                    if let Some(existing_ticker) = existing.ticker.upgrade() {
+                        if existing_interval != interval {
+                            return Err(EnsureEpochTickerError::IntervalMismatch {
+                                existing: existing_interval,
+                                requested: interval,
+                            });
+                        }
+                        return Ok(existing_ticker);
+                    }
+                    *ticker = None;
                 }
-                return Ok(ticker);
+                Some(EpochTickerSlot::Starting {
+                    interval: existing_interval,
+                }) => {
+                    let existing_interval = *existing_interval;
+                    if existing_interval != interval {
+                        return Err(EnsureEpochTickerError::IntervalMismatch {
+                            existing: existing_interval,
+                            requested: interval,
+                        });
+                    }
+                    self.epoch_ticker_ready.wait(&mut ticker);
+                }
+                None => {
+                    *ticker = Some(EpochTickerSlot::Starting { interval });
+                    break;
+                }
             }
         }
 
-        let created = Arc::new(
-            factory(self.engine.clone(), interval).map_err(EnsureEpochTickerError::Start)?,
-        );
-        *ticker = Some(EpochTickerState {
+        drop(ticker);
+        let created = match factory(self.engine.clone(), interval) {
+            Ok(ticker) => Arc::new(ticker),
+            Err(error) => {
+                let mut ticker = self.epoch_ticker.lock();
+                *ticker = None;
+                self.epoch_ticker_ready.notify_all();
+                return Err(EnsureEpochTickerError::Start(error));
+            }
+        };
+
+        let mut ticker = self.epoch_ticker.lock();
+        *ticker = Some(EpochTickerSlot::Ready(EpochTickerState {
             interval,
             ticker: Arc::downgrade(&created),
-        });
+        }));
+        self.epoch_ticker_ready.notify_all();
         Ok(created)
     }
 }
@@ -385,6 +426,54 @@ mod tests {
             attempts.load(Ordering::SeqCst),
             1,
             "only one thread should run the expensive engine initializer"
+        );
+    }
+
+    #[test]
+    fn ensure_epoch_ticker_serializes_concurrent_creation() {
+        let plugin_engine = PluginEngine::for_runtime().expect("plugin engine");
+        let attempts = AtomicUsize::new(0);
+        let release = AtomicBool::new(false);
+
+        std::thread::scope(|scope| {
+            let mut joins = Vec::new();
+            for _ in 0..8 {
+                joins.push(scope.spawn(|| {
+                    plugin_engine
+                        .ensure_epoch_ticker(Duration::from_millis(1), |_engine, _interval| {
+                            attempts.fetch_add(1, Ordering::SeqCst);
+                            while !release.load(Ordering::SeqCst) {
+                                std::hint::spin_loop();
+                            }
+                            Ok::<EpochTicker, ()>(EpochTicker {
+                                stop: Arc::new(AtomicBool::new(false)),
+                                handle: None,
+                            })
+                        })
+                        .expect("concurrent ticker initialization should succeed")
+                }));
+            }
+
+            while attempts.load(Ordering::SeqCst) == 0 {
+                std::hint::spin_loop();
+            }
+            release.store(true, Ordering::SeqCst);
+
+            let first = joins
+                .pop()
+                .expect("at least one join handle")
+                .join()
+                .expect("first thread should succeed");
+            for join in joins {
+                let ticker = join.join().expect("thread should succeed");
+                assert!(Arc::ptr_eq(&ticker, &first));
+            }
+        });
+
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "only one ticker factory should run for concurrent same-interval requests"
         );
     }
 }

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -11,6 +11,10 @@ use crate::StartupThreadSpawnError;
 
 pub(crate) const EPOCH_TICKER_THREAD_NAME: &str = "plugin-epoch-ticker";
 
+fn normalize_epoch_ticker_interval(interval: Duration) -> Duration {
+    interval.max(Duration::from_millis(1))
+}
+
 fn plugin_engine_config() -> Config {
     let mut config = Config::new();
     config.wasm_component_model(true);
@@ -34,9 +38,23 @@ pub(crate) fn shared_component_validation_engine() -> Result<&'static Engine, St
     }
 }
 
+#[derive(Debug)]
+pub(crate) enum EnsureEpochTickerError<E> {
+    IntervalMismatch {
+        existing: Duration,
+        requested: Duration,
+    },
+    Start(E),
+}
+
+struct EpochTickerState {
+    interval: Duration,
+    ticker: Arc<EpochTicker>,
+}
+
 pub(crate) struct PluginEngine {
     engine: Engine,
-    epoch_ticker: Mutex<Option<Arc<EpochTicker>>>,
+    epoch_ticker: Mutex<Option<EpochTickerState>>,
 }
 
 impl PluginEngine {
@@ -55,27 +73,30 @@ impl PluginEngine {
         &self,
         interval: Duration,
         factory: F,
-    ) -> Result<Arc<EpochTicker>, E>
+    ) -> Result<Arc<EpochTicker>, EnsureEpochTickerError<E>>
     where
         F: FnOnce(Engine, Duration) -> Result<EpochTicker, E>,
     {
+        let interval = normalize_epoch_ticker_interval(interval);
         let mut ticker = self.epoch_ticker.lock();
         if let Some(existing) = ticker.as_ref() {
-            return Ok(existing.clone());
+            if existing.interval != interval {
+                return Err(EnsureEpochTickerError::IntervalMismatch {
+                    existing: existing.interval,
+                    requested: interval,
+                });
+            }
+            return Ok(existing.ticker.clone());
         }
 
-        let created = Arc::new(factory(self.engine.clone(), interval)?);
-        *ticker = Some(created.clone());
+        let created = Arc::new(
+            factory(self.engine.clone(), interval).map_err(EnsureEpochTickerError::Start)?,
+        );
+        *ticker = Some(EpochTickerState {
+            interval,
+            ticker: created.clone(),
+        });
         Ok(created)
-    }
-}
-
-impl Default for PluginEngine {
-    fn default() -> Self {
-        Self {
-            engine: build_plugin_engine().expect("plugin engine should initialize"),
-            epoch_ticker: Mutex::new(None),
-        }
     }
 }
 
@@ -110,6 +131,7 @@ impl EpochTicker {
         interval: Duration,
         spawner: NamedThreadSpawner,
     ) -> Result<Self, StartupThreadSpawnError> {
+        let interval = normalize_epoch_ticker_interval(interval);
         let stop = Arc::new(AtomicBool::new(false));
         let handle = spawn_startup_named_thread_with_spawner(
             EPOCH_TICKER_THREAD_NAME,
@@ -130,5 +152,46 @@ impl Drop for EpochTicker {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_epoch_ticker_rejects_mismatched_interval_requests() {
+        let plugin_engine = PluginEngine::for_runtime().expect("plugin engine");
+
+        plugin_engine
+            .ensure_epoch_ticker(Duration::ZERO, |_engine, _interval| {
+                Ok::<EpochTicker, ()>(EpochTicker {
+                    stop: Arc::new(AtomicBool::new(false)),
+                    handle: None,
+                })
+            })
+            .expect("first ticker request should succeed");
+
+        let err = match plugin_engine.ensure_epoch_ticker(
+            Duration::from_millis(2),
+            |_engine, _interval| {
+                Ok::<EpochTicker, ()>(EpochTicker {
+                    stop: Arc::new(AtomicBool::new(false)),
+                    handle: None,
+                })
+            },
+        ) {
+            Ok(_) => panic!("mismatched interval should be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(
+            err,
+            EnsureEpochTickerError::IntervalMismatch {
+                existing,
+                requested,
+            } if existing == Duration::from_millis(1)
+                && requested == Duration::from_millis(2)
+        ));
     }
 }

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -126,12 +126,11 @@ impl EpochTicker {
         Self::start_with_spawner(engine, interval, spawn_named_thread)
     }
 
-    pub(crate) fn start_with_spawner(
+    fn start_with_spawner(
         engine: Engine,
         interval: Duration,
         spawner: NamedThreadSpawner,
     ) -> Result<Self, StartupThreadSpawnError> {
-        let interval = normalize_epoch_ticker_interval(interval);
         let stop = Arc::new(AtomicBool::new(false));
         let handle = spawn_startup_named_thread_with_spawner(
             EPOCH_TICKER_THREAD_NAME,
@@ -158,6 +157,9 @@ impl Drop for EpochTicker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugins::runtime::DEFAULT_EPOCH_TICK_INTERVAL;
+    use std::error::Error;
+    use std::io;
 
     #[test]
     fn ensure_epoch_ticker_rejects_mismatched_interval_requests() {
@@ -193,5 +195,39 @@ mod tests {
             } if existing == Duration::from_millis(1)
                 && requested == Duration::from_millis(2)
         ));
+    }
+
+    #[test]
+    fn epoch_ticker_start_reports_thread_spawn_error() {
+        fn fail_spawner(
+            _builder: std::thread::Builder,
+            routine: crate::thread_util::NamedThreadRoutine,
+        ) -> io::Result<std::thread::JoinHandle<()>> {
+            drop(routine);
+            Err(io::Error::other("simulated epoch ticker thread exhaustion"))
+        }
+
+        let engine = Engine::default();
+        let err = match EpochTicker::start_with_spawner(
+            engine,
+            DEFAULT_EPOCH_TICK_INTERVAL,
+            fail_spawner,
+        ) {
+            Ok(_) => panic!("epoch ticker startup should report thread spawn failure"),
+            Err(err) => err,
+        };
+
+        let io_source = err
+            .source()
+            .expect("thread spawn error should preserve the original io::Error source");
+        let io_error = io_source
+            .downcast_ref::<io::Error>()
+            .expect("thread spawn error source should remain an io::Error");
+
+        assert_eq!(io_error.kind(), io::ErrorKind::Other);
+        assert_eq!(err.thread_name(), EPOCH_TICKER_THREAD_NAME);
+        assert!(err
+            .to_string()
+            .contains("simulated epoch ticker thread exhaustion"));
     }
 }

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -163,6 +163,11 @@ impl PluginEngine {
                 }) => {
                     let existing_interval = *existing_interval;
                     if existing_interval != interval {
+                        // Mismatches against an in-flight startup are reported
+                        // immediately. If that startup later fails or panics,
+                        // `StartingTickerGuard` clears the slot back to `None`,
+                        // and callers that still want a different interval may
+                        // retry against the now-empty slot.
                         return Err(EnsureEpochTickerError::IntervalMismatch {
                             existing: existing_interval,
                             requested: interval,

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -132,7 +132,10 @@ impl PluginEngine {
     /// Interval mismatches are rejected only while a ticker is still live and
     /// shared by current runtime holders. Once the last `Arc<EpochTicker>` is
     /// dropped, the next caller starts a fresh ticker and may choose a new
-    /// interval.
+    /// interval. Mismatches against an in-flight `Starting` slot also return
+    /// immediately; callers that still want a different interval after that
+    /// startup fails or panics must schedule their own retry after receiving
+    /// `EnsureEpochTickerError::IntervalMismatch`.
     pub(crate) fn ensure_epoch_ticker<F, E>(
         &self,
         interval: Duration,

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -15,6 +15,10 @@ fn normalize_epoch_ticker_interval(interval: Duration) -> Duration {
     interval.max(Duration::from_millis(1))
 }
 
+// Single source of truth for plugin engine configuration. Standalone
+// validation, loader compilation, and runtime instantiation must stay aligned
+// so install-time validation matches the engine later used for cached
+// component compilation and execution.
 fn plugin_engine_config() -> Config {
     let mut config = Config::new();
     config.wasm_component_model(true);
@@ -89,6 +93,21 @@ enum EpochTickerSlot {
     Ready(EpochTickerState),
 }
 
+struct StartingTickerGuard<'a> {
+    slot: &'a Mutex<Option<EpochTickerSlot>>,
+    ready: &'a Condvar,
+}
+
+impl Drop for StartingTickerGuard<'_> {
+    fn drop(&mut self) {
+        let mut slot = self.slot.lock();
+        if matches!(slot.as_ref(), Some(EpochTickerSlot::Starting { .. })) {
+            *slot = None;
+            self.ready.notify_all();
+        }
+    }
+}
+
 pub(crate) struct PluginEngine {
     engine: Engine,
     epoch_ticker: Mutex<Option<EpochTickerSlot>>,
@@ -159,14 +178,13 @@ impl PluginEngine {
         }
 
         drop(ticker);
+        let starting_guard = StartingTickerGuard {
+            slot: &self.epoch_ticker,
+            ready: &self.epoch_ticker_ready,
+        };
         let created = match factory(self.engine.clone(), interval) {
             Ok(ticker) => Arc::new(ticker),
-            Err(error) => {
-                let mut ticker = self.epoch_ticker.lock();
-                *ticker = None;
-                self.epoch_ticker_ready.notify_all();
-                return Err(EnsureEpochTickerError::Start(error));
-            }
+            Err(error) => return Err(EnsureEpochTickerError::Start(error)),
         };
 
         let mut ticker = self.epoch_ticker.lock();
@@ -175,6 +193,8 @@ impl PluginEngine {
             ticker: Arc::downgrade(&created),
         }));
         self.epoch_ticker_ready.notify_all();
+        drop(ticker);
+        drop(starting_guard);
         Ok(created)
     }
 }
@@ -239,6 +259,7 @@ mod tests {
     use crate::plugins::runtime::DEFAULT_EPOCH_TICK_INTERVAL;
     use std::error::Error;
     use std::io;
+    use std::panic::AssertUnwindSafe;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
@@ -475,5 +496,47 @@ mod tests {
             1,
             "only one ticker factory should run for concurrent same-interval requests"
         );
+    }
+
+    #[test]
+    fn ensure_epoch_ticker_clears_starting_slot_after_factory_panic() {
+        let plugin_engine = PluginEngine::for_runtime().expect("plugin engine");
+
+        let panic_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let _ = plugin_engine.ensure_epoch_ticker(
+                Duration::from_millis(1),
+                |_engine, _interval| {
+                    panic!("simulated ticker startup panic");
+                    #[allow(unreachable_code)]
+                    Ok::<EpochTicker, ()>(EpochTicker {
+                        stop: Arc::new(AtomicBool::new(false)),
+                        handle: None,
+                    })
+                },
+            );
+        }));
+        assert!(panic_result.is_err());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let plugin_engine = Arc::clone(&plugin_engine);
+        let join = std::thread::spawn(move || {
+            let result = plugin_engine.ensure_epoch_ticker(
+                Duration::from_millis(1),
+                |_engine, _interval| {
+                    Ok::<EpochTicker, ()>(EpochTicker {
+                        stop: Arc::new(AtomicBool::new(false)),
+                        handle: None,
+                    })
+                },
+            );
+            tx.send(result.is_ok()).expect("send result");
+        });
+
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1)),
+            Ok(true),
+            "subsequent callers should not block forever after a startup panic"
+        );
+        join.join().expect("join waiter thread");
     }
 }

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -1,0 +1,134 @@
+use parking_lot::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use wasmtime::{Config, Engine};
+
+use crate::thread_util::{
+    spawn_named_thread, spawn_startup_named_thread_with_spawner, NamedThreadSpawner,
+};
+use crate::StartupThreadSpawnError;
+
+pub(crate) const EPOCH_TICKER_THREAD_NAME: &str = "plugin-epoch-ticker";
+
+fn plugin_engine_config() -> Config {
+    let mut config = Config::new();
+    config.wasm_component_model(true);
+    config.consume_fuel(true);
+    config.epoch_interruption(true);
+    config
+}
+
+fn build_plugin_engine() -> Result<Engine, String> {
+    Engine::new(&plugin_engine_config()).map_err(|e| e.to_string())
+}
+
+// Standalone validation may happen before the loader/runtime pair exists
+// (for example during plugin install/update handling), so it uses a shared
+// fallback engine configured identically to the runtime engine.
+pub(crate) fn shared_component_validation_engine() -> Result<&'static Engine, String> {
+    static ENGINE: OnceLock<Result<Engine, String>> = OnceLock::new();
+    match ENGINE.get_or_init(build_plugin_engine) {
+        Ok(engine) => Ok(engine),
+        Err(message) => Err(message.clone()),
+    }
+}
+
+pub(crate) struct PluginEngine {
+    engine: Engine,
+    epoch_ticker: Mutex<Option<Arc<EpochTicker>>>,
+}
+
+impl PluginEngine {
+    pub(crate) fn for_runtime() -> Result<Arc<Self>, String> {
+        Ok(Arc::new(Self {
+            engine: build_plugin_engine()?,
+            epoch_ticker: Mutex::new(None),
+        }))
+    }
+
+    pub(crate) fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    pub(crate) fn ensure_epoch_ticker<F, E>(
+        &self,
+        interval: Duration,
+        factory: F,
+    ) -> Result<Arc<EpochTicker>, E>
+    where
+        F: FnOnce(Engine, Duration) -> Result<EpochTicker, E>,
+    {
+        let mut ticker = self.epoch_ticker.lock();
+        if let Some(existing) = ticker.as_ref() {
+            return Ok(existing.clone());
+        }
+
+        let created = Arc::new(factory(self.engine.clone(), interval)?);
+        *ticker = Some(created.clone());
+        Ok(created)
+    }
+}
+
+impl Default for PluginEngine {
+    fn default() -> Self {
+        Self {
+            engine: build_plugin_engine().expect("plugin engine should initialize"),
+            epoch_ticker: Mutex::new(None),
+        }
+    }
+}
+
+pub(crate) struct EpochTicker {
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl EpochTicker {
+    fn routine(
+        engine: Engine,
+        interval: Duration,
+        stop: Arc<AtomicBool>,
+    ) -> crate::thread_util::NamedThreadRoutine {
+        Box::new(move || {
+            while !stop.load(Ordering::SeqCst) {
+                std::thread::sleep(interval);
+                engine.increment_epoch();
+            }
+        })
+    }
+
+    pub(crate) fn start(
+        engine: Engine,
+        interval: Duration,
+    ) -> Result<Self, StartupThreadSpawnError> {
+        Self::start_with_spawner(engine, interval, spawn_named_thread)
+    }
+
+    pub(crate) fn start_with_spawner(
+        engine: Engine,
+        interval: Duration,
+        spawner: NamedThreadSpawner,
+    ) -> Result<Self, StartupThreadSpawnError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let handle = spawn_startup_named_thread_with_spawner(
+            EPOCH_TICKER_THREAD_NAME,
+            Self::routine(engine, interval, Arc::clone(&stop)),
+            spawner,
+        )?;
+
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for EpochTicker {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -32,10 +32,15 @@ fn build_plugin_engine() -> Result<Engine, String> {
 // fallback engine configured identically to the runtime engine.
 pub(crate) fn shared_component_validation_engine() -> Result<&'static Engine, String> {
     static ENGINE: OnceLock<Engine> = OnceLock::new();
-    get_or_init_shared_engine(&ENGINE, build_plugin_engine)
+    static INIT_LOCK: Mutex<()> = Mutex::new(());
+    get_or_init_shared_engine(&ENGINE, &INIT_LOCK, build_plugin_engine)
 }
 
-fn get_or_init_shared_engine<F>(engine_cell: &OnceLock<Engine>, init: F) -> Result<&Engine, String>
+fn get_or_init_shared_engine<'a, F>(
+    engine_cell: &'a OnceLock<Engine>,
+    init_lock: &'a Mutex<()>,
+    init: F,
+) -> Result<&'a Engine, String>
 where
     F: FnOnce() -> Result<Engine, String>,
 {
@@ -44,8 +49,14 @@ where
     }
 
     // `OnceLock::get_or_try_init` would express this more directly, but it is
-    // still unstable in the toolchain used here. We only cache successful
-    // construction so standalone validation retries after transient failures.
+    // still unstable in the toolchain used here. We serialize first-use
+    // initialization so only one expensive `Engine::new` runs at a time, while
+    // still caching only successful construction so transient failures retry.
+    let _init_guard = init_lock.lock();
+    if let Some(engine) = engine_cell.get() {
+        return Ok(engine);
+    }
+
     let engine = init()?;
     match engine_cell.set(engine) {
         Ok(()) => {}
@@ -310,9 +321,10 @@ mod tests {
     #[test]
     fn shared_validation_engine_retries_after_failed_initialization() {
         let engine_cell = OnceLock::new();
+        let init_lock = Mutex::new(());
         let attempts = AtomicUsize::new(0);
 
-        let first_err = match get_or_init_shared_engine(&engine_cell, || {
+        let first_err = match get_or_init_shared_engine(&engine_cell, &init_lock, || {
             attempts.fetch_add(1, Ordering::SeqCst);
             Err("transient init failure".to_string())
         }) {
@@ -324,7 +336,7 @@ mod tests {
         assert!(engine_cell.get().is_none());
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
 
-        let engine = get_or_init_shared_engine(&engine_cell, || {
+        let engine = get_or_init_shared_engine(&engine_cell, &init_lock, || {
             attempts.fetch_add(1, Ordering::SeqCst);
             build_plugin_engine()
         })
@@ -337,5 +349,42 @@ mod tests {
                 .expect("successful init should cache the engine")
         ));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn shared_validation_engine_serializes_concurrent_first_use() {
+        let engine_cell = OnceLock::new();
+        let init_lock = Mutex::new(());
+        let attempts = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            let mut joins = Vec::new();
+            for _ in 0..8 {
+                joins.push(scope.spawn(|| {
+                    get_or_init_shared_engine(&engine_cell, &init_lock, || {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        build_plugin_engine()
+                    })
+                    .expect("concurrent initialization should succeed")
+                        as *const Engine as usize
+                }));
+            }
+
+            let first = joins
+                .pop()
+                .expect("at least one join handle")
+                .join()
+                .expect("first thread should succeed");
+            for join in joins {
+                let engine = join.join().expect("thread should succeed");
+                assert_eq!(engine, first);
+            }
+        });
+
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "only one thread should run the expensive engine initializer"
+        );
     }
 }

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -539,4 +539,43 @@ mod tests {
         );
         join.join().expect("join waiter thread");
     }
+
+    #[test]
+    fn ensure_epoch_ticker_clears_starting_slot_after_factory_error() {
+        let plugin_engine = PluginEngine::for_runtime().expect("plugin engine");
+
+        let err = match plugin_engine
+            .ensure_epoch_ticker(Duration::from_millis(1), |_engine, _interval| {
+                Err::<EpochTicker, _>("simulated ticker startup error")
+            }) {
+            Ok(_) => panic!("ticker startup error should be returned"),
+            Err(err) => err,
+        };
+        assert!(matches!(
+            err,
+            EnsureEpochTickerError::Start("simulated ticker startup error")
+        ));
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let plugin_engine = Arc::clone(&plugin_engine);
+        let join = std::thread::spawn(move || {
+            let result = plugin_engine.ensure_epoch_ticker(
+                Duration::from_millis(1),
+                |_engine, _interval| {
+                    Ok::<EpochTicker, &str>(EpochTicker {
+                        stop: Arc::new(AtomicBool::new(false)),
+                        handle: None,
+                    })
+                },
+            );
+            tx.send(result.is_ok()).expect("send result");
+        });
+
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1)),
+            Ok(true),
+            "subsequent callers should not block forever after a startup error"
+        );
+        join.join().expect("join waiter thread");
+    }
 }

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -31,11 +31,27 @@ fn build_plugin_engine() -> Result<Engine, String> {
 // (for example during plugin install/update handling), so it uses a shared
 // fallback engine configured identically to the runtime engine.
 pub(crate) fn shared_component_validation_engine() -> Result<&'static Engine, String> {
-    static ENGINE: OnceLock<Result<Engine, String>> = OnceLock::new();
-    match ENGINE.get_or_init(build_plugin_engine) {
-        Ok(engine) => Ok(engine),
-        Err(message) => Err(message.clone()),
+    static ENGINE: OnceLock<Engine> = OnceLock::new();
+    get_or_init_shared_engine(&ENGINE, build_plugin_engine)
+}
+
+fn get_or_init_shared_engine<F>(engine_cell: &OnceLock<Engine>, init: F) -> Result<&Engine, String>
+where
+    F: FnOnce() -> Result<Engine, String>,
+{
+    if let Some(engine) = engine_cell.get() {
+        return Ok(engine);
     }
+
+    let engine = init()?;
+    match engine_cell.set(engine) {
+        Ok(()) => {}
+        Err(engine) => drop(engine),
+    }
+
+    engine_cell.get().ok_or_else(|| {
+        "shared engine should be initialized after successful construction".to_string()
+    })
 }
 
 #[derive(Debug)]
@@ -160,6 +176,7 @@ mod tests {
     use crate::plugins::runtime::DEFAULT_EPOCH_TICK_INTERVAL;
     use std::error::Error;
     use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn ensure_epoch_ticker_rejects_mismatched_interval_requests() {
@@ -229,5 +246,37 @@ mod tests {
         assert!(err
             .to_string()
             .contains("simulated epoch ticker thread exhaustion"));
+    }
+
+    #[test]
+    fn shared_validation_engine_retries_after_failed_initialization() {
+        let engine_cell = OnceLock::new();
+        let attempts = AtomicUsize::new(0);
+
+        let first_err = match get_or_init_shared_engine(&engine_cell, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err("transient init failure".to_string())
+        }) {
+            Ok(_) => panic!("first shared engine initialization should fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(first_err, "transient init failure");
+        assert!(engine_cell.get().is_none());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        let engine = get_or_init_shared_engine(&engine_cell, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            build_plugin_engine()
+        })
+        .expect("second shared engine initialization should retry and succeed");
+
+        assert!(std::ptr::eq(
+            engine,
+            engine_cell
+                .get()
+                .expect("successful init should cache the engine")
+        ));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -1,6 +1,6 @@
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, Weak};
 use std::time::Duration;
 use wasmtime::{Config, Engine};
 
@@ -49,9 +49,9 @@ where
         Err(engine) => drop(engine),
     }
 
-    engine_cell.get().ok_or_else(|| {
-        "shared engine should be initialized after successful construction".to_string()
-    })
+    Ok(engine_cell
+        .get()
+        .expect("engine must be set after successful OnceLock::set or concurrent set"))
 }
 
 #[derive(Debug)]
@@ -65,7 +65,7 @@ pub(crate) enum EnsureEpochTickerError<E> {
 
 struct EpochTickerState {
     interval: Duration,
-    ticker: Arc<EpochTicker>,
+    ticker: Weak<EpochTicker>,
 }
 
 pub(crate) struct PluginEngine {
@@ -96,13 +96,15 @@ impl PluginEngine {
         let interval = normalize_epoch_ticker_interval(interval);
         let mut ticker = self.epoch_ticker.lock();
         if let Some(existing) = ticker.as_ref() {
-            if existing.interval != interval {
-                return Err(EnsureEpochTickerError::IntervalMismatch {
-                    existing: existing.interval,
-                    requested: interval,
-                });
+            if let Some(ticker) = existing.ticker.upgrade() {
+                if existing.interval != interval {
+                    return Err(EnsureEpochTickerError::IntervalMismatch {
+                        existing: existing.interval,
+                        requested: interval,
+                    });
+                }
+                return Ok(ticker);
             }
-            return Ok(existing.ticker.clone());
         }
 
         let created = Arc::new(
@@ -110,7 +112,7 @@ impl PluginEngine {
         );
         *ticker = Some(EpochTickerState {
             interval,
-            ticker: created.clone(),
+            ticker: Arc::downgrade(&created),
         });
         Ok(created)
     }
@@ -212,6 +214,52 @@ mod tests {
             } if existing == Duration::from_millis(1)
                 && requested == Duration::from_millis(2)
         ));
+    }
+
+    #[test]
+    fn ensure_epoch_ticker_restarts_after_last_runtime_reference_drops() {
+        let plugin_engine = PluginEngine::for_runtime().expect("plugin engine");
+        let starts = AtomicUsize::new(0);
+
+        let first = plugin_engine
+            .ensure_epoch_ticker(Duration::from_millis(1), |_engine, _interval| {
+                starts.fetch_add(1, Ordering::SeqCst);
+                Ok::<EpochTicker, ()>(EpochTicker {
+                    stop: Arc::new(AtomicBool::new(false)),
+                    handle: None,
+                })
+            })
+            .expect("first ticker start should succeed");
+
+        let second = plugin_engine
+            .ensure_epoch_ticker(Duration::from_millis(1), |_engine, _interval| {
+                starts.fetch_add(1, Ordering::SeqCst);
+                Ok::<EpochTicker, ()>(EpochTicker {
+                    stop: Arc::new(AtomicBool::new(false)),
+                    handle: None,
+                })
+            })
+            .expect("concurrent ticker reuse should succeed");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+        drop(first);
+        drop(second);
+
+        let third = plugin_engine
+            .ensure_epoch_ticker(Duration::from_millis(2), |_engine, interval| {
+                starts.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(interval, Duration::from_millis(2));
+                Ok::<EpochTicker, ()>(EpochTicker {
+                    stop: Arc::new(AtomicBool::new(false)),
+                    handle: None,
+                })
+            })
+            .expect("ticker should restart after all runtime references drop");
+
+        assert_eq!(starts.load(Ordering::SeqCst), 2);
+        drop(third);
     }
 
     #[test]

--- a/src/plugins/engine.rs
+++ b/src/plugins/engine.rs
@@ -43,6 +43,9 @@ where
         return Ok(engine);
     }
 
+    // `OnceLock::get_or_try_init` would express this more directly, but it is
+    // still unstable in the toolchain used here. We only cache successful
+    // construction so standalone validation retries after transient failures.
     let engine = init()?;
     match engine_cell.set(engine) {
         Ok(()) => {}
@@ -85,6 +88,12 @@ impl PluginEngine {
         &self.engine
     }
 
+    /// Ensure there is a live epoch ticker for this engine.
+    ///
+    /// Interval mismatches are rejected only while a ticker is still live and
+    /// shared by current runtime holders. Once the last `Arc<EpochTicker>` is
+    /// dropped, the next caller starts a fresh ticker and may choose a new
+    /// interval.
     pub(crate) fn ensure_epoch_ticker<F, E>(
         &self,
         interval: Duration,
@@ -184,7 +193,7 @@ mod tests {
     fn ensure_epoch_ticker_rejects_mismatched_interval_requests() {
         let plugin_engine = PluginEngine::for_runtime().expect("plugin engine");
 
-        plugin_engine
+        let first = plugin_engine
             .ensure_epoch_ticker(Duration::ZERO, |_engine, _interval| {
                 Ok::<EpochTicker, ()>(EpochTicker {
                     stop: Arc::new(AtomicBool::new(false)),
@@ -214,10 +223,12 @@ mod tests {
             } if existing == Duration::from_millis(1)
                 && requested == Duration::from_millis(2)
         ));
+
+        drop(first);
     }
 
     #[test]
-    fn ensure_epoch_ticker_restarts_after_last_runtime_reference_drops() {
+    fn ensure_epoch_ticker_allows_interval_change_after_last_runtime_reference_drops() {
         let plugin_engine = PluginEngine::for_runtime().expect("plugin engine");
         let starts = AtomicUsize::new(0);
 

--- a/src/plugins/loader.rs
+++ b/src/plugins/loader.rs
@@ -200,7 +200,7 @@ impl std::fmt::Debug for LoadedPlugin {
         f.debug_struct("LoadedPlugin")
             .field("manifest", &self.manifest)
             .field("wasm_path", &self.wasm_path)
-            .field("component_cached", &true)
+            .field("component", &"<compiled>")
             .field("discovered_capabilities", &self.discovered_capabilities)
             .finish()
     }
@@ -226,8 +226,8 @@ pub(crate) fn validate_plugin_component_bytes(
     source: &str,
     wasm_bytes: &[u8],
 ) -> Result<(), LoaderError> {
-    let engine = super::engine::shared_component_validation_engine()
-        .map_err(LoaderError::EngineError)?;
+    let engine =
+        super::engine::shared_component_validation_engine().map_err(LoaderError::EngineError)?;
     compile_plugin_component(engine, source, wasm_bytes)?;
     Ok(())
 }
@@ -699,7 +699,6 @@ impl PluginLoader {
         signature_config: super::signature::SignatureConfig,
         engine: Arc<super::engine::PluginEngine>,
     ) -> Result<Self, LoaderError> {
-
         Ok(Self {
             engine,
             plugins: RwLock::new(HashMap::new()),
@@ -808,11 +807,8 @@ impl PluginLoader {
 
         // Validate and introspect the component bytes with the same binary format
         // the runtime later instantiates.
-        let component = compile_plugin_component(
-            self.engine(),
-            &wasm_path.display().to_string(),
-            &wasm_bytes,
-        )?;
+        let component =
+            compile_plugin_component(self.engine(), &wasm_path.display().to_string(), &wasm_bytes)?;
 
         let discovered_capabilities = Some(super::sandbox::enumerate_capabilities(
             &component,
@@ -829,8 +825,13 @@ impl PluginLoader {
             return Err(LoaderError::InvalidPluginId(plugin_id));
         }
 
-        let plugin_manifest =
-            derive_manifest(&plugin_id, wasm_path, &wasm_bytes, &component, self.engine());
+        let plugin_manifest = derive_manifest(
+            &plugin_id,
+            wasm_path,
+            &wasm_bytes,
+            &component,
+            self.engine(),
+        );
 
         let loaded = Arc::new(LoadedPlugin {
             manifest: plugin_manifest,

--- a/src/plugins/loader.rs
+++ b/src/plugins/loader.rs
@@ -20,11 +20,11 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::SystemTime;
 use thiserror::Error;
 use wasmtime::component::Component as WasmComponent;
-use wasmtime::{Config, Engine};
+use wasmtime::Engine;
 
 pub(crate) const RESERVED_PLUGIN_CONFIG_KEYS: &[&str] =
     &["enabled", "entries", "load", "sandbox", "signature"];
@@ -189,8 +189,8 @@ pub struct LoadedPlugin {
     pub manifest: PluginManifest,
     /// Path to the WASM file
     pub wasm_path: PathBuf,
-    /// Raw WASM bytes (for component instantiation)
-    pub wasm_bytes: Vec<u8>,
+    /// Compiled WASM component bound to the shared plugin engine.
+    pub component: WasmComponent,
     /// Discovered WASM capabilities (from component import enumeration).
     pub discovered_capabilities: Option<super::sandbox::DiscoveredCapabilities>,
 }
@@ -200,7 +200,7 @@ impl std::fmt::Debug for LoadedPlugin {
         f.debug_struct("LoadedPlugin")
             .field("manifest", &self.manifest)
             .field("wasm_path", &self.wasm_path)
-            .field("wasm_bytes_len", &self.wasm_bytes.len())
+            .field("component_cached", &true)
             .field("discovered_capabilities", &self.discovered_capabilities)
             .finish()
     }
@@ -211,29 +211,24 @@ impl std::fmt::Debug for LoadedPlugin {
 /// WASM binary magic bytes (\0asm)
 const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
 
-fn component_engine() -> Result<Engine, LoaderError> {
-    let mut config = Config::new();
-    config.wasm_component_model(true);
-    Engine::new(&config).map_err(|e| LoaderError::EngineError(e.to_string()))
-}
-
-fn shared_component_validation_engine() -> Result<&'static Engine, LoaderError> {
-    static ENGINE: OnceLock<Result<Engine, String>> = OnceLock::new();
-    match ENGINE.get_or_init(|| component_engine().map_err(|error| error.to_string())) {
-        Ok(engine) => Ok(engine),
-        Err(message) => Err(LoaderError::EngineError(message.clone())),
-    }
+fn compile_plugin_component(
+    engine: &Engine,
+    source: &str,
+    wasm_bytes: &[u8],
+) -> Result<WasmComponent, LoaderError> {
+    WasmComponent::new(engine, wasm_bytes).map_err(|e| LoaderError::WasmCompileError {
+        path: source.to_string(),
+        message: e.to_string(),
+    })
 }
 
 pub(crate) fn validate_plugin_component_bytes(
     source: &str,
     wasm_bytes: &[u8],
 ) -> Result<(), LoaderError> {
-    let engine = shared_component_validation_engine()?;
-    WasmComponent::new(engine, wasm_bytes).map_err(|e| LoaderError::WasmCompileError {
-        path: source.to_string(),
-        message: e.to_string(),
-    })?;
+    let engine = super::engine::shared_component_validation_engine()
+        .map_err(LoaderError::EngineError)?;
+    compile_plugin_component(engine, source, wasm_bytes)?;
     Ok(())
 }
 
@@ -672,8 +667,8 @@ pub fn load_plugins_manifest(plugins_dir: &Path) -> Result<Option<serde_json::Va
 
 /// Plugin loader that manages discovery and loading of WASM plugins
 pub struct PluginLoader {
-    /// Wasmtime engine (shared across all plugins)
-    engine: Engine,
+    /// Shared plugin execution engine used to compile cached components.
+    engine: Arc<super::engine::PluginEngine>,
     /// Loaded plugins by ID
     plugins: RwLock<HashMap<String, Arc<LoadedPlugin>>>,
     /// Plugins directory
@@ -693,7 +688,17 @@ impl PluginLoader {
         plugins_dir: PathBuf,
         signature_config: super::signature::SignatureConfig,
     ) -> Result<Self, LoaderError> {
-        let engine = component_engine()?;
+        let engine =
+            super::engine::PluginEngine::for_runtime().map_err(LoaderError::EngineError)?;
+        Self::with_signature_config_and_engine(plugins_dir, signature_config, engine)
+    }
+
+    /// Create a new plugin loader with explicit signature config and shared engine.
+    pub(crate) fn with_signature_config_and_engine(
+        plugins_dir: PathBuf,
+        signature_config: super::signature::SignatureConfig,
+        engine: Arc<super::engine::PluginEngine>,
+    ) -> Result<Self, LoaderError> {
 
         Ok(Self {
             engine,
@@ -705,6 +710,11 @@ impl PluginLoader {
 
     /// Get the wasmtime engine
     pub fn engine(&self) -> &Engine {
+        self.engine.engine()
+    }
+
+    /// Get the shared plugin engine.
+    pub(crate) fn shared_engine(&self) -> &Arc<super::engine::PluginEngine> {
         &self.engine
     }
 
@@ -798,16 +808,15 @@ impl PluginLoader {
 
         // Validate and introspect the component bytes with the same binary format
         // the runtime later instantiates.
-        let component = WasmComponent::new(&self.engine, &wasm_bytes).map_err(|e| {
-            LoaderError::WasmCompileError {
-                path: wasm_path.display().to_string(),
-                message: e.to_string(),
-            }
-        })?;
+        let component = compile_plugin_component(
+            self.engine(),
+            &wasm_path.display().to_string(),
+            &wasm_bytes,
+        )?;
 
         let discovered_capabilities = Some(super::sandbox::enumerate_capabilities(
             &component,
-            &self.engine,
+            self.engine(),
         ));
 
         let plugin_id = wasm_path
@@ -821,12 +830,12 @@ impl PluginLoader {
         }
 
         let plugin_manifest =
-            derive_manifest(&plugin_id, wasm_path, &wasm_bytes, &component, &self.engine);
+            derive_manifest(&plugin_id, wasm_path, &wasm_bytes, &component, self.engine());
 
         let loaded = Arc::new(LoadedPlugin {
             manifest: plugin_manifest,
             wasm_path: wasm_path.to_path_buf(),
-            wasm_bytes,
+            component,
             discovered_capabilities,
         });
 
@@ -874,17 +883,16 @@ impl PluginLoader {
 
         // Validate and introspect the component bytes with the same binary format
         // the runtime later instantiates.
-        let component = WasmComponent::new(&self.engine, wasm_bytes).map_err(|e| {
-            LoaderError::WasmCompileError {
-                path: format!("<bytes:{}>", manifest.id),
-                message: e.to_string(),
-            }
-        })?;
+        let component = compile_plugin_component(
+            self.engine(),
+            &format!("<bytes:{}>", manifest.id),
+            wasm_bytes,
+        )?;
 
         // Enumerate WASM capabilities for sandbox checking
         let discovered_capabilities = Some(super::sandbox::enumerate_capabilities(
             &component,
-            &self.engine,
+            self.engine(),
         ));
 
         let plugin_id = manifest.id.clone();
@@ -893,7 +901,7 @@ impl PluginLoader {
         let loaded = LoadedPlugin {
             manifest,
             wasm_path: PathBuf::new(), // No file path for byte-loaded plugins
-            wasm_bytes: wasm_bytes.to_vec(),
+            component,
             discovered_capabilities,
         };
 
@@ -940,7 +948,9 @@ impl PluginLoader {
     /// Reload a plugin from its WASM file.
     ///
     /// The new module is compiled and verified *before* replacing the old one,
-    /// so the plugin stays available if the reload fails.
+    /// so the plugin stays available if the reload fails. Callers must still
+    /// unload and re-instantiate any live runtime worker to pick up the new
+    /// compiled component.
     pub fn reload_plugin(&self, plugin_id: &str) -> Result<(), LoaderError> {
         let wasm_path = {
             let plugins = self.plugins.read();

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -66,6 +66,7 @@ pub(crate) fn validate_managed_plugin_name(name: &str) -> Result<(), String> {
 pub mod bindings;
 pub mod capabilities;
 pub mod dispatch;
+mod engine;
 pub mod hook_utils;
 pub mod host;
 pub mod loader;
@@ -96,6 +97,7 @@ pub use dispatch::{
     is_modifiable_hook, DispatchError, HookDispatchResult, HookDispatcher, ToolDispatcher,
     WebhookDispatcher, MODIFIABLE_HOOKS,
 };
+pub(crate) use engine::PluginEngine;
 pub use host::{
     HostError, HttpRequest, HttpResponse, MediaFetchResult, PluginHostContext,
     PluginHostContextBuilder, MAX_HTTP_BODY_SIZE, MAX_LOG_MESSAGE_SIZE, MAX_URL_LENGTH,

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -1112,6 +1112,8 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
             permission_config,
         } = inputs;
         let epoch_deadline_ticks = compute_epoch_deadline_ticks(DEFAULT_EXECUTION_TIMEOUT);
+        // PluginEngine retains the ticker Arc internally; the runtime keeps the
+        // PluginEngine Arc so the shared ticker stays alive for the runtime lifetime.
         plugin_engine
             .ensure_epoch_ticker(DEFAULT_EPOCH_TICK_INTERVAL, epoch_ticker_factory)
             .map_err(RuntimeError::from)?;

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -41,7 +41,7 @@ use super::bindings::{
 use super::capabilities::{RateLimiterRegistry, SsrfConfig};
 #[cfg(test)]
 use super::engine::EPOCH_TICKER_THREAD_NAME;
-use super::engine::EpochTicker;
+use super::engine::{EnsureEpochTickerError, EpochTicker};
 use super::host::{HostError, HttpRequest, PluginHostContext};
 use super::loader::{LoadedPlugin, PluginKind, PluginLoader, PluginManifest};
 use super::permissions::{
@@ -538,6 +538,17 @@ pub enum RuntimeError {
     #[error("Wasmtime error: {0}")]
     WasmtimeError(String),
 
+    #[error("Plugin runtime engine must match the plugin loader engine")]
+    EngineMismatch,
+
+    #[error(
+        "Plugin epoch ticker interval mismatch: existing {existing:?}, requested {requested:?}"
+    )]
+    EpochTickerIntervalMismatch {
+        existing: Duration,
+        requested: Duration,
+    },
+
     #[error("Plugin returned error: [{code}] {message}")]
     PluginError { code: String, message: String },
 
@@ -563,6 +574,21 @@ impl From<StartupThreadSpawnError> for RuntimeError {
     }
 }
 
+impl From<EnsureEpochTickerError<RuntimeError>> for RuntimeError {
+    fn from(error: EnsureEpochTickerError<RuntimeError>) -> Self {
+        match error {
+            EnsureEpochTickerError::IntervalMismatch {
+                existing,
+                requested,
+            } => Self::EpochTickerIntervalMismatch {
+                existing,
+                requested,
+            },
+            EnsureEpochTickerError::Start(source) => source,
+        }
+    }
+}
+
 /// State held in each plugin's wasmtime store
 pub struct HostState<B: CredentialBackend + Send + Sync + 'static> {
     /// Plugin ID for this instance
@@ -581,6 +607,9 @@ pub struct HostState<B: CredentialBackend + Send + Sync + 'static> {
 
 /// Plugin runtime that manages WASM plugin instances
 pub struct PluginRuntime<B: CredentialBackend + 'static> {
+    /// Shared plugin engine retained directly so ticker ownership remains explicit.
+    plugin_engine: Arc<super::engine::PluginEngine>,
+
     /// Plugin loader
     loader: Arc<PluginLoader>,
 
@@ -791,11 +820,11 @@ impl<B: CredentialBackend + Send + Sync + 'static> Drop for PluginInstanceHandle
 impl<B: CredentialBackend + Send + Sync + 'static> PluginInstanceHandle<B> {
     fn initialize_worker_state(
         plugin_id: String,
+        engine: Engine,
         component: Component,
         epoch_deadline_ticks: u64,
         host_ctx: Arc<PluginHostContext<B>>,
     ) -> Result<PluginWorkerState<B>, RuntimeError> {
-        let engine = component.engine().clone();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -846,6 +875,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginInstanceHandle<B> {
 
     fn spawn(
         manifest: PluginManifest,
+        engine: Engine,
         component: Component,
         epoch_deadline_ticks: u64,
         host_ctx: Arc<PluginHostContext<B>>,
@@ -860,6 +890,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginInstanceHandle<B> {
             .spawn(move || {
                 let mut state = match Self::initialize_worker_state(
                     plugin_id,
+                    engine,
                     component,
                     epoch_deadline_ticks,
                     host_ctx,
@@ -1036,8 +1067,11 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
         sandbox_config: super::sandbox::SandboxConfig,
         permission_config: PermissionConfig,
     ) -> Result<Self, RuntimeError> {
+        if !Arc::ptr_eq(&plugin_engine, loader.shared_engine()) {
+            return Err(RuntimeError::EngineMismatch);
+        }
+
         Self::with_permissions_config_and_epoch_ticker_factory(
-            plugin_engine,
             loader,
             credential_store,
             rate_limiters,
@@ -1049,7 +1083,6 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
     }
 
     fn with_permissions_config_and_epoch_ticker_factory<F>(
-        plugin_engine: Arc<super::engine::PluginEngine>,
         loader: Arc<PluginLoader>,
         credential_store: Arc<CredentialStore<B>>,
         rate_limiters: Arc<RateLimiterRegistry>,
@@ -1061,16 +1094,14 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
     where
         F: FnOnce(Engine, Duration) -> Result<EpochTicker, RuntimeError>,
     {
-        if !Arc::ptr_eq(&plugin_engine, loader.shared_engine()) {
-            return Err(RuntimeError::WasmtimeError(
-                "plugin runtime engine must match the plugin loader engine".to_string(),
-            ));
-        }
-
+        let plugin_engine = loader.shared_engine().clone();
         let epoch_deadline_ticks = compute_epoch_deadline_ticks(DEFAULT_EXECUTION_TIMEOUT);
-        plugin_engine.ensure_epoch_ticker(DEFAULT_EPOCH_TICK_INTERVAL, epoch_ticker_factory)?;
+        plugin_engine
+            .ensure_epoch_ticker(DEFAULT_EPOCH_TICK_INTERVAL, epoch_ticker_factory)
+            .map_err(RuntimeError::from)?;
 
         Ok(Self {
+            plugin_engine,
             loader,
             credential_store,
             rate_limiters,
@@ -1086,6 +1117,11 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
     /// Get the plugin registry
     pub fn registry(&self) -> Arc<PluginRegistry> {
         self.registry.clone()
+    }
+
+    #[cfg(test)]
+    fn engine(&self) -> &Engine {
+        self.plugin_engine.engine()
     }
 
     /// Load and instantiate all plugins from the loader
@@ -1179,12 +1215,14 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
 
         // Initialize the dedicated plugin worker off the async runtime thread.
         let manifest = loaded.manifest.clone();
+        let engine = self.plugin_engine.engine().clone();
         let component = loaded.component.clone();
         let epoch_deadline_ticks = self.epoch_deadline_ticks;
         let handle = Arc::new(
             tokio::task::spawn_blocking(move || {
                 PluginInstanceHandle::spawn(
                     manifest,
+                    engine,
                     component,
                     epoch_deadline_ticks,
                     host_ctx,
@@ -1837,7 +1875,6 @@ mod tests {
         std::fs::create_dir_all(&plugins_dir).unwrap();
 
         let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
-        let plugin_engine = loader.shared_engine().clone();
         let backend = MockCredentialBackend::new(true);
         let credential_store = Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
@@ -1846,7 +1883,6 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
-            plugin_engine,
             loader,
             credential_store,
             Arc::new(RateLimiterRegistry::new()),
@@ -1874,13 +1910,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_runtime_creation_rejects_engine_mismatch() {
+        let temp_dir = tempdir().unwrap();
+        let plugins_dir = temp_dir.path().join("plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+
+        let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
+        let mismatched_engine = super::super::PluginEngine::for_runtime().unwrap();
+        let backend = MockCredentialBackend::new(true);
+        let credential_store = Arc::new(
+            CredentialStore::new(backend, temp_dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        let err = match PluginRuntime::with_permissions_config_and_engine(
+            mismatched_engine,
+            loader,
+            credential_store,
+            Arc::new(RateLimiterRegistry::new()),
+            SsrfConfig::default(),
+            crate::plugins::sandbox::SandboxConfig::default(),
+            PermissionConfig::default(),
+        ) {
+            Ok(_) => panic!("runtime startup should reject a mismatched plugin engine"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, RuntimeError::EngineMismatch));
+    }
+
+    #[tokio::test]
     async fn test_runtime_creation_preserves_epoch_ticker_spawn_error_chain() {
         let temp_dir = tempdir().unwrap();
         let plugins_dir = temp_dir.path().join("plugins");
         std::fs::create_dir_all(&plugins_dir).unwrap();
 
         let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
-        let plugin_engine = loader.shared_engine().clone();
         let backend = MockCredentialBackend::new(true);
         let credential_store = Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
@@ -1889,7 +1955,6 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
-            plugin_engine,
             loader,
             credential_store,
             Arc::new(RateLimiterRegistry::new()),
@@ -1995,18 +2060,21 @@ mod tests {
             .write(true)
             .open(&plugin_path)
             .unwrap()
-            .set_times(
-                std::fs::FileTimes::new().set_modified(
-                    std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
-                ),
-            )
+            .set_times(std::fs::FileTimes::new().set_modified(
+                std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            ))
             .unwrap();
 
         loader.load_plugin(&plugin_path).unwrap();
         runtime.instantiate_plugin("alpha").await.unwrap();
 
         let initial_loaded_version = loader.get_plugin("alpha").unwrap().manifest.version.clone();
-        let initial_live_version = runtime.get_instance("alpha").unwrap().manifest.version.clone();
+        let initial_live_version = runtime
+            .get_instance("alpha")
+            .unwrap()
+            .manifest
+            .version
+            .clone();
         assert_eq!(initial_live_version, initial_loaded_version);
 
         std::fs::write(&plugin_path, tool_plugin_component_bytes()).unwrap();
@@ -2014,11 +2082,9 @@ mod tests {
             .write(true)
             .open(&plugin_path)
             .unwrap()
-            .set_times(
-                std::fs::FileTimes::new().set_modified(
-                    std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_800_000_000),
-                ),
-            )
+            .set_times(std::fs::FileTimes::new().set_modified(
+                std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_800_000_000),
+            ))
             .unwrap();
 
         loader.reload_plugin("alpha").unwrap();
@@ -2033,7 +2099,12 @@ mod tests {
         runtime.unload_plugin("alpha").unwrap();
         runtime.instantiate_plugin("alpha").await.unwrap();
 
-        let restarted_version = runtime.get_instance("alpha").unwrap().manifest.version.clone();
+        let restarted_version = runtime
+            .get_instance("alpha")
+            .unwrap()
+            .manifest
+            .version
+            .clone();
         assert_eq!(restarted_version, reloaded_version);
 
         runtime.unload_plugin("alpha").unwrap();
@@ -2377,7 +2448,7 @@ mod tests {
         // Verify the engine was created with fuel consumption enabled
         // by checking that we can create a store and set fuel on it
         let store = Store::new(
-            runtime.loader.engine(),
+            runtime.engine(),
             HostState {
                 plugin_id: "test".to_string(),
                 host_ctx: Arc::new(PluginHostContext::new(
@@ -2403,7 +2474,7 @@ mod tests {
     async fn test_zero_fuel_store() {
         let runtime = create_test_runtime().await;
         let mut store = Store::new(
-            runtime.loader.engine(),
+            runtime.engine(),
             HostState {
                 plugin_id: "test".to_string(),
                 host_ctx: Arc::new(PluginHostContext::new(

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -22,19 +22,15 @@
 use std::collections::HashMap;
 #[cfg(test)]
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 
 use parking_lot::RwLock;
 use thiserror::Error;
 use wasmtime::component::{Component, ComponentType, Lift, Linker, Lower};
-use wasmtime::{Config, Engine, ResourceLimiter, Store, StoreContextMut};
+use wasmtime::{Engine, ResourceLimiter, Store, StoreContextMut};
 
 use crate::credentials::{CredentialBackend, CredentialStore};
-use crate::thread_util::{
-    spawn_named_thread, spawn_startup_named_thread_with_spawner, NamedThreadSpawner,
-};
 
 use super::bindings::{
     BindingError, ChannelCapabilities, ChannelInfo, ChannelPluginInstance, ChatType,
@@ -43,6 +39,9 @@ use super::bindings::{
     WebhookPluginInstance, WebhookRequest, WebhookResponse, WitHost,
 };
 use super::capabilities::{RateLimiterRegistry, SsrfConfig};
+#[cfg(test)]
+use super::engine::EPOCH_TICKER_THREAD_NAME;
+use super::engine::EpochTicker;
 use super::host::{HostError, HttpRequest, PluginHostContext};
 use super::loader::{LoadedPlugin, PluginKind, PluginLoader, PluginManifest};
 use super::permissions::{
@@ -72,64 +71,12 @@ pub const DEFAULT_FUEL_BUDGET: u64 = 1_000_000_000;
 
 /// Bounded queue depth for per-plugin worker requests.
 const PLUGIN_WORKER_QUEUE_CAPACITY: usize = 64;
-const EPOCH_TICKER_THREAD_NAME: &str = "plugin-epoch-ticker";
 
 fn compute_epoch_deadline_ticks(timeout: Duration) -> u64 {
     let interval_ms = DEFAULT_EPOCH_TICK_INTERVAL.as_millis().max(1);
     let timeout_ms = timeout.as_millis().max(1);
     let ticks = timeout_ms.div_ceil(interval_ms);
     ticks as u64
-}
-
-struct EpochTicker {
-    stop: Arc<AtomicBool>,
-    handle: Option<std::thread::JoinHandle<()>>,
-}
-
-impl EpochTicker {
-    fn routine(
-        engine: Engine,
-        interval: Duration,
-        stop: Arc<AtomicBool>,
-    ) -> crate::thread_util::NamedThreadRoutine {
-        Box::new(move || {
-            while !stop.load(Ordering::SeqCst) {
-                std::thread::sleep(interval);
-                engine.increment_epoch();
-            }
-        })
-    }
-
-    fn start(engine: Engine, interval: Duration) -> Result<Self, StartupThreadSpawnError> {
-        Self::start_with_spawner(engine, interval, spawn_named_thread)
-    }
-
-    fn start_with_spawner(
-        engine: Engine,
-        interval: Duration,
-        spawner: NamedThreadSpawner,
-    ) -> Result<Self, StartupThreadSpawnError> {
-        let stop = Arc::new(AtomicBool::new(false));
-        let handle = spawn_startup_named_thread_with_spawner(
-            EPOCH_TICKER_THREAD_NAME,
-            Self::routine(engine, interval, Arc::clone(&stop)),
-            spawner,
-        )?;
-
-        Ok(Self {
-            stop,
-            handle: Some(handle),
-        })
-    }
-}
-
-impl Drop for EpochTicker {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::SeqCst);
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
 }
 
 struct PluginResourceLimiter {
@@ -634,9 +581,6 @@ pub struct HostState<B: CredentialBackend + Send + Sync + 'static> {
 
 /// Plugin runtime that manages WASM plugin instances
 pub struct PluginRuntime<B: CredentialBackend + 'static> {
-    /// Wasmtime engine (shared)
-    engine: Engine,
-
     /// Plugin loader
     loader: Arc<PluginLoader>,
 
@@ -657,9 +601,6 @@ pub struct PluginRuntime<B: CredentialBackend + 'static> {
 
     /// Epoch deadline ticks for wall-clock timeouts
     epoch_deadline_ticks: u64,
-
-    /// Epoch ticker for wall-clock timeouts (kept for drop)
-    _epoch_ticker: EpochTicker,
 
     /// Loaded plugin instances by ID
     instances: RwLock<HashMap<String, Arc<PluginInstanceHandle<B>>>>,
@@ -850,11 +791,11 @@ impl<B: CredentialBackend + Send + Sync + 'static> Drop for PluginInstanceHandle
 impl<B: CredentialBackend + Send + Sync + 'static> PluginInstanceHandle<B> {
     fn initialize_worker_state(
         plugin_id: String,
-        wasm_bytes: Vec<u8>,
-        engine: Engine,
+        component: Component,
         epoch_deadline_ticks: u64,
         host_ctx: Arc<PluginHostContext<B>>,
     ) -> Result<PluginWorkerState<B>, RuntimeError> {
+        let engine = component.engine().clone();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -886,10 +827,6 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginInstanceHandle<B> {
             let mut linker: Linker<HostState<B>> = Linker::new(&engine);
             PluginRuntime::<B>::add_host_functions_to_linker(&mut linker)?;
 
-            let component = Component::new(&engine, &wasm_bytes).map_err(|e| {
-                RuntimeError::WasmtimeError(format!("Failed to create component: {}", e))
-            })?;
-
             let instance = linker
                 .instantiate_async(&mut store, &component)
                 .await
@@ -909,8 +846,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginInstanceHandle<B> {
 
     fn spawn(
         manifest: PluginManifest,
-        wasm_bytes: Vec<u8>,
-        engine: Engine,
+        component: Component,
         epoch_deadline_ticks: u64,
         host_ctx: Arc<PluginHostContext<B>>,
     ) -> Result<Self, RuntimeError> {
@@ -924,8 +860,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginInstanceHandle<B> {
             .spawn(move || {
                 let mut state = match Self::initialize_worker_state(
                     plugin_id,
-                    wasm_bytes,
-                    engine,
+                    component,
                     epoch_deadline_ticks,
                     host_ctx,
                 ) {
@@ -1081,7 +1016,28 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
         sandbox_config: super::sandbox::SandboxConfig,
         permission_config: PermissionConfig,
     ) -> Result<Self, RuntimeError> {
+        Self::with_permissions_config_and_engine(
+            loader.shared_engine().clone(),
+            loader,
+            credential_store,
+            rate_limiters,
+            ssrf_config,
+            sandbox_config,
+            permission_config,
+        )
+    }
+
+    pub(crate) fn with_permissions_config_and_engine(
+        plugin_engine: Arc<super::engine::PluginEngine>,
+        loader: Arc<PluginLoader>,
+        credential_store: Arc<CredentialStore<B>>,
+        rate_limiters: Arc<RateLimiterRegistry>,
+        ssrf_config: SsrfConfig,
+        sandbox_config: super::sandbox::SandboxConfig,
+        permission_config: PermissionConfig,
+    ) -> Result<Self, RuntimeError> {
         Self::with_permissions_config_and_epoch_ticker_factory(
+            plugin_engine,
             loader,
             credential_store,
             rate_limiters,
@@ -1093,6 +1049,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
     }
 
     fn with_permissions_config_and_epoch_ticker_factory<F>(
+        plugin_engine: Arc<super::engine::PluginEngine>,
         loader: Arc<PluginLoader>,
         credential_store: Arc<CredentialStore<B>>,
         rate_limiters: Arc<RateLimiterRegistry>,
@@ -1104,21 +1061,16 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
     where
         F: FnOnce(Engine, Duration) -> Result<EpochTicker, RuntimeError>,
     {
-        // Configure wasmtime engine
-        let mut config = Config::new();
-        config.wasm_component_model(true);
-        config.consume_fuel(true);
-        config.epoch_interruption(true);
-        // Memory limits are enforced per-instance via resource limiter
-
-        let engine =
-            Engine::new(&config).map_err(|e| RuntimeError::WasmtimeError(e.to_string()))?;
+        if !Arc::ptr_eq(&plugin_engine, loader.shared_engine()) {
+            return Err(RuntimeError::WasmtimeError(
+                "plugin runtime engine must match the plugin loader engine".to_string(),
+            ));
+        }
 
         let epoch_deadline_ticks = compute_epoch_deadline_ticks(DEFAULT_EXECUTION_TIMEOUT);
-        let epoch_ticker = epoch_ticker_factory(engine.clone(), DEFAULT_EPOCH_TICK_INTERVAL)?;
+        plugin_engine.ensure_epoch_ticker(DEFAULT_EPOCH_TICK_INTERVAL, epoch_ticker_factory)?;
 
         Ok(Self {
-            engine,
             loader,
             credential_store,
             rate_limiters,
@@ -1126,7 +1078,6 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
             sandbox_config,
             permission_config,
             epoch_deadline_ticks,
-            _epoch_ticker: epoch_ticker,
             instances: RwLock::new(HashMap::new()),
             registry: Arc::new(PluginRegistry::new()),
         })
@@ -1228,15 +1179,13 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
 
         // Initialize the dedicated plugin worker off the async runtime thread.
         let manifest = loaded.manifest.clone();
-        let wasm_bytes = loaded.wasm_bytes.clone();
-        let engine = self.engine.clone();
+        let component = loaded.component.clone();
         let epoch_deadline_ticks = self.epoch_deadline_ticks;
         let handle = Arc::new(
             tokio::task::spawn_blocking(move || {
                 PluginInstanceHandle::spawn(
                     manifest,
-                    wasm_bytes,
-                    engine,
+                    component,
                     epoch_deadline_ticks,
                     host_ctx,
                 )
@@ -1821,6 +1770,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> HookPluginInstance for HookAd
 mod tests {
     use super::*;
     use crate::credentials::MockCredentialBackend;
+    use crate::test_support::plugins::tool_plugin_component_bytes;
     use std::error::Error as _;
     use tempfile::tempdir;
 
@@ -1887,6 +1837,7 @@ mod tests {
         std::fs::create_dir_all(&plugins_dir).unwrap();
 
         let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
+        let plugin_engine = loader.shared_engine().clone();
         let backend = MockCredentialBackend::new(true);
         let credential_store = Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
@@ -1895,6 +1846,7 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
+            plugin_engine,
             loader,
             credential_store,
             Arc::new(RateLimiterRegistry::new()),
@@ -1928,6 +1880,7 @@ mod tests {
         std::fs::create_dir_all(&plugins_dir).unwrap();
 
         let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
+        let plugin_engine = loader.shared_engine().clone();
         let backend = MockCredentialBackend::new(true);
         let credential_store = Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
@@ -1936,6 +1889,7 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
+            plugin_engine,
             loader,
             credential_store,
             Arc::new(RateLimiterRegistry::new()),
@@ -1984,6 +1938,106 @@ mod tests {
         let runtime = create_test_runtime().await;
         let loaded = runtime.load_all().await.unwrap();
         assert!(loaded.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_instantiate_plugin_can_reuse_cached_component_after_unload() {
+        let temp_dir = tempdir().unwrap();
+        let plugins_dir = temp_dir.path().join("plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+
+        let loader = Arc::new(PluginLoader::new(plugins_dir.clone()).unwrap());
+        let backend = MockCredentialBackend::new(true);
+        let credential_store = Arc::new(
+            CredentialStore::new(backend, temp_dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+        let runtime = PluginRuntime::new(loader.clone(), credential_store).unwrap();
+
+        let plugin_path = plugins_dir.join("alpha.wasm");
+        std::fs::write(&plugin_path, tool_plugin_component_bytes()).unwrap();
+
+        let plugin_id = loader.load_plugin(&plugin_path).unwrap();
+        assert_eq!(plugin_id, "alpha");
+
+        runtime.instantiate_plugin("alpha").await.unwrap();
+        assert!(runtime.get_instance("alpha").is_some());
+        assert_eq!(runtime.registry().get_tools().len(), 1);
+
+        runtime.unload_plugin("alpha").unwrap();
+        assert!(runtime.get_instance("alpha").is_none());
+        assert!(runtime.registry().get_tools().is_empty());
+
+        runtime.instantiate_plugin("alpha").await.unwrap();
+        assert!(runtime.get_instance("alpha").is_some());
+        assert_eq!(runtime.registry().get_tools().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reload_plugin_requires_worker_cycle_to_pick_up_new_component() {
+        let temp_dir = tempdir().unwrap();
+        let plugins_dir = temp_dir.path().join("plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+
+        let loader = Arc::new(PluginLoader::new(plugins_dir.clone()).unwrap());
+        let backend = MockCredentialBackend::new(true);
+        let credential_store = Arc::new(
+            CredentialStore::new(backend, temp_dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+        let runtime = PluginRuntime::new(loader.clone(), credential_store).unwrap();
+
+        let plugin_path = plugins_dir.join("alpha.wasm");
+        std::fs::write(&plugin_path, tool_plugin_component_bytes()).unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&plugin_path)
+            .unwrap()
+            .set_times(
+                std::fs::FileTimes::new().set_modified(
+                    std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+                ),
+            )
+            .unwrap();
+
+        loader.load_plugin(&plugin_path).unwrap();
+        runtime.instantiate_plugin("alpha").await.unwrap();
+
+        let initial_loaded_version = loader.get_plugin("alpha").unwrap().manifest.version.clone();
+        let initial_live_version = runtime.get_instance("alpha").unwrap().manifest.version.clone();
+        assert_eq!(initial_live_version, initial_loaded_version);
+
+        std::fs::write(&plugin_path, tool_plugin_component_bytes()).unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&plugin_path)
+            .unwrap()
+            .set_times(
+                std::fs::FileTimes::new().set_modified(
+                    std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_800_000_000),
+                ),
+            )
+            .unwrap();
+
+        loader.reload_plugin("alpha").unwrap();
+
+        let reloaded_version = loader.get_plugin("alpha").unwrap().manifest.version.clone();
+        assert_ne!(reloaded_version, initial_loaded_version);
+        assert_eq!(
+            runtime.get_instance("alpha").unwrap().manifest.version,
+            initial_live_version
+        );
+
+        runtime.unload_plugin("alpha").unwrap();
+        runtime.instantiate_plugin("alpha").await.unwrap();
+
+        let restarted_version = runtime.get_instance("alpha").unwrap().manifest.version.clone();
+        assert_eq!(restarted_version, reloaded_version);
+
+        runtime.unload_plugin("alpha").unwrap();
+        assert!(runtime.get_instance("alpha").is_none());
     }
 
     #[test]
@@ -2323,7 +2377,7 @@ mod tests {
         // Verify the engine was created with fuel consumption enabled
         // by checking that we can create a store and set fuel on it
         let store = Store::new(
-            &runtime.engine,
+            runtime.loader.engine(),
             HostState {
                 plugin_id: "test".to_string(),
                 host_ctx: Arc::new(PluginHostContext::new(
@@ -2349,7 +2403,7 @@ mod tests {
     async fn test_zero_fuel_store() {
         let runtime = create_test_runtime().await;
         let mut store = Store::new(
-            &runtime.engine,
+            runtime.loader.engine(),
             HostState {
                 plugin_id: "test".to_string(),
                 host_ctx: Arc::new(PluginHostContext::new(

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -1072,6 +1072,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
         }
 
         Self::with_permissions_config_and_epoch_ticker_factory(
+            plugin_engine,
             loader,
             credential_store,
             rate_limiters,
@@ -1083,6 +1084,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
     }
 
     fn with_permissions_config_and_epoch_ticker_factory<F>(
+        plugin_engine: Arc<super::engine::PluginEngine>,
         loader: Arc<PluginLoader>,
         credential_store: Arc<CredentialStore<B>>,
         rate_limiters: Arc<RateLimiterRegistry>,
@@ -1094,7 +1096,6 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
     where
         F: FnOnce(Engine, Duration) -> Result<EpochTicker, RuntimeError>,
     {
-        let plugin_engine = loader.shared_engine().clone();
         let epoch_deadline_ticks = compute_epoch_deadline_ticks(DEFAULT_EXECUTION_TIMEOUT);
         plugin_engine
             .ensure_epoch_ticker(DEFAULT_EPOCH_TICK_INTERVAL, epoch_ticker_factory)
@@ -1828,40 +1829,6 @@ mod tests {
         PluginRuntime::new(loader, credential_store).unwrap()
     }
 
-    #[test]
-    fn test_epoch_ticker_start_reports_thread_spawn_error() {
-        fn fail_spawner(
-            _builder: std::thread::Builder,
-            routine: crate::thread_util::NamedThreadRoutine,
-        ) -> io::Result<std::thread::JoinHandle<()>> {
-            drop(routine);
-            Err(io::Error::other("simulated epoch ticker thread exhaustion"))
-        }
-
-        let engine = Engine::default();
-        let err = match EpochTicker::start_with_spawner(
-            engine,
-            DEFAULT_EPOCH_TICK_INTERVAL,
-            fail_spawner,
-        ) {
-            Ok(_) => panic!("epoch ticker startup should report thread spawn failure"),
-            Err(err) => err,
-        };
-
-        let io_source = err
-            .source()
-            .expect("thread spawn error should preserve the original io::Error source");
-        let io_error = io_source
-            .downcast_ref::<io::Error>()
-            .expect("thread spawn error source should remain an io::Error");
-
-        assert_eq!(io_error.kind(), io::ErrorKind::Other);
-        assert_eq!(err.thread_name(), EPOCH_TICKER_THREAD_NAME);
-        assert!(err
-            .to_string()
-            .contains("simulated epoch ticker thread exhaustion"));
-    }
-
     #[tokio::test]
     async fn test_runtime_creation() {
         let runtime = create_test_runtime().await;
@@ -1875,6 +1842,7 @@ mod tests {
         std::fs::create_dir_all(&plugins_dir).unwrap();
 
         let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
+        let plugin_engine = loader.shared_engine().clone();
         let backend = MockCredentialBackend::new(true);
         let credential_store = Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
@@ -1883,6 +1851,7 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
+            plugin_engine,
             loader,
             credential_store,
             Arc::new(RateLimiterRegistry::new()),
@@ -1947,6 +1916,7 @@ mod tests {
         std::fs::create_dir_all(&plugins_dir).unwrap();
 
         let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
+        let plugin_engine = loader.shared_engine().clone();
         let backend = MockCredentialBackend::new(true);
         let credential_store = Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
@@ -1955,6 +1925,7 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
+            plugin_engine,
             loader,
             credential_store,
             Arc::new(RateLimiterRegistry::new()),

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -1073,6 +1073,13 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
         )
     }
 
+    /// Construct a runtime using the exact shared engine already owned by
+    /// `loader`.
+    ///
+    /// Production bootstrap passes `loader.shared_engine().clone()` here. The
+    /// separate `plugin_engine` parameter exists so tests can inject mismatch
+    /// cases deliberately; any non-matching pair is a contract violation and
+    /// returns `RuntimeError::EngineMismatch`.
     pub(crate) fn with_permissions_config_and_engine(
         plugin_engine: Arc<super::engine::PluginEngine>,
         loader: Arc<PluginLoader>,

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -617,8 +617,13 @@ struct RuntimeInitInputs<B: CredentialBackend + Send + Sync + 'static> {
 
 /// Plugin runtime that manages WASM plugin instances
 pub struct PluginRuntime<B: CredentialBackend + 'static> {
-    /// Shared plugin engine retained directly so ticker ownership remains explicit.
+    /// Shared plugin engine retained directly so runtime stores are always created
+    /// on the same engine the loader used to compile plugin components.
     plugin_engine: Arc<super::engine::PluginEngine>,
+
+    /// Shared epoch ticker retained directly so its lifetime matches active runtimes,
+    /// not unrelated loader references to the shared engine.
+    _epoch_ticker: Arc<EpochTicker>,
 
     /// Plugin loader
     loader: Arc<PluginLoader>,
@@ -1112,14 +1117,13 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
         }
 
         let epoch_deadline_ticks = compute_epoch_deadline_ticks(DEFAULT_EXECUTION_TIMEOUT);
-        // PluginEngine retains the ticker Arc internally; the runtime keeps the
-        // PluginEngine Arc so the shared ticker stays alive for the runtime lifetime.
-        plugin_engine
+        let epoch_ticker = plugin_engine
             .ensure_epoch_ticker(DEFAULT_EPOCH_TICK_INTERVAL, epoch_ticker_factory)
             .map_err(RuntimeError::from)?;
 
         Ok(Self {
             plugin_engine,
+            _epoch_ticker: epoch_ticker,
             loader,
             credential_store,
             rate_limiters,
@@ -1981,47 +1985,6 @@ mod tests {
 
         assert_eq!(spawn_error.thread_name(), EPOCH_TICKER_THREAD_NAME);
         assert_eq!(io_error.raw_os_error(), Some(11));
-    }
-
-    #[tokio::test]
-    async fn test_runtime_creation_private_factory_rejects_engine_mismatch() {
-        let temp_dir = tempdir().unwrap();
-        let plugins_dir = temp_dir.path().join("plugins");
-        std::fs::create_dir_all(&plugins_dir).unwrap();
-
-        let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
-        let mismatched_engine = super::super::PluginEngine::for_runtime().unwrap();
-        let backend = MockCredentialBackend::new(true);
-        let credential_store = Arc::new(
-            CredentialStore::new(backend, temp_dir.path().to_path_buf())
-                .await
-                .unwrap(),
-        );
-
-        let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
-            RuntimeInitInputs {
-                plugin_engine: mismatched_engine,
-                loader,
-                credential_store,
-                rate_limiters: Arc::new(RateLimiterRegistry::new()),
-                ssrf_config: SsrfConfig::default(),
-                sandbox_config: crate::plugins::sandbox::SandboxConfig::default(),
-                permission_config: PermissionConfig::default(),
-            },
-            |_engine, _interval| {
-                Err(RuntimeError::ThreadSpawn {
-                    source: StartupThreadSpawnError::new(
-                        EPOCH_TICKER_THREAD_NAME,
-                        io::Error::other("unexpected ticker startup"),
-                    ),
-                })
-            },
-        ) {
-            Ok(_) => panic!("private runtime factory should reject mismatched plugin engines"),
-            Err(err) => err,
-        };
-
-        assert!(matches!(err, RuntimeError::EngineMismatch));
     }
 
     #[tokio::test]

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -1077,10 +1077,6 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
         sandbox_config: super::sandbox::SandboxConfig,
         permission_config: PermissionConfig,
     ) -> Result<Self, RuntimeError> {
-        if !Arc::ptr_eq(&plugin_engine, loader.shared_engine()) {
-            return Err(RuntimeError::EngineMismatch);
-        }
-
         Self::with_permissions_config_and_epoch_ticker_factory(
             RuntimeInitInputs {
                 plugin_engine,
@@ -1111,6 +1107,10 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
             sandbox_config,
             permission_config,
         } = inputs;
+        if !Arc::ptr_eq(&plugin_engine, loader.shared_engine()) {
+            return Err(RuntimeError::EngineMismatch);
+        }
+
         let epoch_deadline_ticks = compute_epoch_deadline_ticks(DEFAULT_EXECUTION_TIMEOUT);
         // PluginEngine retains the ticker Arc internally; the runtime keeps the
         // PluginEngine Arc so the shared ticker stays alive for the runtime lifetime.
@@ -1981,6 +1981,47 @@ mod tests {
 
         assert_eq!(spawn_error.thread_name(), EPOCH_TICKER_THREAD_NAME);
         assert_eq!(io_error.raw_os_error(), Some(11));
+    }
+
+    #[tokio::test]
+    async fn test_runtime_creation_private_factory_rejects_engine_mismatch() {
+        let temp_dir = tempdir().unwrap();
+        let plugins_dir = temp_dir.path().join("plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+
+        let loader = Arc::new(PluginLoader::new(plugins_dir).unwrap());
+        let mismatched_engine = super::super::PluginEngine::for_runtime().unwrap();
+        let backend = MockCredentialBackend::new(true);
+        let credential_store = Arc::new(
+            CredentialStore::new(backend, temp_dir.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+
+        let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
+            RuntimeInitInputs {
+                plugin_engine: mismatched_engine,
+                loader,
+                credential_store,
+                rate_limiters: Arc::new(RateLimiterRegistry::new()),
+                ssrf_config: SsrfConfig::default(),
+                sandbox_config: crate::plugins::sandbox::SandboxConfig::default(),
+                permission_config: PermissionConfig::default(),
+            },
+            |_engine, _interval| {
+                Err(RuntimeError::ThreadSpawn {
+                    source: StartupThreadSpawnError::new(
+                        EPOCH_TICKER_THREAD_NAME,
+                        io::Error::other("unexpected ticker startup"),
+                    ),
+                })
+            },
+        ) {
+            Ok(_) => panic!("private runtime factory should reject mismatched plugin engines"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, RuntimeError::EngineMismatch));
     }
 
     #[tokio::test]

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -601,6 +601,16 @@ pub struct HostState<B: CredentialBackend + Send + Sync + 'static> {
     limiter: PluginResourceLimiter,
 }
 
+struct RuntimeInitInputs<B: CredentialBackend + Send + Sync + 'static> {
+    plugin_engine: Arc<super::engine::PluginEngine>,
+    loader: Arc<PluginLoader>,
+    credential_store: Arc<CredentialStore<B>>,
+    rate_limiters: Arc<RateLimiterRegistry>,
+    ssrf_config: SsrfConfig,
+    sandbox_config: super::sandbox::SandboxConfig,
+    permission_config: PermissionConfig,
+}
+
 // Note: Full WASI integration will be added when we upgrade to wasmtime with
 // component model preview2 support fully stable. For now, we implement the
 // minimal host functions needed by plugins directly.
@@ -1072,6 +1082,27 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
         }
 
         Self::with_permissions_config_and_epoch_ticker_factory(
+            RuntimeInitInputs {
+                plugin_engine,
+                loader,
+                credential_store,
+                rate_limiters,
+                ssrf_config,
+                sandbox_config,
+                permission_config,
+            },
+            |engine, interval| EpochTicker::start(engine, interval).map_err(RuntimeError::from),
+        )
+    }
+
+    fn with_permissions_config_and_epoch_ticker_factory<F>(
+        inputs: RuntimeInitInputs<B>,
+        epoch_ticker_factory: F,
+    ) -> Result<Self, RuntimeError>
+    where
+        F: FnOnce(Engine, Duration) -> Result<EpochTicker, RuntimeError>,
+    {
+        let RuntimeInitInputs {
             plugin_engine,
             loader,
             credential_store,
@@ -1079,23 +1110,7 @@ impl<B: CredentialBackend + Send + Sync + 'static> PluginRuntime<B> {
             ssrf_config,
             sandbox_config,
             permission_config,
-            |engine, interval| EpochTicker::start(engine, interval).map_err(RuntimeError::from),
-        )
-    }
-
-    fn with_permissions_config_and_epoch_ticker_factory<F>(
-        plugin_engine: Arc<super::engine::PluginEngine>,
-        loader: Arc<PluginLoader>,
-        credential_store: Arc<CredentialStore<B>>,
-        rate_limiters: Arc<RateLimiterRegistry>,
-        ssrf_config: SsrfConfig,
-        sandbox_config: super::sandbox::SandboxConfig,
-        permission_config: PermissionConfig,
-        epoch_ticker_factory: F,
-    ) -> Result<Self, RuntimeError>
-    where
-        F: FnOnce(Engine, Duration) -> Result<EpochTicker, RuntimeError>,
-    {
+        } = inputs;
         let epoch_deadline_ticks = compute_epoch_deadline_ticks(DEFAULT_EXECUTION_TIMEOUT);
         plugin_engine
             .ensure_epoch_ticker(DEFAULT_EPOCH_TICK_INTERVAL, epoch_ticker_factory)
@@ -1851,13 +1866,15 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
-            plugin_engine,
-            loader,
-            credential_store,
-            Arc::new(RateLimiterRegistry::new()),
-            SsrfConfig::default(),
-            crate::plugins::sandbox::SandboxConfig::default(),
-            PermissionConfig::default(),
+            RuntimeInitInputs {
+                plugin_engine,
+                loader,
+                credential_store,
+                rate_limiters: Arc::new(RateLimiterRegistry::new()),
+                ssrf_config: SsrfConfig::default(),
+                sandbox_config: crate::plugins::sandbox::SandboxConfig::default(),
+                permission_config: PermissionConfig::default(),
+            },
             |_engine, _interval| {
                 Err(RuntimeError::ThreadSpawn {
                     source: StartupThreadSpawnError::new(
@@ -1925,13 +1942,15 @@ mod tests {
         );
 
         let err = match PluginRuntime::with_permissions_config_and_epoch_ticker_factory(
-            plugin_engine,
-            loader,
-            credential_store,
-            Arc::new(RateLimiterRegistry::new()),
-            SsrfConfig::default(),
-            crate::plugins::sandbox::SandboxConfig::default(),
-            PermissionConfig::default(),
+            RuntimeInitInputs {
+                plugin_engine,
+                loader,
+                credential_store,
+                rate_limiters: Arc::new(RateLimiterRegistry::new()),
+                ssrf_config: SsrfConfig::default(),
+                sandbox_config: crate::plugins::sandbox::SandboxConfig::default(),
+                permission_config: PermissionConfig::default(),
+            },
             |_engine, _interval| {
                 Err(RuntimeError::ThreadSpawn {
                     source: StartupThreadSpawnError::new(

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -167,7 +167,9 @@ fn managed_plugin_activation_entry(entry: &ManagedPluginConfigEntry) -> PluginAc
 
 fn plugin_runtime_init_error_is_fatal(error: &RuntimeError) -> bool {
     match error {
-        RuntimeError::ThreadSpawn { .. } | RuntimeError::EngineMismatch => true,
+        RuntimeError::ThreadSpawn { .. }
+        | RuntimeError::EngineMismatch
+        | RuntimeError::EpochTickerIntervalMismatch { .. } => true,
         // All other runtime init failures intentionally degrade into a report-only
         // bootstrap result so startup can continue without plugin execution.
         RuntimeError::PluginNotFound(_)
@@ -178,7 +180,6 @@ fn plugin_runtime_init_error_is_fatal(error: &RuntimeError) -> bool {
         | RuntimeError::HostError(_)
         | RuntimeError::LoaderError(_)
         | RuntimeError::WasmtimeError(_)
-        | RuntimeError::EpochTickerIntervalMismatch { .. }
         | RuntimeError::PluginError { .. }
         | RuntimeError::FuelExhausted { .. }
         | RuntimeError::CapabilityDenied { .. } => false,
@@ -875,7 +876,7 @@ mod tests {
         assert!(plugin_runtime_init_error_is_fatal(
             &RuntimeError::EngineMismatch
         ));
-        assert!(!plugin_runtime_init_error_is_fatal(
+        assert!(plugin_runtime_init_error_is_fatal(
             &RuntimeError::EpochTickerIntervalMismatch {
                 existing: Duration::from_millis(1),
                 requested: Duration::from_millis(2),

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -88,6 +88,10 @@ pub(crate) struct PluginBootstrapResult {
 }
 
 #[cfg(test)]
+pub(crate) const TEST_FORCE_PLUGIN_ENGINE_INIT_FAILURE_ENV: &str =
+    "CARAPACE_TEST_FORCE_PLUGIN_ENGINE_INIT_FAILURE";
+
+#[cfg(test)]
 pub(crate) const TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV: &str =
     "CARAPACE_TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE";
 
@@ -315,7 +319,7 @@ fn resolve_managed_plugin_path(
 
 fn initialize_plugin_engine() -> Result<Arc<PluginEngine>, LoaderError> {
     #[cfg(test)]
-    if let Some(message) = std::env::var_os(TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV)
+    if let Some(message) = std::env::var_os(TEST_FORCE_PLUGIN_ENGINE_INIT_FAILURE_ENV)
         .filter(|value| !value.is_empty())
     {
         return Err(LoaderError::EngineError(
@@ -331,6 +335,15 @@ fn initialize_plugin_loader(
     signature_config: SignatureConfig,
     plugin_engine: Arc<PluginEngine>,
 ) -> Result<Arc<PluginLoader>, LoaderError> {
+    #[cfg(test)]
+    if let Some(message) = std::env::var_os(TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV)
+        .filter(|value| !value.is_empty())
+    {
+        return Err(LoaderError::EngineError(
+            message.to_string_lossy().into_owned(),
+        ));
+    }
+
     PluginLoader::with_signature_config_and_engine(managed_dir, signature_config, plugin_engine)
         .map(Arc::new)
 }
@@ -427,6 +440,8 @@ pub(crate) fn start_plugin_services(
 
 struct BlockingPluginBootstrapResult {
     report: PluginActivationReport,
+    // Engine initialization can succeed before loader initialization fails, so
+    // these options intentionally represent separate bootstrap phases.
     plugin_engine: Option<Arc<PluginEngine>>,
     loader: Option<Arc<PluginLoader>>,
     loaded_plugin_ids: Vec<String>,
@@ -503,7 +518,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
             push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
             return BlockingPluginBootstrapResult {
                 report,
-                plugin_engine: None,
+                plugin_engine: Some(plugin_engine),
                 loader: None,
                 loaded_plugin_ids: Vec::new(),
                 report_index_by_plugin_id: HashMap::new(),
@@ -843,9 +858,12 @@ pub(crate) fn stop_plugin_services(ws_state: &WsServerState) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::env::ScopedEnv;
+    use serde_json::json;
+    use std::time::Duration;
 
     #[test]
-    fn test_plugin_runtime_thread_spawn_errors_are_fatal() {
+    fn test_plugin_runtime_init_error_classification() {
         assert!(plugin_runtime_init_error_is_fatal(
             &RuntimeError::ThreadSpawn {
                 source: crate::StartupThreadSpawnError::new(
@@ -858,7 +876,54 @@ mod tests {
             &RuntimeError::EngineMismatch
         ));
         assert!(!plugin_runtime_init_error_is_fatal(
+            &RuntimeError::EpochTickerIntervalMismatch {
+                existing: Duration::from_millis(1),
+                requested: Duration::from_millis(2),
+            }
+        ));
+        assert!(!plugin_runtime_init_error_is_fatal(
             &RuntimeError::InstantiationError("component load failed".to_string(),)
         ));
+    }
+
+    #[test]
+    fn discover_and_load_plugins_preserves_engine_on_loader_init_failure() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut env = ScopedEnv::new();
+        env.set(
+            TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV,
+            "forced loader init failure",
+        );
+        let cfg = json!({
+            "plugins": {
+                "entries": {
+                    "alpha": {
+                        "enabled": true,
+                        "installId": "install-alpha",
+                        "requestedAt": 1700000001000u64
+                    }
+                }
+            }
+        });
+
+        let result = discover_and_load_plugins(cfg, temp.path().to_path_buf());
+
+        assert!(result.plugin_engine.is_some());
+        assert!(result.loader.is_none());
+        assert_eq!(
+            result.report.errors,
+            vec!["failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"]
+        );
+        assert_eq!(result.report.entries.len(), 1);
+        assert_eq!(
+            result.report.entries[0].state,
+            PluginActivationState::Failed
+        );
+        assert_eq!(
+            result.report.entries[0].reason.as_deref(),
+            Some(
+                "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"
+            )
+        );
     }
 }

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -9,7 +9,7 @@ use crate::plugins::loader::{is_reserved_plugin_id, load_plugins_manifest, Loade
 use crate::plugins::permissions::PermissionConfig;
 use crate::plugins::sandbox::SandboxConfig;
 use crate::plugins::signature::SignatureConfig;
-use crate::plugins::{PluginLoader, PluginRegistry, PluginRuntime, RuntimeError};
+use crate::plugins::{PluginEngine, PluginLoader, PluginRegistry, PluginRuntime, RuntimeError};
 use crate::server::ws::WsServerState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -312,10 +312,7 @@ fn resolve_managed_plugin_path(
     Ok(canonical_path)
 }
 
-fn initialize_plugin_loader(
-    managed_dir: PathBuf,
-    signature_config: SignatureConfig,
-) -> Result<Arc<PluginLoader>, LoaderError> {
+fn initialize_plugin_engine() -> Result<Arc<PluginEngine>, LoaderError> {
     #[cfg(test)]
     if let Some(message) = std::env::var_os(TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV)
         .filter(|value| !value.is_empty())
@@ -325,7 +322,16 @@ fn initialize_plugin_loader(
         ));
     }
 
-    PluginLoader::with_signature_config(managed_dir, signature_config).map(Arc::new)
+    PluginEngine::for_runtime().map_err(LoaderError::EngineError)
+}
+
+fn initialize_plugin_loader(
+    managed_dir: PathBuf,
+    signature_config: SignatureConfig,
+    plugin_engine: Arc<PluginEngine>,
+) -> Result<Arc<PluginLoader>, LoaderError> {
+    PluginLoader::with_signature_config_and_engine(managed_dir, signature_config, plugin_engine)
+        .map(Arc::new)
 }
 
 fn discover_config_path_plugins(path: &Path) -> Result<Vec<PathBuf>, String> {
@@ -420,6 +426,7 @@ pub(crate) fn start_plugin_services(
 
 struct BlockingPluginBootstrapResult {
     report: PluginActivationReport,
+    plugin_engine: Option<Arc<PluginEngine>>,
     loader: Option<Arc<PluginLoader>>,
     loaded_plugin_ids: Vec<String>,
     report_index_by_plugin_id: HashMap<String, usize>,
@@ -454,6 +461,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
         }
         return BlockingPluginBootstrapResult {
             report,
+            plugin_engine: None,
             loader: None,
             loaded_plugin_ids: Vec::new(),
             report_index_by_plugin_id: HashMap::new(),
@@ -465,7 +473,28 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
     let signature_config = plugin_signature_config_from_config(&cfg);
     let sandbox_config = plugin_sandbox_config_from_config(&cfg);
     let permission_config = PermissionConfig::default();
-    let loader = match initialize_plugin_loader(managed_dir.clone(), signature_config) {
+    let plugin_engine = match initialize_plugin_engine() {
+        Ok(plugin_engine) => plugin_engine,
+        Err(error) => {
+            let reason = format!("failed to initialize plugin engine: {error}");
+            report.errors.push(reason.clone());
+            push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
+            return BlockingPluginBootstrapResult {
+                report,
+                plugin_engine: None,
+                loader: None,
+                loaded_plugin_ids: Vec::new(),
+                report_index_by_plugin_id: HashMap::new(),
+                sandbox_config,
+                permission_config,
+            };
+        }
+    };
+    let loader = match initialize_plugin_loader(
+        managed_dir.clone(),
+        signature_config,
+        plugin_engine.clone(),
+    ) {
         Ok(loader) => loader,
         Err(error) => {
             let reason = format!("failed to initialize plugin loader: {error}");
@@ -473,6 +502,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
             push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
             return BlockingPluginBootstrapResult {
                 report,
+                plugin_engine: None,
                 loader: None,
                 loaded_plugin_ids: Vec::new(),
                 report_index_by_plugin_id: HashMap::new(),
@@ -623,6 +653,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
     let loaded_plugin_ids = loader.list_plugins();
     BlockingPluginBootstrapResult {
         report,
+        plugin_engine: Some(plugin_engine),
         loader: Some(loader),
         loaded_plugin_ids,
         report_index_by_plugin_id,
@@ -661,12 +692,21 @@ pub(crate) async fn bootstrap_plugin_runtime(
 
     let BlockingPluginBootstrapResult {
         mut report,
+        plugin_engine,
         loader,
         loaded_plugin_ids,
         report_index_by_plugin_id,
         sandbox_config,
         permission_config,
     } = blocking;
+
+    let Some(plugin_engine) = plugin_engine else {
+        return Ok(PluginBootstrapResult {
+            registry,
+            runtime: None,
+            activation_report: report,
+        });
+    };
 
     let Some(loader) = loader else {
         return Ok(PluginBootstrapResult {
@@ -705,7 +745,8 @@ pub(crate) async fn bootstrap_plugin_runtime(
         }
     };
 
-    let runtime = match PluginRuntime::with_permissions_config(
+    let runtime = match PluginRuntime::with_permissions_config_and_engine(
+        plugin_engine,
         loader.clone(),
         credential_store,
         Arc::new(crate::plugins::RateLimiterRegistry::new()),

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -174,6 +174,8 @@ fn plugin_runtime_init_error_is_fatal(error: &RuntimeError) -> bool {
         | RuntimeError::HostError(_)
         | RuntimeError::LoaderError(_)
         | RuntimeError::WasmtimeError(_)
+        | RuntimeError::EngineMismatch
+        | RuntimeError::EpochTickerIntervalMismatch { .. }
         | RuntimeError::PluginError { .. }
         | RuntimeError::FuelExhausted { .. }
         | RuntimeError::CapabilityDenied { .. } => false,
@@ -476,7 +478,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
     let plugin_engine = match initialize_plugin_engine() {
         Ok(plugin_engine) => plugin_engine,
         Err(error) => {
-            let reason = format!("failed to initialize plugin engine: {error}");
+            let reason = format!("failed to initialize plugin loader: {error}");
             report.errors.push(reason.clone());
             push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
             return BlockingPluginBootstrapResult {

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -186,7 +186,7 @@ fn plugin_runtime_init_error_is_fatal(error: &RuntimeError) -> bool {
     }
 }
 
-fn push_loader_init_failure_entries(
+fn push_plugin_init_failure_entries(
     report: &mut PluginActivationReport,
     managed_entries: &[ManagedPluginConfigEntry],
     reason: &str,
@@ -495,7 +495,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
         Err(error) => {
             let reason = format!("failed to initialize plugin engine: {error}");
             report.errors.push(reason.clone());
-            push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
+            push_plugin_init_failure_entries(&mut report, &managed_entries, &reason);
             return BlockingPluginBootstrapResult {
                 report,
                 plugin_engine: None,
@@ -516,7 +516,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
         Err(error) => {
             let reason = format!("failed to initialize plugin loader: {error}");
             report.errors.push(reason.clone());
-            push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
+            push_plugin_init_failure_entries(&mut report, &managed_entries, &reason);
             return BlockingPluginBootstrapResult {
                 report,
                 plugin_engine: Some(plugin_engine),

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -163,7 +163,7 @@ fn managed_plugin_activation_entry(entry: &ManagedPluginConfigEntry) -> PluginAc
 
 fn plugin_runtime_init_error_is_fatal(error: &RuntimeError) -> bool {
     match error {
-        RuntimeError::ThreadSpawn { .. } => true,
+        RuntimeError::ThreadSpawn { .. } | RuntimeError::EngineMismatch => true,
         // All other runtime init failures intentionally degrade into a report-only
         // bootstrap result so startup can continue without plugin execution.
         RuntimeError::PluginNotFound(_)
@@ -174,7 +174,6 @@ fn plugin_runtime_init_error_is_fatal(error: &RuntimeError) -> bool {
         | RuntimeError::HostError(_)
         | RuntimeError::LoaderError(_)
         | RuntimeError::WasmtimeError(_)
-        | RuntimeError::EngineMismatch
         | RuntimeError::EpochTickerIntervalMismatch { .. }
         | RuntimeError::PluginError { .. }
         | RuntimeError::FuelExhausted { .. }
@@ -478,7 +477,7 @@ fn discover_and_load_plugins(cfg: Value, state_dir: PathBuf) -> BlockingPluginBo
     let plugin_engine = match initialize_plugin_engine() {
         Ok(plugin_engine) => plugin_engine,
         Err(error) => {
-            let reason = format!("failed to initialize plugin loader: {error}");
+            let reason = format!("failed to initialize plugin engine: {error}");
             report.errors.push(reason.clone());
             push_loader_init_failure_entries(&mut report, &managed_entries, &reason);
             return BlockingPluginBootstrapResult {
@@ -854,6 +853,9 @@ mod tests {
                     std::io::Error::other("simulated thread exhaustion"),
                 ),
             }
+        ));
+        assert!(plugin_runtime_init_error_is_fatal(
+            &RuntimeError::EngineMismatch
         ));
         assert!(!plugin_runtime_init_error_is_fatal(
             &RuntimeError::InstantiationError("component load failed".to_string(),)

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1256,6 +1256,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bootstrap_plugin_runtime_reports_loader_init_failure_per_managed_plugin() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut env = ScopedEnv::new();
+        env.set(
+            crate::server::plugin_bootstrap::TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV,
+            "forced loader init failure",
+        );
+        let cfg = json!({
+            "plugins": {
+                "entries": {
+                    "alpha": {
+                        "enabled": true,
+                        "installId": "install-alpha",
+                        "requestedAt": 1700000001000u64
+                    },
+                    "beta": {
+                        "enabled": false,
+                        "installId": "install-beta",
+                        "requestedAt": 1700000002000u64
+                    }
+                }
+            }
+        });
+
+        let result = bootstrap_plugin_runtime(&cfg, temp.path())
+            .await
+            .expect("plugin bootstrap should not fatally fail");
+        let report = result.activation_report;
+
+        assert!(result.runtime.is_none());
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(
+            report.errors[0],
+            "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"
+        );
+        assert_eq!(report.entries.len(), 2);
+
+        let alpha = report
+            .entries
+            .iter()
+            .find(|entry| entry.name == "alpha")
+            .expect("alpha entry");
+        assert!(alpha.enabled);
+        assert_eq!(alpha.state, PluginActivationState::Failed);
+        assert_eq!(
+            alpha.reason.as_deref(),
+            Some(
+                "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"
+            )
+        );
+        assert_eq!(alpha.install_id.as_ref(), Some(&json!("install-alpha")));
+        assert_eq!(alpha.requested_at, Some(1700000001000u64));
+
+        let beta = report
+            .entries
+            .iter()
+            .find(|entry| entry.name == "beta")
+            .expect("beta entry");
+        assert!(!beta.enabled);
+        assert_eq!(beta.state, PluginActivationState::Disabled);
+        assert_eq!(
+            beta.reason.as_deref(),
+            Some("managed plugin is disabled in plugins.entries")
+        );
+        assert_eq!(beta.install_id.as_ref(), Some(&json!("install-beta")));
+        assert_eq!(beta.requested_at, Some(1700000002000u64));
+    }
+
+    #[tokio::test]
     async fn bootstrap_plugin_runtime_ignores_stray_managed_wasm_files() {
         let temp = tempfile::tempdir().expect("temp dir");
         write_minimal_wasm(&temp.path().join("plugins"), "rogue");

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -692,7 +692,7 @@ mod tests {
     use crate::server::plugin_bootstrap::{
         bootstrap_plugin_runtime, load_plugin_candidate, start_plugin_services,
         stop_plugin_services, PluginActivationEntry, PluginActivationReport,
-        PluginActivationSource, PluginActivationState, TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV,
+        PluginActivationSource, PluginActivationState, TEST_FORCE_PLUGIN_ENGINE_INIT_FAILURE_ENV,
     };
     use crate::server::ws::WsServerConfig;
     use crate::test_support::{env::ScopedEnv, plugins::tool_plugin_component_bytes};
@@ -1191,8 +1191,8 @@ mod tests {
         let temp = tempfile::tempdir().expect("temp dir");
         let mut env = ScopedEnv::new();
         env.set(
-            TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV,
-            "forced loader init failure",
+            TEST_FORCE_PLUGIN_ENGINE_INIT_FAILURE_ENV,
+            "forced engine init failure",
         );
         let cfg = json!({
             "plugins": {
@@ -1220,7 +1220,7 @@ mod tests {
         assert_eq!(report.errors.len(), 1);
         assert_eq!(
             report.errors[0],
-            "failed to initialize plugin engine: Wasmtime engine error: forced loader init failure"
+            "failed to initialize plugin engine: Wasmtime engine error: forced engine init failure"
         );
         assert_eq!(report.entries.len(), 2);
 
@@ -1234,7 +1234,7 @@ mod tests {
         assert_eq!(
             alpha.reason.as_deref(),
             Some(
-                "failed to initialize plugin engine: Wasmtime engine error: forced loader init failure"
+                "failed to initialize plugin engine: Wasmtime engine error: forced engine init failure"
             )
         );
         assert_eq!(alpha.install_id.as_ref(), Some(&json!("install-alpha")));

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1187,7 +1187,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bootstrap_plugin_runtime_reports_loader_init_failure_per_managed_plugin() {
+    async fn bootstrap_plugin_runtime_reports_engine_init_failure_per_managed_plugin() {
         let temp = tempfile::tempdir().expect("temp dir");
         let mut env = ScopedEnv::new();
         env.set(
@@ -1220,7 +1220,7 @@ mod tests {
         assert_eq!(report.errors.len(), 1);
         assert_eq!(
             report.errors[0],
-            "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"
+            "failed to initialize plugin engine: Wasmtime engine error: forced loader init failure"
         );
         assert_eq!(report.entries.len(), 2);
 
@@ -1234,7 +1234,7 @@ mod tests {
         assert_eq!(
             alpha.reason.as_deref(),
             Some(
-                "failed to initialize plugin loader: Wasmtime engine error: forced loader init failure"
+                "failed to initialize plugin engine: Wasmtime engine error: forced loader init failure"
             )
         );
         assert_eq!(alpha.install_id.as_ref(), Some(&json!("install-alpha")));


### PR DESCRIPTION
## Summary
- compile plugin components once during load and cache the compiled `Component` on `LoadedPlugin`
- introduce a shared `PluginEngine` so the loader and runtime use the same wasmtime engine and a single epoch ticker
- instantiate workers from the cached component instead of recompiling raw wasm bytes
- keep standalone validation on a fallback engine with the same config, and document that reload still requires unload/re-instantiation for live workers

## Why
Closes #333.

The issue text frames this as a per-invocation recompilation problem, but the current runtime only recompiles at plugin instantiation/startup, not on each plugin call. This fix targets the real problems:
- plugin startup latency
- steady-state memory usage from retaining raw wasm bytes
- the structural invariant that compiled components must be instantiated on the same engine they were compiled against

## Testing
- `scripts/cargo-serial check`
- `scripts/cargo-serial nextest run test_instantiate_plugin_can_reuse_cached_component_after_unload test_reload_plugin_requires_worker_cycle_to_pick_up_new_component bootstrap_plugin_runtime_activates_valid_managed_tool_component bootstrap_plugin_runtime_activates_valid_config_path_tool_component`