### PR TITLE
Guarantee Signal read receipts before typing starts

### DIFF
--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -2319,6 +2319,123 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_inbound_signal_read_receipt_is_sent_before_typing_starts() {
+        let _config_guard = crate::test_support::config::ScopedConfigCache::new();
+        crate::config::clear_cache();
+        crate::config::update_cache(
+            serde_json::json!({
+                "channels": {
+                    "signal": {
+                        "features": {
+                            "typing": {
+                                "enabled": true,
+                                "intervalSeconds": 30
+                            },
+                            "readReceipts": {
+                                "enabled": true
+                            }
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({}),
+        );
+
+        let plugin = Arc::new(ActivityRecordingChannel::new());
+        let plugin_registry = Arc::new(PluginRegistry::new());
+        plugin_registry.register_channel("signal".to_string(), plugin.clone());
+        let (state, _tmp) = make_test_state_with_plugin_registry(plugin_registry);
+        let (read_receipt_shutdown_tx, read_receipt_shutdown_rx) =
+            tokio::sync::watch::channel(false);
+        state
+            .activity_service()
+            .spawn_read_receipt_worker(state.clone(), read_receipt_shutdown_rx);
+
+        let chat_id = "+15551234567";
+        let claimed_read_receipt = state
+            .activity_service()
+            .try_claim_read_receipt(
+                "signal",
+                ReadReceiptContext {
+                    recipient: chat_id.to_string(),
+                    timestamp: Some(1706745600000),
+                    ..Default::default()
+                },
+            )
+            .expect("receipt ownership should be claimable before inbound append");
+
+        let dispatch = crate::channels::inbound::dispatch_inbound_text_with_options(
+            &state,
+            "signal",
+            chat_id,
+            chat_id,
+            "Hello",
+            Some(chat_id.to_string()),
+            crate::channels::inbound::InboundDispatchOptions {
+                claimed_read_receipt: Some(claimed_read_receipt),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("inbound dispatch should succeed");
+
+        assert_eq!(
+            plugin.events(),
+            vec!["read"],
+            "the claimed Signal receipt should be sent before the run can start typing"
+        );
+
+        let session_key = {
+            let registry = state.agent_run_registry.lock();
+            registry
+                .get(&dispatch.run_id)
+                .expect("inbound dispatch should register the run")
+                .session_key
+                .clone()
+        };
+
+        let provider = Arc::new(MockProvider::new(vec![vec![StreamEvent::Stop {
+            reason: StopReason::EndTurn,
+            usage: TokenUsage {
+                input_tokens: 5,
+                output_tokens: 0,
+            },
+        }]]));
+        let config = AgentConfig {
+            max_turns: 5,
+            deliver: true,
+            ..Default::default()
+        };
+
+        let result = execute_run(
+            dispatch.run_id,
+            session_key,
+            config,
+            state.clone(),
+            provider,
+            CancellationToken::new(),
+        )
+        .await;
+        assert!(result.is_ok(), "execute_run failed: {:?}", result.err());
+
+        assert_eq!(
+            plugin.events(),
+            vec!["read", "start", "stop"],
+            "Signal should be marked read before typing begins"
+        );
+
+        let receipt_tasks = state.activity_service().read_receipt_queue().list();
+        assert_eq!(receipt_tasks.len(), 1);
+        assert_eq!(receipt_tasks[0].state, crate::tasks::TaskState::Done);
+
+        read_receipt_shutdown_tx
+            .send(true)
+            .expect("read receipt worker shutdown signal should send");
+        state.shutdown_activity_service().await;
+        crate::config::clear_cache();
+    }
+
+    #[tokio::test]
     async fn test_execute_run_skips_channel_activity_when_delivery_disabled() {
         let _config_guard = crate::test_support::config::ScopedConfigCache::new();
         crate::config::clear_cache();

--- a/src/channels/activity.rs
+++ b/src/channels/activity.rs
@@ -3401,6 +3401,43 @@ mod tests {
         assert_eq!(tasks[0].state, crate::tasks::TaskState::RetryWait);
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_acknowledge_read_receipt_now_falls_back_to_direct_send_when_persist_fails() {
+        let plugin = Arc::new(MockChannel::new(ChannelCapabilities {
+            read_receipts: true,
+            ..Default::default()
+        }));
+        let plugin_registry = Arc::new(PluginRegistry::new());
+        plugin_registry.register_channel("signal".to_string(), plugin.clone());
+        let service = Arc::new(ActivityService::with_read_receipt_queue_for_test(Arc::new(
+            TaskQueue::with_capacity_limit(None, Some(0)),
+        )));
+        let state = Arc::new(
+            crate::server::ws::WsServerState::new(crate::server::ws::WsServerConfig::default())
+                .with_plugin_registry(plugin_registry)
+                .with_activity_service(service.clone()),
+        );
+
+        service
+            .acknowledge_read_receipt_now(
+                state.as_ref(),
+                "signal",
+                ReadReceiptContext {
+                    recipient: "+15551234567".to_string(),
+                    timestamp: Some(123),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("persist failure should fall back to direct read receipt dispatch");
+
+        assert_eq!(plugin.mark_read_count.load(Ordering::Relaxed), 1);
+        assert!(
+            service.read_receipt_queue().list().is_empty(),
+            "synthetic failed enqueue should not leave a persisted queue entry"
+        );
+    }
+
     #[test]
     fn test_inline_read_receipt_result_reports_sent_but_unfinalized_done_state() {
         let result = ActivityService::inline_read_receipt_result(

--- a/src/channels/activity.rs
+++ b/src/channels/activity.rs
@@ -547,19 +547,26 @@ impl ActivityService {
             .await
     }
 
-    pub async fn enqueue_ready_read_receipt(
+    async fn persist_ready_read_receipt_task(
         &self,
         channel_id: &str,
         ctx: ReadReceiptContext,
-    ) -> Option<String> {
-        let task = self
-            .read_receipt_queue
+    ) -> crate::tasks::DurableTask {
+        self.read_receipt_queue
             .enqueue_async(
                 serde_json::to_value(ReadReceiptTaskPayload::new(channel_id, ctx))
                     .expect("read receipt task payload should serialize"),
                 None,
             )
-            .await;
+            .await
+    }
+
+    pub async fn enqueue_ready_read_receipt(
+        &self,
+        channel_id: &str,
+        ctx: ReadReceiptContext,
+    ) -> Option<String> {
+        let task = self.persist_ready_read_receipt_task(channel_id, ctx).await;
         if task.state == crate::tasks::TaskState::Failed {
             tracing::warn!(
                 channel = %channel_id,
@@ -576,18 +583,114 @@ impl ActivityService {
         }
     }
 
+    async fn claim_ready_read_receipt_task(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<crate::tasks::DurableTask>, String> {
+        tokio::task::spawn_blocking({
+            let queue = self.read_receipt_queue.clone();
+            let task_id = task_id.to_string();
+            move || queue.claim_task(&task_id, crate::time::unix_now_ms_u64())
+        })
+        .await
+        .map_err(|err| format!("read receipt inline-claim worker failed: {err}"))
+    }
+
+    async fn finalize_read_receipt_task(
+        &self,
+        task_id: &str,
+        outcome: &TaskExecutionOutcome,
+    ) -> Result<(), String> {
+        let updated = match outcome {
+            TaskExecutionOutcome::Done { run_id } => {
+                tokio::task::spawn_blocking({
+                    let queue = self.read_receipt_queue.clone();
+                    let task_id = task_id.to_string();
+                    let run_id = run_id.clone();
+                    move || queue.mark_done(&task_id, run_id.as_deref())
+                })
+                .await
+            }
+            TaskExecutionOutcome::RetryWait { delay_ms, error } => {
+                tokio::task::spawn_blocking({
+                    let queue = self.read_receipt_queue.clone();
+                    let task_id = task_id.to_string();
+                    let error = error.clone();
+                    let delay_ms = *delay_ms;
+                    move || queue.mark_retry_wait(&task_id, delay_ms, &error)
+                })
+                .await
+            }
+            TaskExecutionOutcome::Blocked { reason, category } => {
+                tokio::task::spawn_blocking({
+                    let queue = self.read_receipt_queue.clone();
+                    let task_id = task_id.to_string();
+                    let reason = reason.clone();
+                    let category = *category;
+                    move || queue.mark_blocked(&task_id, &reason, category)
+                })
+                .await
+            }
+            TaskExecutionOutcome::Failed { error } => {
+                tokio::task::spawn_blocking({
+                    let queue = self.read_receipt_queue.clone();
+                    let task_id = task_id.to_string();
+                    let error = error.clone();
+                    move || queue.mark_failed(&task_id, &error)
+                })
+                .await
+            }
+            TaskExecutionOutcome::Cancelled { reason } => {
+                tokio::task::spawn_blocking({
+                    let queue = self.read_receipt_queue.clone();
+                    let task_id = task_id.to_string();
+                    let reason = reason.clone();
+                    move || queue.mark_cancelled(&task_id, reason.as_deref())
+                })
+                .await
+            }
+        }
+        .map_err(|err| format!("read receipt inline-state worker failed: {err}"))?;
+
+        if updated {
+            Ok(())
+        } else {
+            Err(format!(
+                "failed to update read receipt task '{}' after inline dispatch",
+                task_id
+            ))
+        }
+    }
+
     pub async fn acknowledge_read_receipt_now(
         &self,
         state: &WsServerState,
         channel_id: &str,
         ctx: ReadReceiptContext,
     ) -> Result<(), String> {
-        if self
-            .enqueue_ready_read_receipt(channel_id, ctx.clone())
-            .await
-            .is_some()
-        {
-            return Ok(());
+        let task = self
+            .persist_ready_read_receipt_task(channel_id, ctx.clone())
+            .await;
+        if task.state != crate::tasks::TaskState::Failed {
+            let task_id = task.id.clone();
+            let Some(claimed_task) = self.claim_ready_read_receipt_task(&task_id).await? else {
+                return Err(format!(
+                    "failed to claim newly persisted read receipt task '{}' for immediate dispatch",
+                    task_id
+                ));
+            };
+            let outcome = execute_read_receipt_task(state, claimed_task).await;
+            self.finalize_read_receipt_task(&task_id, &outcome).await?;
+            return match outcome {
+                TaskExecutionOutcome::Done { .. } | TaskExecutionOutcome::RetryWait { .. } => {
+                    Ok(())
+                }
+                TaskExecutionOutcome::Blocked { reason, .. } => Err(reason),
+                TaskExecutionOutcome::Failed { error } => Err(error),
+                TaskExecutionOutcome::Cancelled { reason } => Err(reason.unwrap_or_else(|| {
+                    "read receipt task was cancelled during immediate dispatch".to_string()
+                })),
+            };
         }
 
         tracing::warn!(
@@ -1106,50 +1209,53 @@ pub(crate) async fn send_read_receipt_immediately(
         })
 }
 
+async fn execute_read_receipt_task(
+    state: &WsServerState,
+    task: crate::tasks::DurableTask,
+) -> TaskExecutionOutcome {
+    if let Some(error) = read_receipt_policy_violation_error(&task) {
+        return TaskExecutionOutcome::Failed { error };
+    }
+
+    let payload = match ReadReceiptTaskPayload::from_value(task.payload) {
+        Ok(payload) => payload,
+        Err(err) => {
+            return TaskExecutionOutcome::Failed {
+                error: format!("invalid read receipt task payload: {err}"),
+            };
+        }
+    };
+
+    let plugin = match prepare_read_receipt_dispatch_plugin(state, &payload.channel_id).await {
+        Ok(plugin) => plugin,
+        Err(ReadReceiptDispatchError::Retryable(err)) => {
+            return TaskExecutionOutcome::RetryWait {
+                delay_ms: READ_RECEIPT_RETRY_DELAY_MS,
+                error: err,
+            };
+        }
+        Err(ReadReceiptDispatchError::Permanent(err)) => {
+            return TaskExecutionOutcome::Failed { error: err };
+        }
+    };
+
+    match send_verified_read_receipt_with_plugin(plugin, &payload.channel_id, payload.context).await
+    {
+        Ok(()) => TaskExecutionOutcome::Done { run_id: None },
+        Err(ReadReceiptDispatchError::Retryable(err)) => TaskExecutionOutcome::RetryWait {
+            delay_ms: READ_RECEIPT_RETRY_DELAY_MS,
+            error: err,
+        },
+        Err(ReadReceiptDispatchError::Permanent(err)) => {
+            TaskExecutionOutcome::Failed { error: err }
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl TaskExecutor for ReadReceiptTaskExecutor {
     async fn execute(&self, task: crate::tasks::DurableTask) -> TaskExecutionOutcome {
-        if let Some(error) = read_receipt_policy_violation_error(&task) {
-            return TaskExecutionOutcome::Failed { error };
-        }
-
-        let payload = match ReadReceiptTaskPayload::from_value(task.payload) {
-            Ok(payload) => payload,
-            Err(err) => {
-                return TaskExecutionOutcome::Failed {
-                    error: format!("invalid read receipt task payload: {err}"),
-                };
-            }
-        };
-
-        let plugin =
-            match prepare_read_receipt_dispatch_plugin(self.state.as_ref(), &payload.channel_id)
-                .await
-            {
-                Ok(plugin) => plugin,
-                Err(ReadReceiptDispatchError::Retryable(err)) => {
-                    return TaskExecutionOutcome::RetryWait {
-                        delay_ms: READ_RECEIPT_RETRY_DELAY_MS,
-                        error: err,
-                    };
-                }
-                Err(ReadReceiptDispatchError::Permanent(err)) => {
-                    return TaskExecutionOutcome::Failed { error: err };
-                }
-            };
-
-        match send_verified_read_receipt_with_plugin(plugin, &payload.channel_id, payload.context)
-            .await
-        {
-            Ok(()) => TaskExecutionOutcome::Done { run_id: None },
-            Err(ReadReceiptDispatchError::Retryable(err)) => TaskExecutionOutcome::RetryWait {
-                delay_ms: READ_RECEIPT_RETRY_DELAY_MS,
-                error: err,
-            },
-            Err(ReadReceiptDispatchError::Permanent(err)) => {
-                TaskExecutionOutcome::Failed { error: err }
-            }
-        }
+        execute_read_receipt_task(self.state.as_ref(), task).await
     }
 }
 

--- a/src/channels/activity.rs
+++ b/src/channels/activity.rs
@@ -663,6 +663,41 @@ impl ActivityService {
         }
     }
 
+    fn inline_read_receipt_result(
+        outcome: TaskExecutionOutcome,
+        finalize_result: Result<(), String>,
+    ) -> Result<(), String> {
+        match (outcome, finalize_result) {
+            (TaskExecutionOutcome::Done { .. }, Ok(())) => Ok(()),
+            (TaskExecutionOutcome::Done { .. }, Err(err)) => Err(format!(
+                "read receipt was sent but durable task finalization failed: {err}"
+            )),
+            (TaskExecutionOutcome::RetryWait { error, .. }, Ok(())) => Err(error),
+            (TaskExecutionOutcome::RetryWait { error, .. }, Err(err)) => Err(format!(
+                "{error}; additionally failed to persist the retry schedule: {err}"
+            )),
+            (TaskExecutionOutcome::Blocked { reason, .. }, Ok(())) => Err(reason),
+            (TaskExecutionOutcome::Blocked { reason, .. }, Err(err)) => Err(format!(
+                "{reason}; additionally failed to persist the blocked state: {err}"
+            )),
+            (TaskExecutionOutcome::Failed { error }, Ok(())) => Err(error),
+            (TaskExecutionOutcome::Failed { error }, Err(err)) => Err(format!(
+                "{error}; additionally failed to persist the failure state: {err}"
+            )),
+            (TaskExecutionOutcome::Cancelled { reason }, Ok(())) => {
+                Err(reason.unwrap_or_else(|| {
+                    "read receipt task was cancelled during immediate dispatch".to_string()
+                }))
+            }
+            (TaskExecutionOutcome::Cancelled { reason }, Err(err)) => Err(format!(
+                "{}; additionally failed to persist the cancellation state: {err}",
+                reason.unwrap_or_else(|| {
+                    "read receipt task was cancelled during immediate dispatch".to_string()
+                })
+            )),
+        }
+    }
+
     pub async fn acknowledge_read_receipt_now(
         &self,
         state: &WsServerState,
@@ -675,16 +710,8 @@ impl ActivityService {
         if task.state != crate::tasks::TaskState::Failed {
             let task_id = task.id.clone();
             let outcome = execute_read_receipt_task(state, task).await;
-            self.finalize_read_receipt_task(&task_id, &outcome).await?;
-            return match outcome {
-                TaskExecutionOutcome::Done { .. } => Ok(()),
-                TaskExecutionOutcome::RetryWait { error, .. } => Err(error),
-                TaskExecutionOutcome::Blocked { reason, .. } => Err(reason),
-                TaskExecutionOutcome::Failed { error } => Err(error),
-                TaskExecutionOutcome::Cancelled { reason } => Err(reason.unwrap_or_else(|| {
-                    "read receipt task was cancelled during immediate dispatch".to_string()
-                })),
-            };
+            let finalize_result = self.finalize_read_receipt_task(&task_id, &outcome).await;
+            return Self::inline_read_receipt_result(outcome, finalize_result);
         }
 
         tracing::warn!(
@@ -3372,6 +3399,25 @@ mod tests {
         let tasks = service.read_receipt_queue().list();
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].state, crate::tasks::TaskState::RetryWait);
+    }
+
+    #[test]
+    fn test_inline_read_receipt_result_reports_sent_but_unfinalized_done_state() {
+        let result = ActivityService::inline_read_receipt_result(
+            TaskExecutionOutcome::Done { run_id: None },
+            Err("queue update failed".to_string()),
+        );
+
+        let err =
+            result.expect_err("done outcome with failed finalization should surface an error");
+        assert!(
+            err.contains("read receipt was sent but durable task finalization failed"),
+            "unexpected error message: {err}"
+        );
+        assert!(
+            err.contains("queue update failed"),
+            "unexpected error message: {err}"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/channels/activity.rs
+++ b/src/channels/activity.rs
@@ -561,6 +561,20 @@ impl ActivityService {
             .await
     }
 
+    async fn persist_running_read_receipt_task(
+        &self,
+        channel_id: &str,
+        ctx: ReadReceiptContext,
+    ) -> crate::tasks::DurableTask {
+        self.read_receipt_queue
+            .enqueue_running_async_with_policy(
+                serde_json::to_value(ReadReceiptTaskPayload::new(channel_id, ctx))
+                    .expect("read receipt task payload should serialize"),
+                crate::tasks::TaskPolicy::default(),
+            )
+            .await
+    }
+
     pub async fn enqueue_ready_read_receipt(
         &self,
         channel_id: &str,
@@ -581,19 +595,6 @@ impl ActivityService {
             self.read_receipt_wake.notify_one();
             Some(task.id)
         }
-    }
-
-    async fn claim_ready_read_receipt_task(
-        &self,
-        task_id: &str,
-    ) -> Result<Option<crate::tasks::DurableTask>, String> {
-        tokio::task::spawn_blocking({
-            let queue = self.read_receipt_queue.clone();
-            let task_id = task_id.to_string();
-            move || queue.claim_task(&task_id, crate::time::unix_now_ms_u64())
-        })
-        .await
-        .map_err(|err| format!("read receipt inline-claim worker failed: {err}"))
     }
 
     async fn finalize_read_receipt_task(
@@ -669,22 +670,15 @@ impl ActivityService {
         ctx: ReadReceiptContext,
     ) -> Result<(), String> {
         let task = self
-            .persist_ready_read_receipt_task(channel_id, ctx.clone())
+            .persist_running_read_receipt_task(channel_id, ctx.clone())
             .await;
         if task.state != crate::tasks::TaskState::Failed {
             let task_id = task.id.clone();
-            let Some(claimed_task) = self.claim_ready_read_receipt_task(&task_id).await? else {
-                return Err(format!(
-                    "failed to claim newly persisted read receipt task '{}' for immediate dispatch",
-                    task_id
-                ));
-            };
-            let outcome = execute_read_receipt_task(state, claimed_task).await;
+            let outcome = execute_read_receipt_task(state, task).await;
             self.finalize_read_receipt_task(&task_id, &outcome).await?;
             return match outcome {
-                TaskExecutionOutcome::Done { .. } | TaskExecutionOutcome::RetryWait { .. } => {
-                    Ok(())
-                }
+                TaskExecutionOutcome::Done { .. } => Ok(()),
+                TaskExecutionOutcome::RetryWait { error, .. } => Err(error),
                 TaskExecutionOutcome::Blocked { reason, .. } => Err(reason),
                 TaskExecutionOutcome::Failed { error } => Err(error),
                 TaskExecutionOutcome::Cancelled { reason } => Err(reason.unwrap_or_else(|| {
@@ -3348,6 +3342,36 @@ mod tests {
             .expect("completion task should join cleanly")
             .expect("direct-send fallback should succeed");
         assert_eq!(plugin.mark_read_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_acknowledge_read_receipt_now_returns_err_when_retry_is_scheduled() {
+        let service = Arc::new(ActivityService::new());
+        let state = Arc::new(
+            crate::server::ws::WsServerState::new(crate::server::ws::WsServerConfig::default())
+                .with_activity_service(service.clone()),
+        );
+
+        let err = service
+            .acknowledge_read_receipt_now(
+                state.as_ref(),
+                "signal",
+                ReadReceiptContext {
+                    recipient: "+15551234567".to_string(),
+                    timestamp: Some(123),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("retryable inline dispatch should not report success");
+
+        assert!(
+            err.contains("plugin registry unavailable"),
+            "retryable error should surface the underlying dispatch reason"
+        );
+        let tasks = service.read_receipt_queue().list();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].state, crate::tasks::TaskState::RetryWait);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -597,6 +597,28 @@ impl TaskQueue {
         claimed
     }
 
+    /// Claim one specific due task and move it to `running`.
+    pub fn claim_task(&self, id: &str, now: u64) -> Option<DurableTask> {
+        let mut claimed = None;
+        {
+            let mut tasks = self.tasks.write();
+            if let Some(task) = tasks.iter_mut().find(|task| task.id == id) {
+                if is_due(task, now) {
+                    task.state = TaskState::Running;
+                    task.attempts = task.attempts.saturating_add(1);
+                    task.next_run_at_ms = None;
+                    task.updated_at_ms = now;
+                    claimed = Some(task.clone());
+                }
+            }
+        }
+
+        if claimed.is_some() {
+            self.flush_to_disk();
+        }
+        claimed
+    }
+
     /// Mark a task as done.
     pub fn mark_done(&self, id: &str, run_id: Option<&str>) -> bool {
         self.update_task_if(
@@ -1104,6 +1126,19 @@ mod tests {
         assert_eq!(claimed[0].id, task.id);
         assert_eq!(claimed[0].state, TaskState::Running);
         assert_eq!(claimed[0].attempts, 1);
+    }
+
+    #[test]
+    fn test_claim_task_marks_specific_due_task_running_and_increments_attempts() {
+        let queue = TaskQueue::in_memory();
+        let task = queue.enqueue(serde_json::json!({"kind":"demo"}), Some(1));
+
+        let claimed = queue
+            .claim_task(&task.id, 10)
+            .expect("specific due task should be claimable");
+        assert_eq!(claimed.id, task.id);
+        assert_eq!(claimed.state, TaskState::Running);
+        assert_eq!(claimed.attempts, 1);
     }
 
     #[test]

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -307,6 +307,10 @@ impl TaskQueue {
     /// This is for call sites that durably persist work before executing it
     /// inline, while still relying on queue recovery to resume the work after
     /// a crash or restart.
+    ///
+    /// The same capacity-full contract as [`Self::enqueue`] applies: on full
+    /// queue with no evictable terminal task, the returned `Failed` task ID is
+    /// synthetic and not present in the queue.
     pub fn enqueue_running_with_policy(&self, payload: Value, policy: TaskPolicy) -> DurableTask {
         let now = now_ms();
         let mut task = self.build_task(
@@ -1183,6 +1187,24 @@ mod tests {
         let stored = queue.get(&task.id).expect("task should be persisted");
         assert_eq!(stored.state, TaskState::Running);
         assert_eq!(stored.attempts, 1);
+    }
+
+    #[test]
+    fn test_enqueue_running_with_policy_returns_synthetic_failed_task_when_queue_is_full() {
+        let queue = TaskQueue::with_capacity_limit(None, Some(0));
+        let task = queue
+            .enqueue_running_with_policy(serde_json::json!({"kind":"demo"}), TaskPolicy::default());
+
+        assert_eq!(task.state, TaskState::Failed);
+        assert_eq!(task.attempts, 0);
+        assert_eq!(
+            task.last_error.as_deref(),
+            Some(TASK_QUEUE_FULL_NO_EVICTION_ERROR)
+        );
+        assert!(
+            queue.get(&task.id).is_none(),
+            "failed enqueue should return a synthetic task id, not a persisted queue entry"
+        );
     }
 
     #[test]

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -302,6 +302,33 @@ impl TaskQueue {
         task
     }
 
+    /// Add a new task that starts already claimed in `running` state.
+    ///
+    /// This is for call sites that durably persist work before executing it
+    /// inline, while still relying on queue recovery to resume the work after
+    /// a crash or restart.
+    pub fn enqueue_running_with_policy(&self, payload: Value, policy: TaskPolicy) -> DurableTask {
+        let now = now_ms();
+        let mut task = self.build_task(
+            payload,
+            BuildTaskParams {
+                state: TaskState::Running,
+                next_run_at_ms: None,
+                last_error: None,
+                policy,
+                blocked_reason: None,
+                now,
+            },
+        );
+        task.attempts = 1;
+
+        self.insert_task(&mut task, now);
+        if task.state == TaskState::Failed {
+            task.attempts = 0;
+        }
+        task
+    }
+
     /// Add a new task that starts in `blocked` state.
     pub fn enqueue_blocked_with_policy(
         &self,
@@ -487,6 +514,45 @@ impl TaskQueue {
         }
     }
 
+    /// Async-safe enqueue wrapper for tasks that start already claimed in
+    /// `running` state.
+    pub async fn enqueue_running_async_with_policy(
+        self: &Arc<Self>,
+        payload: Value,
+        policy: TaskPolicy,
+    ) -> DurableTask {
+        let queue = Arc::clone(self);
+        let payload_fallback = payload.clone();
+        let policy_fallback = policy.clone();
+        match tokio::task::spawn_blocking(move || {
+            queue.enqueue_running_with_policy(payload, policy)
+        })
+        .await
+        {
+            Ok(task) => task,
+            Err(err) => {
+                warn!(error = %err, "enqueue worker failed");
+                warn!(
+                    "falling back to a dedicated running-task enqueue thread after enqueue worker failure"
+                );
+                let fallback_task = self.build_failed_enqueue_task(
+                    payload_fallback.clone(),
+                    policy_fallback.clone(),
+                    None,
+                );
+                self.enqueue_via_dedicated_thread(
+                    "task-queue-running-enqueue-fallback",
+                    move |queue_fallback| {
+                        queue_fallback
+                            .enqueue_running_with_policy(payload_fallback, policy_fallback)
+                    },
+                    fallback_task,
+                )
+                .await
+            }
+        }
+    }
+
     /// Async-safe enqueue wrapper that starts the task in `blocked` state.
     pub async fn enqueue_blocked_async_with_policy(
         self: &Arc<Self>,
@@ -592,28 +658,6 @@ impl TaskQueue {
         }
 
         if !claimed.is_empty() {
-            self.flush_to_disk();
-        }
-        claimed
-    }
-
-    /// Claim one specific due task and move it to `running`.
-    pub fn claim_task(&self, id: &str, now: u64) -> Option<DurableTask> {
-        let mut claimed = None;
-        {
-            let mut tasks = self.tasks.write();
-            if let Some(task) = tasks.iter_mut().find(|task| task.id == id) {
-                if is_due(task, now) {
-                    task.state = TaskState::Running;
-                    task.attempts = task.attempts.saturating_add(1);
-                    task.next_run_at_ms = None;
-                    task.updated_at_ms = now;
-                    claimed = Some(task.clone());
-                }
-            }
-        }
-
-        if claimed.is_some() {
             self.flush_to_disk();
         }
         claimed
@@ -1129,16 +1173,16 @@ mod tests {
     }
 
     #[test]
-    fn test_claim_task_marks_specific_due_task_running_and_increments_attempts() {
+    fn test_enqueue_running_with_policy_marks_task_running_and_increments_attempts() {
         let queue = TaskQueue::in_memory();
-        let task = queue.enqueue(serde_json::json!({"kind":"demo"}), Some(1));
+        let task = queue
+            .enqueue_running_with_policy(serde_json::json!({"kind":"demo"}), TaskPolicy::default());
 
-        let claimed = queue
-            .claim_task(&task.id, 10)
-            .expect("specific due task should be claimable");
-        assert_eq!(claimed.id, task.id);
-        assert_eq!(claimed.state, TaskState::Running);
-        assert_eq!(claimed.attempts, 1);
+        assert_eq!(task.state, TaskState::Running);
+        assert_eq!(task.attempts, 1);
+        let stored = queue.get(&task.id).expect("task should be persisted");
+        assert_eq!(stored.state, TaskState::Running);
+        assert_eq!(stored.attempts, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This follow-up fixes the remaining ordering gap in Signal explicit read receipts.

What changed:
- persist the ingest-time read-receipt task directly in durable `Running` state at claim completion and execute that same task inline, instead of leaving the first send to race the background worker
- keep the durable task queue and worker for persistence, retries, startup recovery, and later retry processing
- make inline result mapping explicit so `Done` plus durable finalization failure is reported accurately instead of looking like a generic send failure
- add regression coverage for Signal event order `read -> start -> stop` on the inbound append path and for the `Done + finalization failure` result mapping

## Root Cause
The refactor in #352 moved receipt ownership to the durable inbound append boundary, but the common success path still only persisted receipt work and returned. That left external Signal `mark_read` delivery to race the background worker against executor typing start.

## Impact
Signal direct messages with `readReceipts.enabled: true` now send the explicit read receipt before typing begins on the normal success path, while still preserving durable receipt state and retry behavior.

## Validation
- `scripts/cargo-serial fmt --all --check`
- `scripts/cargo-serial check --tests`
- `scripts/cargo-serial clippy --all-targets -- -D warnings`
- `scripts/cargo-serial nextest run`

Addresses #350.