### PR TITLE
Prepare v0.7.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "carapace"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carapace"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.93"
 description = "A security-focused personal AI assistant — hardened alternative to openclaw/clawdbot"

--- a/docs/release.md
+++ b/docs/release.md
@@ -71,7 +71,7 @@ Use this when an upgrade causes a regression.
 1. Stop Cara.
 2. Reinstall the previous known-good binary (pinned tag URL).
 3. Restore backup created before the upgrade:
-   - `cara restore --path ./carapace-backup.tar.gz`
+   - `cara restore ./carapace-backup.tar.gz`
 4. Start Cara.
 5. Verify:
    - `cara status --port 18789`

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -6,13 +6,13 @@
 - Fixed Signal explicit read receipts so the durable append boundary owns receipt completion and the normal success path sends the read receipt before typing begins.
 
 ## Breaking Changes
-- Existing `v0.6.0` installs do not require a config migration if you keep using direct `model` strings and leave session encryption off or unchanged.
 - If `sessions.encryption.mode` rewrites plaintext sessions into encrypted artifacts (for example `if_password` with `CARAPACE_CONFIG_PASSWORD` present, or `required`), older releases such as `v0.6.0` cannot transparently read that rewritten session store. Rolling back after those writes requires the pre-upgrade backup or a fresh session store.
 - The new `routes` map and `route` selector fields are additive in `v0.7.0`, but they are not understood by `v0.6.0`. If you adopt named routes and later roll back, restore the pre-upgrade config or convert those route references back to direct `model` strings first.
 
 ## Migration Steps
 - Before upgrading, create a backup:
   - `cara backup --output ./carapace-backup-v0.6.x.tar.gz`
+- If you keep direct `model` strings and leave session encryption off or unchanged, a routine `v0.6.0 -> v0.7.0` upgrade does not require an immediate config migration.
 - If you plan to enable encrypted sessions, set and retain `CARAPACE_CONFIG_PASSWORD` before first `v0.7.0` start, and keep backing up the full state directory so `.crypto-manifest` is preserved with the rest of the session store.
   - There is still no in-place session-encryption rekey/password-change flow. If you later need to change `CARAPACE_CONFIG_PASSWORD`, export or delete the encrypted sessions and start with a fresh encrypted session store.
   - If you still have legacy plaintext sessions that will be touched and migrated on `v0.7.0`, keep `CARAPACE_SERVER_SECRET` stable during that migration window; rotating it too early can invalidate old integrity sidecars before those sessions are rewritten.

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,56 @@
+## Summary
+- Added encrypted session artifacts at rest, including `.crypto-manifest` recovery metadata, stricter integrity handling, and fail-closed recovery behavior for encrypted session state.
+- Added named execution routes plus session-level route precedence so requests, sessions, agents, and defaults can target reusable backend definitions instead of repeating raw `provider:model` strings everywhere.
+- Unified shared OAuth onboarding and auth-profile persistence for Codex and Gemini flows, tightening encrypted token storage and reducing provider-specific setup divergence.
+- Hardened the shared WASM plugin engine/bootstrap path, including shared-engine first-use coordination and cached compiled component reuse.
+- Fixed Signal explicit read receipts so the durable append boundary owns receipt completion and the normal success path sends the read receipt before typing begins.
+
+## Breaking Changes
+- Existing `v0.6.0` installs do not require a config migration if you keep using direct `model` strings and leave session encryption off or unchanged.
+- If `sessions.encryption.mode` rewrites plaintext sessions into encrypted artifacts (for example `if_password` with `CARAPACE_CONFIG_PASSWORD` present, or `required`), older releases such as `v0.6.0` cannot transparently read that rewritten session store. Rolling back after those writes requires the pre-upgrade backup or a fresh session store.
+- The new `routes` map and `route` selector fields are additive in `v0.7.0`, but they are not understood by `v0.6.0`. If you adopt named routes and later roll back, restore the pre-upgrade config or convert those route references back to direct `model` strings first.
+
+## Migration Steps
+- Before upgrading, create a backup:
+  - `cara backup --output ./carapace-backup-v0.6.x.tar.gz`
+- If you plan to enable encrypted sessions, set and retain `CARAPACE_CONFIG_PASSWORD` before first `v0.7.0` start, and keep backing up the full state directory so `.crypto-manifest` is preserved with the rest of the session store.
+- If you want to adopt named routes, define them under the top-level `routes` map and then point agents/defaults at route names instead of editing every `model` field by hand.
+  - Example:
+    - `routes.fast.model: "gemini:gemini-2.0-flash"`
+    - `agents.defaults.route: "fast"`
+- After upgrade, verify the install:
+  - `cara verify --outcome auto`
+  - `cara verify --outcome autonomy`
+- If you use Signal with explicit read receipts enabled, validate one real direct-message thread after upgrade so the expected `read -> typing -> reply` ordering is confirmed in your deployment.
+
+## Rollback Steps
+- Reinstall the previous known-good binary, for example `v0.6.0`.
+- If `v0.7.0` has rewritten any sessions into encrypted form, restore the backup you created before upgrade:
+  - `cara restore --path ./carapace-backup-v0.6.x.tar.gz`
+- If you adopted `routes` or new `route` config fields on `v0.7.0`, revert those config changes or restore the pre-upgrade config backup before starting `v0.6.0`.
+- Re-run:
+  - `cara status --port 18789`
+  - `cara verify --outcome auto --port 18789`
+  - `cara verify --outcome autonomy --port 18789`
+
+## Security
+- Session history, metadata, and archives can now encrypt at rest under the session-encryption policy, with recovery gated on the paired `.crypto-manifest` instead of trusting the password alone.
+- Session integrity handling is tightened around encrypted recovery, manifest backfill, and mixed plaintext/encrypted migration paths so corruption fails closed more consistently.
+- Shared OAuth onboarding for Codex and Gemini now runs through the common encrypted auth-profile path rather than duplicating provider-specific token persistence behavior.
+- Shared plugin engine/bootstrap handling is hardened around startup ownership, component compilation reuse, and first-use coordination.
+- No new public advisories are introduced by this release.
+
+## Verification
+- Verify published artifacts and Sigstore bundles:
+  - `RELEASE_TAG=v0.7.0 ./scripts/smoke/verify-release-artifacts.sh`
+- After upgrading, verify runtime behavior:
+  - `cara verify --outcome auto`
+  - `cara verify --outcome autonomy`
+- If you enable encrypted sessions, unlock at least one existing session after restart and confirm its history loads with the same `CARAPACE_CONFIG_PASSWORD`.
+- If you use Signal read receipts, validate one real direct-message thread against the Signal smoke playbook after the release build is installed.
+
+## Known Caveats
+- There is still no in-place session-encryption rekey/password-change flow. Changing `CARAPACE_CONFIG_PASSWORD` after encrypted session artifacts already exist requires exporting or deleting those sessions and starting from a fresh encrypted store.
+- During touch-time migration of older plaintext sessions into encrypted form, keep a stable `CARAPACE_SERVER_SECRET` until the legacy sessions you care about have been opened or migrated; rotating the legacy integrity secret too early can invalidate old sidecars.
+- Signal explicit read receipts still apply only to supported direct-message text ingests. Unsupported Signal group or non-text messages remain unread when explicit read receipts are enabled because Carapace does not ingest them yet.
+- Signal runtime wiring is implemented, but published live smoke evidence is still narrower than the core CLI/control paths; keep using the documented channel smoke playbook for release validation.

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -14,6 +14,8 @@
 - Before upgrading, create a backup:
   - `cara backup --output ./carapace-backup-v0.6.x.tar.gz`
 - If you plan to enable encrypted sessions, set and retain `CARAPACE_CONFIG_PASSWORD` before first `v0.7.0` start, and keep backing up the full state directory so `.crypto-manifest` is preserved with the rest of the session store.
+  - There is still no in-place session-encryption rekey/password-change flow. If you later need to change `CARAPACE_CONFIG_PASSWORD`, export or delete the encrypted sessions and start with a fresh encrypted session store.
+  - If you still have legacy plaintext sessions that will be touched and migrated on `v0.7.0`, keep `CARAPACE_SERVER_SECRET` stable during that migration window; rotating it too early can invalidate old integrity sidecars before those sessions are rewritten.
 - If you want to adopt named routes, define them under the top-level `routes` map and then point agents/defaults at route names instead of editing every `model` field by hand.
   - Example:
     - `routes.fast.model: "gemini:gemini-2.0-flash"`
@@ -26,7 +28,7 @@
 ## Rollback Steps
 - Reinstall the previous known-good binary, for example `v0.6.0`.
 - If `v0.7.0` has rewritten any sessions into encrypted form, restore the backup you created before upgrade:
-  - `cara restore --path ./carapace-backup-v0.6.x.tar.gz`
+  - `cara restore ./carapace-backup-v0.6.x.tar.gz`
 - If you adopted `routes` or new `route` config fields on `v0.7.0`, revert those config changes or restore the pre-upgrade config backup before starting `v0.6.0`.
 - Re-run:
   - `cara status --port 18789`

--- a/docs/site/cli-tasks.md
+++ b/docs/site/cli-tasks.md
@@ -43,7 +43,7 @@ Command ladder:
 ## Backup, restore, reset
 
 - Backup state: `cara backup --output ./carapace-backup.tar.gz`
-- Restore state: `cara restore --path ./carapace-backup.tar.gz`
+- Restore state: `cara restore ./carapace-backup.tar.gz`
 - Reset categories: `cara reset --all --force`
 
 ## Update lifecycle

--- a/docs/site/ops.md
+++ b/docs/site/ops.md
@@ -85,7 +85,7 @@ cara backup --output ./carapace-backup.tar.gz
 Restore from backup:
 
 ```bash
-cara restore --path ./carapace-backup.tar.gz
+cara restore ./carapace-backup.tar.gz
 ```
 
 ## 7) Update flow


### PR DESCRIPTION
## Summary
Prepare the `v0.7.0` stable release.

What changed:
- bump crate/package version from `0.6.0` to `0.7.0`
- add curated release notes at `docs/releases/v0.7.0.md`
- keep the release-prep scope aligned with the prior stable release workflow (`Cargo.toml`, `Cargo.lock`, release notes)

## Notes
The release notes cover the major post-`v0.6.0` trains now on `master`, including:
- encrypted session artifacts at rest
- named routes and session-level route precedence
- shared OAuth onboarding/auth-profile hardening
- shared plugin engine/bootstrap hardening
- the Signal read-receipt ordering fix from `#350`

## Validation
- `scripts/cargo-serial check`
- `./scripts/check-docs-state-messaging.sh`