### PR TITLE
refactor: consolidate consecutive messages with the same role in Gemini and Vertex agents

### DIFF
--- a/src/agent/gemini.rs
+++ b/src/agent/gemini.rs
@@ -126,86 +126,7 @@ impl GeminiProvider {
         }
 
         // Convert LlmMessages to Gemini contents format
-        let mut contents: Vec<Value> = Vec::new();
-        let mut current_role: Option<&'static str> = None;
-        let mut current_parts: Vec<Value> = Vec::new();
-
-        for msg in &request.messages {
-            let role = match msg.role {
-                LlmRole::User => "user",
-                LlmRole::Assistant => "model",
-            };
-
-            let mut parts: Vec<Value> = Vec::new();
-
-            for block in &msg.content {
-                match block {
-                    ContentBlock::Text { text, metadata } => {
-                        let mut part = json!({ "text": text });
-                        apply_gemini_thought_signature(&mut part, metadata);
-                        parts.push(part);
-                    }
-                    ContentBlock::ToolUse {
-                        id: _,
-                        name,
-                        input,
-                        metadata,
-                    } => {
-                        let mut part = json!({
-                            "functionCall": {
-                                "name": name,
-                                "args": input,
-                            }
-                        });
-                        apply_gemini_thought_signature(&mut part, metadata);
-                        parts.push(part);
-                    }
-                    ContentBlock::ToolResult {
-                        tool_use_id: _,
-                        content,
-                        is_error: _,
-                    } => {
-                        // For tool results, we need to look up the tool name.
-                        // Gemini uses functionResponse with name and response.
-                        // We look backwards through messages to find the matching tool use name.
-                        let tool_name = find_tool_name_for_result(&request.messages, block);
-                        let part = json!({
-                            "functionResponse": {
-                                "name": tool_name,
-                                "response": {
-                                    "result": content,
-                                }
-                            }
-                        });
-                        parts.push(part);
-                    }
-                }
-            }
-
-            if !parts.is_empty() {
-                if Some(role) == current_role {
-                    current_parts.extend(parts);
-                } else {
-                    if let Some(r) = current_role {
-                        contents.push(json!({
-                            "role": r,
-                            "parts": std::mem::take(&mut current_parts),
-                        }));
-                    }
-                    current_role = Some(role);
-                    current_parts = parts;
-                }
-            }
-        }
-
-        if let Some(r) = current_role {
-            contents.push(json!({
-                "role": r,
-                "parts": current_parts,
-            }));
-        }
-
-        body["contents"] = json!(contents);
+        body["contents"] = json!(build_gemini_contents(&request.messages));
 
         // Tools (function declarations)
         if !request.tools.is_empty() {
@@ -317,6 +238,89 @@ impl GeminiProvider {
             }
         }
     }
+}
+
+pub(crate) fn build_gemini_contents(messages: &[LlmMessage]) -> Vec<Value> {
+    let mut contents: Vec<Value> = Vec::new();
+    let mut current_role: Option<&'static str> = None;
+    let mut current_parts: Vec<Value> = Vec::new();
+
+    for msg in messages {
+        let role = match msg.role {
+            LlmRole::User => "user",
+            LlmRole::Assistant => "model",
+        };
+
+        let mut parts: Vec<Value> = Vec::new();
+
+        for block in &msg.content {
+            match block {
+                ContentBlock::Text { text, metadata } => {
+                    let mut part = json!({ "text": text });
+                    apply_gemini_thought_signature(&mut part, metadata);
+                    parts.push(part);
+                }
+                ContentBlock::ToolUse {
+                    id: _,
+                    name,
+                    input,
+                    metadata,
+                } => {
+                    let mut part = json!({
+                        "functionCall": {
+                            "name": name,
+                            "args": input,
+                        }
+                    });
+                    apply_gemini_thought_signature(&mut part, metadata);
+                    parts.push(part);
+                }
+                ContentBlock::ToolResult {
+                    tool_use_id: _,
+                    content,
+                    is_error: _,
+                } => {
+                    // For tool results, we need to look up the tool name.
+                    // Gemini uses functionResponse with name and response.
+                    // We look backwards through messages to find the matching tool use name.
+                    let tool_name = find_tool_name_for_result(messages, block);
+                    let part = json!({
+                        "functionResponse": {
+                            "name": tool_name,
+                            "response": {
+                                "result": content,
+                            }
+                        }
+                    });
+                    parts.push(part);
+                }
+            }
+        }
+
+        if !parts.is_empty() {
+            if Some(role) == current_role {
+                current_parts.extend(parts);
+            } else {
+                if let Some(r) = current_role {
+                    contents.push(json!({
+                        "role": r,
+                        "parts": std::mem::take(&mut current_parts),
+                    }));
+                }
+                current_role = Some(role);
+                current_parts = parts;
+            }
+        }
+    }
+
+    if let Some(r) = current_role {
+        contents.push(json!({
+            "role": r,
+            "parts": current_parts,
+        }));
+    }
+
+    contents
 }
 
 /// Find the tool name that corresponds to a ToolResult block by searching

--- a/src/agent/gemini.rs
+++ b/src/agent/gemini.rs
@@ -127,6 +127,8 @@ impl GeminiProvider {
 
         // Convert LlmMessages to Gemini contents format
         let mut contents: Vec<Value> = Vec::new();
+        let mut current_role: Option<&'static str> = None;
+        let mut current_parts: Vec<Value> = Vec::new();
 
         for msg in &request.messages {
             let role = match msg.role {
@@ -181,11 +183,26 @@ impl GeminiProvider {
             }
 
             if !parts.is_empty() {
-                contents.push(json!({
-                    "role": role,
-                    "parts": parts,
-                }));
+                if Some(role) == current_role {
+                    current_parts.extend(parts);
+                } else {
+                    if let Some(r) = current_role {
+                        contents.push(json!({
+                            "role": r,
+                            "parts": std::mem::take(&mut current_parts),
+                        }));
+                    }
+                    current_role = Some(role);
+                    current_parts = parts;
+                }
             }
+        }
+
+        if let Some(r) = current_role {
+            contents.push(json!({
+                "role": r,
+                "parts": current_parts,
+            }));
         }
 
         body["contents"] = json!(contents);

--- a/src/agent/vertex.rs
+++ b/src/agent/vertex.rs
@@ -227,7 +227,9 @@ pub(crate) fn build_gemini_body(request: &CompletionRequest) -> Value {
     }
 
     // Convert LlmMessages to Gemini contents format
-    body["contents"] = json!(crate::agent::gemini::build_gemini_contents(&request.messages));
+    body["contents"] = json!(crate::agent::gemini::build_gemini_contents(
+        &request.messages
+    ));
 
     // Tools
     if !request.tools.is_empty() {

--- a/src/agent/vertex.rs
+++ b/src/agent/vertex.rs
@@ -227,83 +227,7 @@ pub(crate) fn build_gemini_body(request: &CompletionRequest) -> Value {
     }
 
     // Convert LlmMessages to Gemini contents format
-    let mut contents: Vec<Value> = Vec::new();
-    let mut current_role: Option<&'static str> = None;
-    let mut current_parts: Vec<Value> = Vec::new();
-
-    for msg in &request.messages {
-        let role = match msg.role {
-            LlmRole::User => "user",
-            LlmRole::Assistant => "model",
-        };
-
-        let mut parts: Vec<Value> = Vec::new();
-
-        for block in &msg.content {
-            match block {
-                ContentBlock::Text { text, metadata } => {
-                    let mut part = json!({ "text": text });
-                    apply_gemini_thought_signature(&mut part, metadata);
-                    parts.push(part);
-                }
-                ContentBlock::ToolUse {
-                    id: _,
-                    name,
-                    input,
-                    metadata,
-                } => {
-                    let mut part = json!({
-                        "functionCall": {
-                            "name": name,
-                            "args": input,
-                        }
-                    });
-                    apply_gemini_thought_signature(&mut part, metadata);
-                    parts.push(part);
-                }
-                ContentBlock::ToolResult {
-                    tool_use_id: _,
-                    content,
-                    is_error: _,
-                } => {
-                    let tool_name = find_tool_name_for_result(&request.messages, block);
-                    let part = json!({
-                        "functionResponse": {
-                            "name": tool_name,
-                            "response": {
-                                "result": content,
-                            }
-                        }
-                    });
-                    parts.push(part);
-                }
-            }
-        }
-
-        if !parts.is_empty() {
-            if Some(role) == current_role {
-                current_parts.extend(parts);
-            } else {
-                if let Some(r) = current_role {
-                    contents.push(json!({
-                        "role": r,
-                        "parts": std::mem::take(&mut current_parts),
-                    }));
-                }
-                current_role = Some(role);
-                current_parts = parts;
-            }
-        }
-    }
-
-    if let Some(r) = current_role {
-        contents.push(json!({
-            "role": r,
-            "parts": current_parts,
-        }));
-    }
-
-    body["contents"] = json!(contents);
+    body["contents"] = json!(crate::agent::gemini::build_gemini_contents(&request.messages));
 
     // Tools
     if !request.tools.is_empty() {
@@ -805,25 +729,6 @@ impl TokenProvider for FallbackTokenProvider {
             }
         }
     }
-}
-
-fn find_tool_name_for_result<'a>(messages: &'a [LlmMessage], block: &ContentBlock) -> &'a str {
-    let target_id = match block {
-        ContentBlock::ToolResult { tool_use_id, .. } => tool_use_id,
-        _ => return "unknown",
-    };
-
-    for msg in messages.iter().rev() {
-        for b in &msg.content {
-            if let ContentBlock::ToolUse { id, name, .. } = b {
-                if id == target_id {
-                    return name;
-                }
-            }
-        }
-    }
-
-    "unknown"
 }
 
 /// Strip the `vertex:` prefix from a model identifier.

--- a/src/agent/vertex.rs
+++ b/src/agent/vertex.rs
@@ -1324,6 +1324,98 @@ mod tests {
     }
 
     #[test]
+    fn test_gemini_adapter_build_body_batches_consecutive_roles() {
+        let request = CompletionRequest {
+            model: "gemini-1.5-pro".to_string(),
+            messages: vec![
+                LlmMessage {
+                    role: LlmRole::User,
+                    content: vec![ContentBlock::Text {
+                        text: "First user message".to_string(),
+                        metadata: None,
+                    }],
+                },
+                LlmMessage {
+                    role: LlmRole::Assistant,
+                    content: vec![ContentBlock::ToolUse {
+                        id: "call_1".to_string(),
+                        name: "get_weather".to_string(),
+                        input: json!({"city": "SF"}),
+                        metadata: None,
+                    }],
+                },
+                LlmMessage {
+                    role: LlmRole::Assistant,
+                    content: vec![ContentBlock::ToolUse {
+                        id: "call_2".to_string(),
+                        name: "get_time".to_string(),
+                        input: json!({"tz": "UTC"}),
+                        metadata: None,
+                    }],
+                },
+                LlmMessage {
+                    role: LlmRole::User,
+                    content: vec![ContentBlock::ToolResult {
+                        tool_use_id: "call_1".to_string(),
+                        content: "72F".to_string(),
+                        is_error: false,
+                    }],
+                },
+                LlmMessage {
+                    role: LlmRole::User,
+                    content: vec![ContentBlock::ToolResult {
+                        tool_use_id: "call_2".to_string(),
+                        content: "12:00".to_string(),
+                        is_error: false,
+                    }],
+                },
+            ],
+            system: None,
+            temperature: None,
+            max_tokens: 100,
+            tools: vec![],
+            extra: None,
+        };
+
+        let body = build_gemini_body(&request);
+        let contents = body["contents"].as_array().unwrap();
+
+        // Should be 3 content entries: user, model (batched 2), user (batched 2)
+        assert_eq!(contents.len(), 3);
+
+        assert_eq!(contents[0]["role"], "user");
+        assert_eq!(contents[0]["parts"].as_array().unwrap().len(), 1);
+        assert_eq!(contents[0]["parts"][0]["text"], "First user message");
+
+        assert_eq!(contents[1]["role"], "model");
+        assert_eq!(contents[1]["parts"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            contents[1]["parts"][0]["functionCall"]["name"],
+            "get_weather"
+        );
+        assert_eq!(contents[1]["parts"][1]["functionCall"]["name"], "get_time");
+
+        assert_eq!(contents[2]["role"], "user");
+        assert_eq!(contents[2]["parts"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            contents[2]["parts"][0]["functionResponse"]["name"],
+            "get_weather"
+        );
+        assert_eq!(
+            contents[2]["parts"][0]["functionResponse"]["response"]["result"],
+            "72F"
+        );
+        assert_eq!(
+            contents[2]["parts"][1]["functionResponse"]["name"],
+            "get_time"
+        );
+        assert_eq!(
+            contents[2]["parts"][1]["functionResponse"]["response"]["result"],
+            "12:00"
+        );
+    }
+
+    #[test]
     fn test_resolve_request_config() {
         let provider = VertexProvider::new(
             "my-project".to_string(),

--- a/src/agent/vertex.rs
+++ b/src/agent/vertex.rs
@@ -228,6 +228,8 @@ pub(crate) fn build_gemini_body(request: &CompletionRequest) -> Value {
 
     // Convert LlmMessages to Gemini contents format
     let mut contents: Vec<Value> = Vec::new();
+    let mut current_role: Option<&'static str> = None;
+    let mut current_parts: Vec<Value> = Vec::new();
 
     for msg in &request.messages {
         let role = match msg.role {
@@ -279,11 +281,26 @@ pub(crate) fn build_gemini_body(request: &CompletionRequest) -> Value {
         }
 
         if !parts.is_empty() {
-            contents.push(json!({
-                "role": role,
-                "parts": parts,
-            }));
+            if Some(role) == current_role {
+                current_parts.extend(parts);
+            } else {
+                if let Some(r) = current_role {
+                    contents.push(json!({
+                        "role": r,
+                        "parts": std::mem::take(&mut current_parts),
+                    }));
+                }
+                current_role = Some(role);
+                current_parts = parts;
+            }
         }
+    }
+
+    if let Some(r) = current_role {
+        contents.push(json!({
+            "role": r,
+            "parts": current_parts,
+        }));
     }
 
     body["contents"] = json!(contents);


### PR DESCRIPTION
This pull request refactors how LLM messages are converted to the Gemini contents format in both the `GeminiProvider` and `build_gemini_body` implementations. The main improvement is batching consecutive messages with the same role into a single entry, which optimizes the structure and reduces redundancy in the resulting JSON.

**Refactoring and message batching:**

* Consecutive messages with the same role are now combined into a single entry in the Gemini contents format, rather than creating a separate entry for each message. This is done by accumulating parts for the current role and only pushing to the contents vector when the role changes or at the end of processing. (`src/agent/gemini.rs` [[1]](diffhunk://#diff-9c978514795a57a742b931e60c91aed3cc86f0a3af1037fca1fc65e0f797d83bR130-R131) [[2]](diffhunk://#diff-9c978514795a57a742b931e60c91aed3cc86f0a3af1037fca1fc65e0f797d83bR186-R205); `src/agent/vertex.rs` [[3]](diffhunk://#diff-29382c9412dc07a0c9559c60971524087cc2282e1ec17dcee64809b0234e083dR231-R232) [[4]](diffhunk://#diff-29382c9412dc07a0c9559c60971524087cc2282e1ec17dcee64809b0234e083dR284-R303)

This fixes a 400 error Vertex was throwing: 

```
error: "LLM provider error: LLM provider error: Vertex API returned 400 Bad Request: Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn."
```