### PR TITLE
fix: use sourceUuid in addition to sourceNumber as Signal identifier

### DIFF
--- a/src/channels/signal_receive.rs
+++ b/src/channels/signal_receive.rs
@@ -937,6 +937,7 @@ mod tests {
     #[test]
     fn test_effective_source_number_empty_source_number_fallback() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("   ".to_string()),
             source: Some("+15559876543".to_string()),
             timestamp: None,
@@ -1345,6 +1346,7 @@ mod tests {
     #[test]
     fn test_build_signal_read_receipt_context_uses_available_timestamp() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: None,
@@ -1368,6 +1370,7 @@ mod tests {
     #[test]
     fn test_build_signal_read_receipt_context_prefers_data_message_timestamp() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600999),
@@ -1390,6 +1393,7 @@ mod tests {
     #[test]
     fn test_build_signal_read_receipt_context_skips_missing_timestamp() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: None,
@@ -1411,6 +1415,7 @@ mod tests {
     #[test]
     fn test_read_receipt_context_for_signal_run_skips_context_when_feature_disabled() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600000),
@@ -1433,6 +1438,7 @@ mod tests {
     #[test]
     fn test_read_receipt_context_for_signal_run_returns_context_when_feature_enabled() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600999),
@@ -1468,6 +1474,7 @@ mod tests {
     #[test]
     fn test_resolve_sender_and_peer_ignores_empty_group_id() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: None,
@@ -1493,6 +1500,7 @@ mod tests {
     #[test]
     fn test_resolve_sender_and_peer_rejects_group_message_with_phone_number_like_id() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: None,
@@ -1515,6 +1523,7 @@ mod tests {
     #[test]
     fn test_resolve_sender_and_peer_rejects_group_messages() {
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: None,
@@ -1690,6 +1699,7 @@ mod tests {
             WsServerState::new(WsServerConfig::default()).with_plugin_registry(plugin_registry),
         );
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600000),
@@ -1728,6 +1738,7 @@ mod tests {
             WsServerState::new(WsServerConfig::default()).with_plugin_registry(plugin_registry),
         );
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600000),
@@ -1805,6 +1816,7 @@ mod tests {
             "other claims should be blocked while the poll reservation owns the slot"
         );
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600000),
@@ -1851,6 +1863,7 @@ mod tests {
                 .with_activity_service(activity_service),
         );
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600000),
@@ -1916,6 +1929,7 @@ mod tests {
         state.set_llm_provider(None);
 
         let envelope = SignalEnvelope {
+            source_uuid: None,
             source_number: Some("+15559876543".to_string()),
             source: None,
             timestamp: Some(1706745600000),

--- a/src/channels/signal_receive.rs
+++ b/src/channels/signal_receive.rs
@@ -63,7 +63,11 @@ pub struct SignalDataMessage {
 }
 
 impl SignalEnvelope {
-    /// Returns the effective source number, preferring `sourceNumber` over `sourceUuid` and `source`.
+    /// Returns the effective source identifier for the envelope.
+    ///
+    /// This prefers `sourceNumber` when present, but may also return
+    /// `sourceUuid` (for phone-number privacy) or the legacy `source` field,
+    /// so the result is not guaranteed to be a phone number.
     pub fn effective_source_number(&self) -> Option<&str> {
         self.source_number
             .as_deref()

--- a/src/channels/signal_receive.rs
+++ b/src/channels/signal_receive.rs
@@ -947,6 +947,45 @@ mod tests {
     }
 
     #[test]
+    fn test_effective_source_number_uuid_fallback() {
+        let envelope = SignalEnvelope {
+            source_uuid: Some("bc10cb01-949e-4c75-8eb6-04dbdbda16e0".to_string()),
+            source_number: None,
+            source: Some("+15559876543".to_string()),
+            timestamp: None,
+            data_message: None,
+        };
+        assert_eq!(
+            envelope.effective_source_number(),
+            Some("bc10cb01-949e-4c75-8eb6-04dbdbda16e0")
+        );
+    }
+
+    #[test]
+    fn test_effective_source_number_both_absent_fallback() {
+        let envelope = SignalEnvelope {
+            source_uuid: None,
+            source_number: None,
+            source: Some("+15559876543".to_string()),
+            timestamp: None,
+            data_message: None,
+        };
+        assert_eq!(envelope.effective_source_number(), Some("+15559876543"));
+    }
+
+    #[test]
+    fn test_effective_source_number_both_empty_fallback() {
+        let envelope = SignalEnvelope {
+            source_uuid: Some("   ".to_string()),
+            source_number: Some("   ".to_string()),
+            source: Some("+15559876543".to_string()),
+            timestamp: None,
+            data_message: None,
+        };
+        assert_eq!(envelope.effective_source_number(), Some("+15559876543"));
+    }
+
+    #[test]
     fn test_parse_envelope_with_duplicate_source_fields() {
         let json = r#"[
             {

--- a/src/channels/signal_receive.rs
+++ b/src/channels/signal_receive.rs
@@ -29,6 +29,10 @@ pub struct SignalEnvelope {
     #[serde(default, rename = "sourceNumber")]
     pub source_number: Option<String>,
 
+    /// Source UUID (used when phone number privacy is enabled).
+    #[serde(default, rename = "sourceUuid")]
+    pub source_uuid: Option<String>,
+
     /// Legacy source field.
     #[serde(default)]
     pub source: Option<String>,
@@ -59,11 +63,12 @@ pub struct SignalDataMessage {
 }
 
 impl SignalEnvelope {
-    /// Returns the effective source number, preferring `sourceNumber` over `source`.
+    /// Returns the effective source number, preferring `sourceNumber` over `sourceUuid` and `source`.
     pub fn effective_source_number(&self) -> Option<&str> {
         self.source_number
             .as_deref()
             .filter(|s| !s.trim().is_empty())
+            .or_else(|| self.source_uuid.as_deref().filter(|s| !s.trim().is_empty()))
             .or_else(|| self.source.as_deref().filter(|s| !s.trim().is_empty()))
     }
 }


### PR DESCRIPTION
This pull request enhances support for source identification in the `SignalEnvelope` struct by adding a new `source_uuid` field and updating the logic for determining the effective source number. This change improves handling of privacy features where a UUID may be used instead of a phone number.

**Support for source UUIDs and improved source selection:**

* Added a new optional `source_uuid` field to the `SignalEnvelope` struct, which is used when phone number privacy is enabled.
* Updated the `effective_source_number` method to prefer `sourceNumber`, then `sourceUuid`, and finally the legacy `source` field, ensuring the most appropriate identifier is selected.

Incoming Signal messages were rejected because the sending account was not passing sourceNumber, just sourceUuid.