### PR TITLE
fix(pages): preserve ../ on channel links from cookbook pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,26 @@ on:
       - "scripts/check-pages-links.sh"
       - "scripts/check-docs-state-messaging.sh"
       - ".github/workflows/pages.yml"
+  pull_request:
+    paths:
+      - "website/**"
+      - "docs/cookbook/**"
+      - "docs/getting-started.md"
+      - "docs/plugin-development.md"
+      - "docs/release.md"
+      - "docs/cli.md"
+      - "docs/channels.md"
+      - "docs/channel-smoke.md"
+      - "docs/security.md"
+      - "docs/security-comparison.md"
+      - "docs/feature-status.yaml"
+      - "docs/feature-evidence.yaml"
+      - "docs/site/**"
+      - "SECURITY.md"
+      - "scripts/build-pages-content.sh"
+      - "scripts/check-pages-links.sh"
+      - "scripts/check-docs-state-messaging.sh"
+      - ".github/workflows/pages.yml"
   workflow_dispatch:
 
 permissions:
@@ -29,8 +49,10 @@ permissions:
   pages: write
   id-token: write
 
+# Scope concurrency by ref so PR validation runs don't cancel an in-flight
+# master deploy (and vice versa).
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -60,13 +82,19 @@ jobs:
       - name: Validate generated internal links
         run: ./scripts/check-pages-links.sh public
 
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      # Artifact upload + deploy only run on push to master; PRs stop after
+      # validation. upload-pages-artifact also requires pages/id-token scope
+      # that is not granted to pull_request events from forks.
+      - if: github.event_name == 'push'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: public
 
   deploy:
+    if: github.event_name == 'push'
     name: Deploy Pages
     needs: build
     runs-on: ubuntu-latest

--- a/scripts/build-pages-content.sh
+++ b/scripts/build-pages-content.sh
@@ -45,19 +45,32 @@ rewrite_links() {
   local body="$1"
   local kind="$2"
 
-  # Cookbook pages publish one level deeper (public/cookbook/*.html), so
-  # `../channels.md` / `../channel-smoke.md` references must keep the `../`
-  # prefix instead of being stripped by the generic rewrites below.
-  if [[ "$kind" == "cookbook" ]]; then
-    body="$(printf '%s' "$body" | sed -E \
-      -e 's|href="\.\./channel-smoke\.md(#[-A-Za-z0-9._/]*)?"|href="../channel-smoke.html\1"|g' \
-      -e 's|href="\.\./channels\.md(#[-A-Za-z0-9._/]*)?"|href="../channels.html\1"|g')"
-  fi
-
+  # Absolute-URL redirects for out-of-site references are depth-agnostic and
+  # must run before the cookbook pre-pass below so the broad `../X.md` rule
+  # does not accidentally rewrite them to a relative HTML path.
   body="$(printf '%s' "$body" | sed -E \
     -e 's|href="\.\./CONTRIBUTING\.md"|href="https://github.com/puremachinery/carapace/blob/main/CONTRIBUTING.md"|g' \
     -e 's|href="\.\./architecture\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/architecture.md\1"|g' \
     -e 's|href="\.\./protocol/([^":#]+)\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md\2"|g' \
+    -e 's|href="protocol/([^":#]+)\.md"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md"|g')"
+
+  # Cookbook pages publish one level deeper (public/cookbook/*.html), so every
+  # `../X.md` reference to a sibling top-level doc must keep the `../` prefix
+  # rather than being stripped by the generic rewrites below. Handle slug
+  # renames (security.md -> security-model.html, SECURITY.md -> security-policy.html)
+  # explicitly before the catch-all. The `../feature-*.yaml` rules mirror the
+  # docs-kind rules but preserve `../` for depth.
+  if [[ "$kind" == "cookbook" ]]; then
+    body="$(printf '%s' "$body" | sed -E \
+      -e 's|href="\.\./security\.md(#[-A-Za-z0-9._/]*)?"|href="../security-model.html\1"|g' \
+      -e 's|href="\.\./\.\./SECURITY\.md(#[-A-Za-z0-9._/]*)?"|href="../security-policy.html\1"|g' \
+      -e 's|href="\.\./SECURITY\.md(#[-A-Za-z0-9._/]*)?"|href="../security-policy.html\1"|g' \
+      -e 's|href="\.\./([A-Za-z0-9._-]+)\.md(#[-A-Za-z0-9._/]*)?"|href="../\1.html\2"|g' \
+      -e 's|href="\.\./feature-status\.yaml"|href="../feature-status.yaml"|g' \
+      -e 's|href="\.\./feature-evidence\.yaml"|href="../feature-evidence.yaml"|g')"
+  fi
+
+  body="$(printf '%s' "$body" | sed -E \
     -e 's|href="\.\./release\.md"|href="release.html"|g' \
     -e 's|href="\.\./cli\.md"|href="cli.html"|g' \
     -e 's|href="\.\./feature-status\.yaml"|href="feature-status.yaml"|g' \
@@ -71,7 +84,6 @@ rewrite_links() {
     -e 's|href="\.\./SECURITY\.md"|href="security-policy.html"|g' \
     -e 's|href="\.\./([A-Za-z0-9._-]+)\.md(#[-A-Za-z0-9._/]*)?"|href="\1.html\2"|g' \
     -e 's|href="docs/security\.md"|href="security-model.html"|g' \
-    -e 's|href="protocol/([^":#]+)\.md"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md"|g' \
     -e 's|href="cookbook/README\.md"|href="cookbook/"|g' \
     -e 's|href="cookbook/([^":#]+)\.md(#[-A-Za-z0-9._/]*)?"|href="cookbook/\1.html\2"|g' \
     -e 's|href="\.\./cookbook/README\.md"|href="cookbook/"|g' \

--- a/scripts/build-pages-content.sh
+++ b/scripts/build-pages-content.sh
@@ -45,6 +45,15 @@ rewrite_links() {
   local body="$1"
   local kind="$2"
 
+  # Cookbook pages publish one level deeper (public/cookbook/*.html), so
+  # `../channels.md` / `../channel-smoke.md` references must keep the `../`
+  # prefix instead of being stripped by the generic rewrites below.
+  if [[ "$kind" == "cookbook" ]]; then
+    body="$(printf '%s' "$body" | sed -E \
+      -e 's|href="\.\./channel-smoke\.md(#[-A-Za-z0-9._/]*)?"|href="../channel-smoke.html\1"|g' \
+      -e 's|href="\.\./channels\.md(#[-A-Za-z0-9._/]*)?"|href="../channels.html\1"|g')"
+  fi
+
   body="$(printf '%s' "$body" | sed -E \
     -e 's|href="\.\./CONTRIBUTING\.md"|href="https://github.com/puremachinery/carapace/blob/main/CONTRIBUTING.md"|g' \
     -e 's|href="\.\./architecture\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/architecture.md\1"|g' \


### PR DESCRIPTION
## Summary

Fixes the Pages workflow failure on master caused by two broken internal
links in `public/cookbook/signal-assistant.html`.

`docs/cookbook/signal-assistant.md` legitimately references
`../channels.md` and `../channel-smoke.md`, but `scripts/build-pages-content.sh`
was stripping the `../` prefix unconditionally (correct for top-level
docs pages that publish to `public/*.html`, wrong for cookbook pages
that publish to `public/cookbook/*.html`). The rendered HTML therefore
resolved `channels.html` / `channel-smoke.html` against
`public/cookbook/`, where no such files exist, and
`check-pages-links.sh` failed the build.

The fix adds a cookbook-specific pre-pass in `rewrite_links` that
rewrites `../channels.md` → `../channels.html` and
`../channel-smoke.md` → `../channel-smoke.html` before the generic
`../`-stripping rules run — mirroring the existing pattern for
`../site/*.md` on line 71.

## Test plan

- [x] `rm -rf public && mkdir -p public && cp -R website/. public/ && ./scripts/check-docs-state-messaging.sh && ./scripts/build-pages-content.sh public && ./scripts/check-pages-links.sh public` — passes locally
- [x] `public/cookbook/signal-assistant.html` now renders `../channels.html` / `../channel-smoke.html`
- [x] `public/docs.html` (docs kind) still renders bare `channels.html` / `channel-smoke.html` (unchanged)
- [ ] Pages workflow succeeds on this PR