### PR TITLE
fix(pages): validate cookbook link rewrites in PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,26 @@ on:
       - "scripts/check-pages-links.sh"
       - "scripts/check-docs-state-messaging.sh"
       - ".github/workflows/pages.yml"
+  pull_request:
+    paths:
+      - "website/**"
+      - "docs/cookbook/**"
+      - "docs/getting-started.md"
+      - "docs/plugin-development.md"
+      - "docs/release.md"
+      - "docs/cli.md"
+      - "docs/channels.md"
+      - "docs/channel-smoke.md"
+      - "docs/security.md"
+      - "docs/security-comparison.md"
+      - "docs/feature-status.yaml"
+      - "docs/feature-evidence.yaml"
+      - "docs/site/**"
+      - "SECURITY.md"
+      - "scripts/build-pages-content.sh"
+      - "scripts/check-pages-links.sh"
+      - "scripts/check-docs-state-messaging.sh"
+      - ".github/workflows/pages.yml"
   workflow_dispatch:
 
 permissions:
@@ -29,8 +49,10 @@ permissions:
   pages: write
   id-token: write
 
+# Scope concurrency by ref so PR validation runs don't cancel an in-flight
+# master deploy (and vice versa).
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -60,13 +82,19 @@ jobs:
       - name: Validate generated internal links
         run: ./scripts/check-pages-links.sh public
 
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      # Artifact upload + deploy only run on push to master; PRs stop after
+      # validation. upload-pages-artifact also requires pages/id-token scope
+      # that is not granted to pull_request events from forks.
+      - if: github.event_name == 'push'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: public
 
   deploy:
+    if: github.event_name == 'push'
     name: Deploy Pages
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,8 +46,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Scope concurrency by ref so PR validation runs don't cancel an in-flight
 # master deploy (and vice versa).
@@ -56,8 +54,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build Pages artifact
+  validate:
+    name: Validate Pages content
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -82,21 +82,48 @@ jobs:
       - name: Validate generated internal links
         run: ./scripts/check-pages-links.sh public
 
-      # Artifact upload + deploy only run on push to master; PRs stop after
-      # validation. upload-pages-artifact also requires pages/id-token scope
-      # that is not granted to pull_request events from forks.
-      - if: github.event_name == 'push'
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+  package:
+    if: github.event_name == 'push'
+    name: Package Pages artifact
+    needs: validate
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - if: github.event_name == 'push'
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - name: Prepare site
+        run: |
+          rm -rf public
+          mkdir -p public
+          cp -R website/. public/
+
+      - name: Install Pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
+      - name: Render website docs pages from Markdown
+        run: ./scripts/build-pages-content.sh public
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: public
 
   deploy:
     if: github.event_name == 'push'
     name: Deploy Pages
-    needs: build
+    needs: package
+    permissions:
+      pages: write
+      id-token: write
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -83,23 +83,6 @@ If you want Cara to inspect one local project directory, enable the
 `filesystem` block for a single workspace root and start with the
 [guarded local project assistant recipe](docs/cookbook/guarded-local-project-assistant.md).
 
-## Status
-
-Carapace ships a stable release line. Core paths are tested and verified for
-routine use, while partial and in-progress areas remain explicitly documented.
-
-- Working now: setup wizard, local chat (`cara chat`), token auth enforcement,
-  health/control endpoints (including durable task controls), control UI
-  frontend foundation (status/channels/redacted config editor), Codex
-  subscription onboarding, per-channel activity config with Signal
-  typing/read-receipt flows, and OpenAI-compatible HTTP endpoints.
-- In progress: advanced Control UI flows (pairing/workflow UX), broader
-  channel smoke evidence, and hardened internet-facing deployment guidance.
-
-See [docs/feature-status.yaml](docs/feature-status.yaml) and
-[docs/feature-evidence.yaml](docs/feature-evidence.yaml) for the current source
-of truth.
-
 ## Roadmap
 
 Active and planned work is tracked on

--- a/scripts/build-pages-content.sh
+++ b/scripts/build-pages-content.sh
@@ -45,10 +45,32 @@ rewrite_links() {
   local body="$1"
   local kind="$2"
 
+  # Absolute-URL redirects for out-of-site references are depth-agnostic and
+  # must run before the cookbook pre-pass below so the broad `../X.md` rule
+  # does not accidentally rewrite them to a relative HTML path.
   body="$(printf '%s' "$body" | sed -E \
     -e 's|href="\.\./CONTRIBUTING\.md"|href="https://github.com/puremachinery/carapace/blob/main/CONTRIBUTING.md"|g' \
     -e 's|href="\.\./architecture\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/architecture.md\1"|g' \
     -e 's|href="\.\./protocol/([^":#]+)\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md\2"|g' \
+    -e 's|href="protocol/([^":#]+)\.md"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md"|g')"
+
+  # Cookbook pages publish one level deeper (public/cookbook/*.html), so every
+  # `../X.md` reference to a sibling top-level doc must keep the `../` prefix
+  # rather than being stripped by the generic rewrites below. Handle slug
+  # renames (security.md -> security-model.html, SECURITY.md -> security-policy.html)
+  # explicitly before the catch-all. The `../feature-*.yaml` rules mirror the
+  # docs-kind rules but preserve `../` for depth.
+  if [[ "$kind" == "cookbook" ]]; then
+    body="$(printf '%s' "$body" | sed -E \
+      -e 's|href="\.\./security\.md(#[-A-Za-z0-9._/]*)?"|href="../security-model.html\1"|g' \
+      -e 's|href="\.\./\.\./SECURITY\.md(#[-A-Za-z0-9._/]*)?"|href="../security-policy.html\1"|g' \
+      -e 's|href="\.\./SECURITY\.md(#[-A-Za-z0-9._/]*)?"|href="../security-policy.html\1"|g' \
+      -e 's|href="\.\./([A-Za-z0-9._-]+)\.md(#[-A-Za-z0-9._/]*)?"|href="../\1.html\2"|g' \
+      -e 's|href="\.\./feature-status\.yaml"|href="../feature-status.yaml"|g' \
+      -e 's|href="\.\./feature-evidence\.yaml"|href="../feature-evidence.yaml"|g')"
+  fi
+
+  body="$(printf '%s' "$body" | sed -E \
     -e 's|href="\.\./release\.md"|href="release.html"|g' \
     -e 's|href="\.\./cli\.md"|href="cli.html"|g' \
     -e 's|href="\.\./feature-status\.yaml"|href="feature-status.yaml"|g' \
@@ -62,7 +84,6 @@ rewrite_links() {
     -e 's|href="\.\./SECURITY\.md"|href="security-policy.html"|g' \
     -e 's|href="\.\./([A-Za-z0-9._-]+)\.md(#[-A-Za-z0-9._/]*)?"|href="\1.html\2"|g' \
     -e 's|href="docs/security\.md"|href="security-model.html"|g' \
-    -e 's|href="protocol/([^":#]+)\.md"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md"|g' \
     -e 's|href="cookbook/README\.md"|href="cookbook/"|g' \
     -e 's|href="cookbook/([^":#]+)\.md(#[-A-Za-z0-9._/]*)?"|href="cookbook/\1.html\2"|g' \
     -e 's|href="\.\./cookbook/README\.md"|href="cookbook/"|g' \

--- a/scripts/build-pages-content.sh
+++ b/scripts/build-pages-content.sh
@@ -52,7 +52,7 @@ rewrite_links() {
     -e 's|href="\.\./CONTRIBUTING\.md"|href="https://github.com/puremachinery/carapace/blob/main/CONTRIBUTING.md"|g' \
     -e 's|href="\.\./architecture\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/architecture.md\1"|g' \
     -e 's|href="\.\./protocol/([^":#]+)\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md\2"|g' \
-    -e 's|href="protocol/([^":#]+)\.md"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md"|g')"
+    -e 's|href="protocol/([^":#]+)\.md(#[-A-Za-z0-9._/]*)?"|href="https://github.com/puremachinery/carapace/blob/main/docs/protocol/\1.md\2"|g')"
 
   # Cookbook pages publish one level deeper (public/cookbook/*.html), so every
   # `../X.md` reference to a sibling top-level doc must keep the `../` prefix
@@ -68,21 +68,23 @@ rewrite_links() {
       -e 's|href="\.\./([A-Za-z0-9._-]+)\.md(#[-A-Za-z0-9._/]*)?"|href="../\1.html\2"|g' \
       -e 's|href="\.\./feature-status\.yaml"|href="../feature-status.yaml"|g' \
       -e 's|href="\.\./feature-evidence\.yaml"|href="../feature-evidence.yaml"|g')"
+  else
+    body="$(printf '%s' "$body" | sed -E \
+      -e 's|href="\.\./release\.md"|href="release.html"|g' \
+      -e 's|href="\.\./cli\.md"|href="cli.html"|g' \
+      -e 's|href="\.\./feature-status\.yaml"|href="feature-status.yaml"|g' \
+      -e 's|href="\.\./feature-evidence\.yaml"|href="feature-evidence.yaml"|g' \
+      -e 's|href="\.\./channel-smoke\.md"|href="channel-smoke.html"|g' \
+      -e 's|href="\.\./channels\.md"|href="channels.html"|g' \
+      -e 's|href="\.\./getting-started\.md"|href="getting-started.html"|g' \
+      -e 's|href="\.\./security\.md(#[-A-Za-z0-9._/]*)?"|href="security-model.html\1"|g' \
+      -e 's|href="\.\./security-comparison\.md(#[-A-Za-z0-9._/]*)?"|href="security-comparison.html\1"|g' \
+      -e 's|href="\.\./\.\./SECURITY\.md(#[-A-Za-z0-9._/]*)?"|href="security-policy.html\1"|g' \
+      -e 's|href="\.\./SECURITY\.md(#[-A-Za-z0-9._/]*)?"|href="security-policy.html\1"|g' \
+      -e 's|href="\.\./([A-Za-z0-9._-]+)\.md(#[-A-Za-z0-9._/]*)?"|href="\1.html\2"|g')"
   fi
 
   body="$(printf '%s' "$body" | sed -E \
-    -e 's|href="\.\./release\.md"|href="release.html"|g' \
-    -e 's|href="\.\./cli\.md"|href="cli.html"|g' \
-    -e 's|href="\.\./feature-status\.yaml"|href="feature-status.yaml"|g' \
-    -e 's|href="\.\./feature-evidence\.yaml"|href="feature-evidence.yaml"|g' \
-    -e 's|href="\.\./channel-smoke\.md"|href="channel-smoke.html"|g' \
-    -e 's|href="\.\./channels\.md"|href="channels.html"|g' \
-    -e 's|href="\.\./getting-started\.md"|href="getting-started.html"|g' \
-    -e 's|href="\.\./security\.md"|href="security-model.html"|g' \
-    -e 's|href="\.\./security-comparison\.md"|href="security-comparison.html"|g' \
-    -e 's|href="\.\./\.\./SECURITY\.md"|href="security-policy.html"|g' \
-    -e 's|href="\.\./SECURITY\.md"|href="security-policy.html"|g' \
-    -e 's|href="\.\./([A-Za-z0-9._-]+)\.md(#[-A-Za-z0-9._/]*)?"|href="\1.html\2"|g' \
     -e 's|href="docs/security\.md"|href="security-model.html"|g' \
     -e 's|href="cookbook/README\.md"|href="cookbook/"|g' \
     -e 's|href="cookbook/([^":#]+)\.md(#[-A-Za-z0-9._/]*)?"|href="cookbook/\1.html\2"|g' \


### PR DESCRIPTION
## Summary

- fix cookbook Pages link rewriting so `../X.md` references from `docs/cookbook/*` stay one level up after HTML rendering
- broaden the cookbook rewrite pass in `scripts/build-pages-content.sh` so sibling top-level docs and `feature-*.yaml` links resolve correctly
- run the Pages validation workflow on `pull_request` events for site-relevant changes, while keeping artifact upload and deploy gated to `push`

## Validation

- `./scripts/check-docs-state-messaging.sh`
- `just workflow-lint`
- `mkdir -p public-pages-check && cp -R website/. public-pages-check/`
- `bash scripts/build-pages-content.sh public-pages-check`
- `scripts/check-pages-links.sh public-pages-check`
