### PR TITLE
chore: refresh dependency batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,8 +505,8 @@ dependencies = [
  "wasmtime",
  "win32job",
  "windows-sys 0.61.2",
- "wit-component 0.246.2",
- "wit-parser 0.246.2",
+ "wit-component 0.247.0",
+ "wit-parser 0.247.0",
  "x509-parser",
  "zeroize",
 ]
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1251,18 +1251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,23 +1635,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni 0.22.4",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1672,21 +1659,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2048,6 +2060,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2109,7 +2124,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2117,10 +2132,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2292,9 +2356,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mdns-sd"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451927183d65d600e52b4e877a1251e051576f84fa01e5b4a50b450dfaaa537c"
+checksum = "c2bb8ce26633738d98ffcef71ec58bff967c6675be50229823c2835f6316e67e"
 dependencies = [
  "fastrand",
  "flume",
@@ -2380,6 +2444,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -2730,6 +2800,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -3240,7 +3321,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -3534,9 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1c326f5796df635de915cc1b2d29485423df10a4997be6103091772f503451"
+checksum = "15ee875bc02244694d5b380ba437349d269cf168bbd84e896437c579317ac6e4"
 dependencies = [
  "base64",
  "hex",
@@ -3552,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6271208173601a0f058f5fb5354561905a7ead9b4185d85a6c2ed97fbdd31338"
+checksum = "c38e3886caf4e1a5a20806c0dc0f5acf33a0bd9c720415ece9e44ddc7a7bf1c1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3574,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692e1c1037124c0305e6e342c6a5fa180a31d6ce0eafc0e6c8f001d200083f8d"
+checksum = "eaa2a84ceb4b2a7bd42cff428555b7ac8897ce22b8c74a56558b53ac6ff10af9"
 dependencies = [
  "base64",
  "hex",
@@ -3587,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21abbf2ab10930dd2eb77cbc4c24b1efa6da89f6f0dce9b28b7c1362e7b80da8"
+checksum = "c012c1a119e2533d236d5d4244fec16e3be1243ce3fa0e0e9130cb6fc5f830c9"
 dependencies = [
  "base64",
  "hex",
@@ -3605,9 +3686,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f9d2f2dc33e04c80cfd5f11c93b64f0a2555b1d7f92b5aa16307266f05ad8c"
+checksum = "6fa1be3a70fdefac1156561f70b44263601dce6ca8ce7022c0c51b142ec0138f"
 dependencies = [
  "base64",
  "chrono",
@@ -3629,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43c677d430038c216b4f6368efc8cea42f35eca4d20fe5fcf51133d71b3b51b"
+checksum = "2d48313c1591c98f6233882786809069ff8f047271d3ffac48fb34966f61ba4e"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3655,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa6bca8f329e06c7ccb5b9f9be82b165b2be063396be0ee57b13402b994744"
+checksum = "7cb6793ac7a0960807ed731055763f0cdf3ae356c5eccfdb21a44b9671e96d6c"
 dependencies = [
  "base64",
  "chrono",
@@ -3670,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44caf1ea504259cf70c7c16527d8a3fa07bd9374ba4e59ec247e7d13a7f2cb8"
+checksum = "056618bdcc8d8b015f97f49602f95e6adf4ee851eb777d11a01241cdc40f5abe"
 dependencies = [
  "base64",
  "chrono",
@@ -3703,6 +3784,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -3872,6 +3969,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4047,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4459,9 +4577,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4620,6 +4738,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4633,14 +4761,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.246.2"
+version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e4c2aa916c425dcca61a6887d3e135acdee2c6d0ed51fd61c08d41ddaf62b1"
+checksum = "665fe59e56cc9b419ca6fcca56673e3421d1a5011e3b65caf6b726fd9e041d10"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -4692,6 +4820,18 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.17.0",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4964,22 +5104,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "246.0.2"
+version = "247.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
+checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.246.2",
+ "wasm-encoder 0.247.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.2"
+version = "1.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
+checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
 dependencies = [
  "wast",
 ]
@@ -5681,9 +5821,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.246.2"
+version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1936c26cb24b93dc36bf78fb5dc35c55cd37f66ecdc2d2663a717d9fb3ee951e"
+checksum = "9d567162a6b9843080e5e0053f696623ff694bae8ae017c9ec536d1873bbe3d8"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -5692,11 +5832,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.246.2",
- "wasm-metadata 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.247.0",
+ "wasm-metadata 0.247.0",
+ "wasmparser 0.247.0",
  "wat",
- "wit-parser 0.246.2",
+ "wit-parser 0.247.0",
 ]
 
 [[package]]
@@ -5734,6 +5874,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ axum = { version = "0.8", features = ["ws"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 reqwest = { version = "0.13", features = ["rustls", "stream", "json", "blocking", "multipart", "form"], default-features = false }
-hickory-resolver = "0.25"
+hickory-resolver = "0.26"
 url = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -81,8 +81,8 @@ insta = { version = "1", features = ["json"] }
 tokio-test = "0.4"
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-wit-component = { version = "0.246.2", features = ["dummy-module"] }
-wit-parser = "0.246.2"
+wit-component = { version = "0.247.0", features = ["dummy-module"] }
+wit-parser = "0.247.0"
 
 [features]
 gateway = []

--- a/src/channels/media_fetch.rs
+++ b/src/channels/media_fetch.rs
@@ -3,8 +3,6 @@
 use std::net::IpAddr;
 use std::time::Duration;
 
-use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 
 use crate::media::fetch::{DEFAULT_FETCH_TIMEOUT_MS, MAX_FETCH_TIMEOUT_MS, MAX_URL_LENGTH};
@@ -123,14 +121,11 @@ fn resolve_and_validate_dns(
     let host = host.to_string();
     let ssrf_config = ssrf_config.clone();
     let fut = async move {
-        let resolver = TokioResolver::builder_with_config(
-            ResolverConfig::default(),
-            TokioRuntimeProvider::default(),
-        )
-        .build()
-        .map_err(|e| {
-            ResolveDnsError::Retryable(format!("DNS resolver initialization failed: {e}"))
-        })?;
+        let resolver = TokioResolver::builder_tokio()
+            .and_then(|builder| builder.build())
+            .map_err(|e| {
+                ResolveDnsError::Retryable(format!("DNS resolver initialization failed: {e}"))
+            })?;
         let lookup = resolver.lookup_ip(&host).await.map_err(|e| {
             ResolveDnsError::Retryable(format!("DNS resolution failed: {host}: {e}"))
         })?;

--- a/src/channels/media_fetch.rs
+++ b/src/channels/media_fetch.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 
 use crate::media::fetch::{DEFAULT_FETCH_TIMEOUT_MS, MAX_FETCH_TIMEOUT_MS, MAX_URL_LENGTH};
@@ -125,9 +125,12 @@ fn resolve_and_validate_dns(
     let fut = async move {
         let resolver = TokioResolver::builder_with_config(
             ResolverConfig::default(),
-            TokioConnectionProvider::default(),
+            TokioRuntimeProvider::default(),
         )
-        .build();
+        .build()
+        .map_err(|e| {
+            ResolveDnsError::Retryable(format!("DNS resolver initialization failed: {e}"))
+        })?;
         let lookup = resolver.lookup_ip(&host).await.map_err(|e| {
             ResolveDnsError::Retryable(format!("DNS resolution failed: {host}: {e}"))
         })?;

--- a/src/media/fetch.rs
+++ b/src/media/fetch.rs
@@ -12,7 +12,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 use reqwest::Client;
 use thiserror::Error;
@@ -278,9 +278,10 @@ impl MediaFetcher {
     ) -> Result<IpAddr, FetchError> {
         let resolver = TokioResolver::builder_with_config(
             ResolverConfig::default(),
-            TokioConnectionProvider::default(),
+            TokioRuntimeProvider::default(),
         )
-        .build();
+        .build()
+        .map_err(|e| FetchError::DnsResolution(format!("resolver initialization failed: {e}")))?;
 
         let lookup = resolver
             .lookup_ip(host)

--- a/src/media/fetch.rs
+++ b/src/media/fetch.rs
@@ -11,8 +11,6 @@
 use std::net::IpAddr;
 use std::time::Duration;
 
-use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 use reqwest::Client;
 use thiserror::Error;
@@ -276,12 +274,11 @@ impl MediaFetcher {
         host: &str,
         ssrf_config: &SsrfConfig,
     ) -> Result<IpAddr, FetchError> {
-        let resolver = TokioResolver::builder_with_config(
-            ResolverConfig::default(),
-            TokioRuntimeProvider::default(),
-        )
-        .build()
-        .map_err(|e| FetchError::DnsResolution(format!("resolver initialization failed: {e}")))?;
+        let resolver = TokioResolver::builder_tokio()
+            .and_then(|builder| builder.build())
+            .map_err(|e| {
+                FetchError::DnsResolution(format!("resolver initialization failed: {e}"))
+            })?;
 
         let lookup = resolver
             .lookup_ip(host)

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -8,8 +8,6 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 use parking_lot::RwLock;
 use reqwest::Client;
@@ -96,6 +94,9 @@ pub enum HostError {
 
     #[error("HTTP error: {0}")]
     Http(String),
+
+    #[error("DNS error: {0}")]
+    DnsResolution(String),
 
     #[error("Media fetch error: {0}")]
     MediaFetch(String),
@@ -534,18 +535,16 @@ impl<B: CredentialBackend + 'static> PluginHostContext<B> {
     /// returns a public IP but later returns a private IP.
     async fn resolve_and_validate_dns(&self, host: &str) -> Result<IpAddr, HostError> {
         // Create a resolver
-        let resolver = TokioResolver::builder_with_config(
-            ResolverConfig::default(),
-            TokioRuntimeProvider::default(),
-        )
-        .build()
-        .map_err(|e| HostError::Http(format!("DNS resolver initialization failed: {e}")))?;
+        let resolver = TokioResolver::builder_tokio()
+            .and_then(|builder| builder.build())
+            .map_err(|e| {
+                HostError::DnsResolution(format!("resolver initialization failed: {e}"))
+            })?;
 
         // Resolve the hostname
-        let lookup = resolver
-            .lookup_ip(host)
-            .await
-            .map_err(|e| HostError::Http(format!("DNS resolution failed for {}: {}", host, e)))?;
+        let lookup = resolver.lookup_ip(host).await.map_err(|e| {
+            HostError::DnsResolution(format!("resolution failed for {}: {}", host, e))
+        })?;
 
         // Collect IPs and validate each one
         let mut validated_ip: Option<IpAddr> = None;
@@ -558,7 +557,7 @@ impl<B: CredentialBackend + 'static> PluginHostContext<B> {
 
         // Ensure at least one IP was resolved and validated
         validated_ip.ok_or_else(|| {
-            HostError::Http(format!("DNS resolution returned no addresses for {}", host))
+            HostError::DnsResolution(format!("resolution returned no addresses for {}", host))
         })
     }
 
@@ -662,7 +661,9 @@ impl<B: CredentialBackend + 'static> PluginHostContext<B> {
             }
             Err(e) => {
                 return Err(match e {
-                    HostError::Http(msg) => HostError::MediaFetch(msg),
+                    HostError::Http(msg) | HostError::DnsResolution(msg) => {
+                        HostError::MediaFetch(msg)
+                    }
                     other => other,
                 });
             }
@@ -721,7 +722,9 @@ impl<B: CredentialBackend + 'static> PluginHostContext<B> {
                 .resolve_and_validate_dns(&host)
                 .await
                 .map_err(|e| match e {
-                    HostError::Http(msg) => HostError::MediaFetch(msg),
+                    HostError::Http(msg) | HostError::DnsResolution(msg) => {
+                        HostError::MediaFetch(msg)
+                    }
                     other => other,
                 })?;
             let socket_addr = std::net::SocketAddr::new(validated_ip, port);

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 use parking_lot::RwLock;
 use reqwest::Client;
@@ -536,9 +536,10 @@ impl<B: CredentialBackend + 'static> PluginHostContext<B> {
         // Create a resolver
         let resolver = TokioResolver::builder_with_config(
             ResolverConfig::default(),
-            TokioConnectionProvider::default(),
+            TokioRuntimeProvider::default(),
         )
-        .build();
+        .build()
+        .map_err(|e| HostError::Http(format!("DNS resolver initialization failed: {e}")))?;
 
         // Resolve the hostname
         let lookup = resolver

--- a/src/server/ws/handlers/plugins.rs
+++ b/src/server/ws/handlers/plugins.rs
@@ -8,8 +8,6 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 
 #[cfg(unix)]
@@ -350,14 +348,11 @@ fn validate_and_resolve_dns(url: &url::Url) -> Result<(String, u16, Option<IpAdd
         // Host is a hostname -- resolve DNS and validate every returned IP.
         let host_for_lookup = host.clone();
         let ip = run_sync_blocking_send(async move {
-            let resolver = TokioResolver::builder_with_config(
-                ResolverConfig::default(),
-                TokioRuntimeProvider::default(),
-            )
-            .build()
-            .map_err(|e| {
-                PluginDnsError::Unavailable(format!("DNS resolver initialization failed: {e}"))
-            })?;
+            let resolver = TokioResolver::builder_tokio()
+                .and_then(|builder| builder.build())
+                .map_err(|e| {
+                    PluginDnsError::Unavailable(format!("DNS resolver initialization failed: {e}"))
+                })?;
 
             let lookup = resolver.lookup_ip(&host_for_lookup).await.map_err(|e| {
                 PluginDnsError::Unavailable(format!(

--- a/src/server/ws/handlers/plugins.rs
+++ b/src/server/ws/handlers/plugins.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use hickory_resolver::config::ResolverConfig;
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::TokioResolver;
 
 #[cfg(unix)]
@@ -352,9 +352,12 @@ fn validate_and_resolve_dns(url: &url::Url) -> Result<(String, u16, Option<IpAdd
         let ip = run_sync_blocking_send(async move {
             let resolver = TokioResolver::builder_with_config(
                 ResolverConfig::default(),
-                TokioConnectionProvider::default(),
+                TokioRuntimeProvider::default(),
             )
-            .build();
+            .build()
+            .map_err(|e| {
+                PluginDnsError::Unavailable(format!("DNS resolver initialization failed: {e}"))
+            })?;
 
             let lookup = resolver.lookup_ip(&host_for_lookup).await.map_err(|e| {
                 PluginDnsError::Unavailable(format!(

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use sigstore_trust_root::TrustedRoot;
+use sigstore_trust_root::{TrustedRoot, TufConfig};
 use sigstore_types::{Bundle, Sha256Hash};
 use sigstore_verify::{VerificationPolicy, Verifier, DEFAULT_CLOCK_SKEW_SECONDS};
 use std::fmt;
@@ -15,7 +15,7 @@ use tokio::io::AsyncWriteExt;
 
 #[cfg(test)]
 use sigstore_trust_root::{
-    TufConfig, PRODUCTION_TUF_ROOT, SIGSTORE_PRODUCTION_TRUSTED_ROOT, TRUSTED_ROOT_TARGET,
+    PRODUCTION_TUF_ROOT, SIGSTORE_PRODUCTION_TRUSTED_ROOT, TRUSTED_ROOT_TARGET,
 };
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -846,20 +846,7 @@ async fn verify_parsed_bundle_signature_with_trust_root(
 }
 
 async fn load_sigstore_trust_root() -> Result<TrustedRoot, UpdateError> {
-    TrustedRoot::from_tuf().await.map_err(|err| {
-        UpdateError::retryable(
-            Some(UpdatePhase::Verified),
-            format!("failed to initialize sigstore trust root: {err}"),
-        )
-    })
-}
-
-#[cfg(test)]
-async fn load_sigstore_trust_root_with_config(
-    config: TufConfig,
-    tuf_root: &'static [u8],
-) -> Result<TrustedRoot, UpdateError> {
-    TrustedRoot::from_tuf_with_config(config, tuf_root)
+    TrustedRoot::from_tuf(TufConfig::production())
         .await
         .map_err(|err| {
             UpdateError::retryable(
@@ -870,8 +857,20 @@ async fn load_sigstore_trust_root_with_config(
 }
 
 #[cfg(test)]
+async fn load_sigstore_trust_root_with_config(
+    config: TufConfig,
+) -> Result<TrustedRoot, UpdateError> {
+    TrustedRoot::from_tuf(config).await.map_err(|err| {
+        UpdateError::retryable(
+            Some(UpdatePhase::Verified),
+            format!("failed to initialize sigstore trust root: {err}"),
+        )
+    })
+}
+
+#[cfg(test)]
 fn load_embedded_sigstore_trust_root() -> Result<TrustedRoot, UpdateError> {
-    TrustedRoot::production().map_err(|err| {
+    TrustedRoot::from_json(SIGSTORE_PRODUCTION_TRUSTED_ROOT).map_err(|err| {
         UpdateError::retryable(
             Some(UpdatePhase::Verified),
             format!("failed to initialize sigstore trust root: {err}"),
@@ -1966,7 +1965,6 @@ mod tests {
             TufConfig::production()
                 .with_cache_dir(dir.path().to_path_buf())
                 .offline(),
-            PRODUCTION_TUF_ROOT,
         )
         .await
         .expect("offline TUF loader should read cached trusted root");
@@ -1979,16 +1977,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_load_sigstore_trust_root_offline_failure_is_retryable() {
+    async fn test_load_sigstore_trust_root_offline_production_falls_back_to_embedded() {
         let dir = tempfile::tempdir().unwrap();
-        let err = load_sigstore_trust_root_with_config(
+        let root = load_sigstore_trust_root_with_config(
             TufConfig::production()
                 .with_cache_dir(dir.path().to_path_buf())
                 .offline(),
-            PRODUCTION_TUF_ROOT,
         )
         .await
-        .expect_err("missing offline TUF cache should fail");
+        .expect("offline production loader should fall back to embedded trusted root");
+        let embedded = load_embedded_sigstore_trust_root().unwrap();
+
+        assert_eq!(
+            serde_json::to_value(&root).unwrap(),
+            serde_json::to_value(&embedded).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_load_sigstore_trust_root_offline_custom_missing_cache_failure_is_retryable() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = load_sigstore_trust_root_with_config(
+            TufConfig::custom("https://example.invalid/sigstore-tuf/", PRODUCTION_TUF_ROOT)
+                .with_cache_dir(dir.path().to_path_buf())
+                .offline(),
+        )
+        .await
+        .expect_err("custom offline TUF loader should fail without cached target");
 
         assert!(err.retryable);
         assert_eq!(err.phase, Some(UpdatePhase::Verified));
@@ -2012,7 +2027,6 @@ mod tests {
             TufConfig::production()
                 .with_cache_dir(dir.path().to_path_buf())
                 .offline(),
-            PRODUCTION_TUF_ROOT,
         )
         .await
         .expect("offline TUF loader should read cached trusted root");

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -1953,7 +1953,7 @@ mod tests {
     #[tokio::test]
     async fn test_load_sigstore_trust_root_offline_tuf_cache_matches_embedded_production() {
         let dir = tempfile::tempdir().unwrap();
-        let targets_dir = dir.path().join("targets");
+        let targets_dir = dir.path().join("sigstore-rust");
         std::fs::create_dir_all(&targets_dir).unwrap();
         std::fs::write(
             targets_dir.join(TRUSTED_ROOT_TARGET),
@@ -2015,7 +2015,7 @@ mod tests {
     #[tokio::test]
     async fn test_verify_bundle_signature_accepts_v070_sha256sums_bundle_with_offline_tuf_root() {
         let dir = tempfile::tempdir().unwrap();
-        let targets_dir = dir.path().join("targets");
+        let targets_dir = dir.path().join("sigstore-rust");
         std::fs::create_dir_all(&targets_dir).unwrap();
         std::fs::write(
             targets_dir.join(TRUSTED_ROOT_TARGET),


### PR DESCRIPTION
## Summary

- Consolidates dependency updates from Dependabot PRs #378, #379, #381, and #382.
- Updates `hickory-resolver` to 0.26, `wit-component`/`wit-parser` to 0.247, and refreshes the grouped patch updates for `clap`, `tokio`, `uuid`, `mdns-sd`, and `sigstore-*`.
- Migrates Hickory resolver construction to `TokioRuntimeProvider` and handles fallible resolver builds.
- Updates Sigstore trust-root loading/tests for the explicit `TufConfig` API and the new production offline embedded fallback behavior.

## Validation

- `scripts/cargo-serial check --tests`
- `scripts/cargo-serial clippy --all-targets --all-features -- -D warnings`
- `env CARAPACE_ALLOW_REAL_CARGO=1 ./scripts/run-nextest-guarded.sh --all-targets -P golden`
- `scripts/cargo-serial deny check`
- `scripts/cargo-serial audit`
- `env CARAPACE_ALLOW_REAL_CARGO=1 ./scripts/run-nextest-guarded.sh --all-targets -P fast`
