### PR TITLE
docs: capability-aware routing — deferred design record (#189)

### DIFF
--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -100,6 +100,14 @@ routes: {
 This is the design as drafted. It carries the **open questions** below
 that would need resolution before this could ship.
 
+> **Heads up for anyone copy-pasting the example above into a live config:**
+> adding `routes.byCapability` today would be **silently ignored** by
+> `load_routes`, which iterates every key under `routes` and tries
+> `serde_json::from_value::<RouteConfig>` on each value. `byCapability`
+> is an object (not a `RouteConfig`), and `RouteConfig` has no `route`
+> field today, so the entry would emit a `tracing::warn!` and be
+> dropped. See **O1** below for what would have to change first.
+
 ### Resolution order (as drafted)
 
 Highest to lowest precedence:
@@ -200,7 +208,8 @@ design doc implies.
 `src/config/routes.rs` already surfaces config-key-path remediation
 hints through `AgentError::Provider` for two error paths that reach
 external callers today. `resolve_execution_target` is called from
-`resolve_agent_model` (`src/agent/mod.rs:254`), and the resulting
+inside `resolve_agent_model` (defined at `src/agent/mod.rs:254`, with
+the actual call site at `src/agent/mod.rs:~293`), and the resulting
 `AgentError` is fmt-stringified to external callers via:
 
 - HTTP: `src/server/http.rs:~1308` (`AgentResponse::error(&e.to_string())`)

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -205,36 +205,37 @@ security-first gateway.
 it is being tracked separately at higher urgency than this deferred
 design doc implies.
 
-`src/config/routes.rs` already surfaces config-key-path remediation
-hints through `AgentError::Provider` for two error paths that reach
-external callers today. `resolve_execution_target` is called from
-inside `resolve_agent_model` (defined at `src/agent/mod.rs:254`, with
-the actual call site at `src/agent/mod.rs:~293`), and the resulting
-`AgentError` is fmt-stringified to external callers via:
+`resolve_execution_target` in `src/config/routes.rs` already surfaces
+config-key-path remediation hints through `AgentError::Provider` for
+two error paths that reach external callers today. The resolver is
+called from inside `resolve_agent_model` (in `src/agent/mod.rs`), and
+the resulting `AgentError` is fmt-stringified to external callers via:
 
-- HTTP: `src/server/http.rs:~1308` (`AgentResponse::error(&e.to_string())`)
-- WebSocket: `src/server/ws/handlers/sessions.rs:~2102`
-  (`error_shape(ERROR_UNAVAILABLE, &e.to_string(), None)`, called
-  from the `resolve_agent_model` site at line ~2091)
+- **HTTP** — the `AgentResponse::error(&e.to_string())` arm in
+  `src/server/http.rs` after the request handler's
+  `resolve_agent_model` call.
+- **WebSocket** — the `error_shape(ERROR_UNAVAILABLE, &e.to_string(), None)`
+  arm in `src/server/ws/handlers/sessions.rs` after the agent-run
+  handler's `resolve_agent_model` call.
 
-The auto-reply background-trigger path in the same file (around
-line ~2502) also calls `resolve_agent_model`, but its error arm is
-`tracing::warn!(...)` followed by a generic `(None, "queued")` return
-— the error string is logged server-side only and never reaches the
-external caller. That path is **not** a leak surface and needs no
-remediation in #398.
+A second `resolve_agent_model` call site exists in
+`src/server/ws/handlers/sessions.rs` for the auto-reply
+background-trigger path, but its error arm is `tracing::warn!(...)`
+followed by `(None, "queued")` — the error string is logged
+server-side only and never reaches the external caller. That path is
+**not** a leak surface and needs no remediation in #398.
 
 Note this is **not** the OpenAI-compat provider-error surface
 (`src/server/openai.rs`); that path handles errors from
 `call_llm_provider`, not route-resolution. The two surfaces are
 disjoint.
 
-The two leaking error messages:
+The two leaking error messages from `resolve_execution_target`:
 
 - `unknown route "<name>"; define it in the top-level \`routes\` config
-  map` (`src/config/routes.rs:~98`)
+  map`
 - `no model configured; set \`route\` or \`model\` in agent config or
-  defaults` (`src/config/routes.rs:~120`)
+  defaults`
 
 The remediation — introduce a `ConfigError`-family variant, surface a
 stable wire-format code at the server boundary, keep human-readable

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -1,0 +1,387 @@
+# Capability-Aware Routing for Multimodal Workflows
+
+Status: design proposal (issue #189)
+Owner: routes/agent layer (`src/config/routes.rs`, `src/agent/factory.rs`)
+Scope: gateway request resolution; no provider-side capability negotiation.
+
+## Problem
+
+Carapace exposes a single execution target per agent through
+`agents.defaults.model` and the `routes` map (`src/config/routes.rs`,
+`src/agent/provider.rs`). Multimodal-adjacent work today is shipped at the
+*tool* layer: `src/media/` runs Claude Vision, GPT-4 Vision, and Whisper
+transcription as side calls (see `feature-status.yaml`, Media section). There
+is no first-class way to say "for this turn, route to a vision-capable model"
+or "use a different backend when the agent is asked to generate an image."
+
+The result is that an operator who configures `agents.defaults.route: "fast"`
+to a non-vision model has no recourse short of swapping agents or models
+manually at request time. That is the friction this design removes.
+
+The proposal here defines a typed, explicit capability override that composes
+with the existing named-routes precedence chain rather than replacing it.
+
+## Non-goals (first slice)
+
+- Automatic capability detection from request payloads or MIME sniffing.
+- Automatic failover between models on capability mismatch.
+- Cost-aware or latency-aware routing.
+- Provider-side capability negotiation or feature flags discovered at
+  runtime.
+- A general-purpose multi-agent dispatcher.
+
+## 1. Capability buckets
+
+Initial typed enum:
+
+| Capability | Reason in scope | Backed by today |
+|---|---|---|
+| `vision` | Already shipped via `src/media/` Claude Vision + GPT-4 Vision. Routing UX is the gap. | `feature-status.yaml` Media section |
+| `image_generation` | Carapace ships Venice provider but has no first-class generate-image route. Highest user-visible win for the slice. | `src/agent/venice.rs` |
+| `audio_transcription` | Whisper already shipped. Inclusion lets transcription runs target an OpenAI-compat or local backend distinct from chat. | `feature-status.yaml` Media |
+| `reasoning` | Listed as a candidate in the issue; included to validate that non-multimodal capabilities fit the same shape. Routes to higher-tier models (e.g. `anthropic:claude-opus-*`). | n/a (new) |
+
+Excluded from the typed enum for the first slice:
+
+- `code_execution`, `web_browsing`, `function_calling` — already covered by
+  the tool dispatch and prompt-guard layers; no routing decision to make.
+- `tts` — TTS providers are an orthogonal abstraction (`src/server/ws/handlers/tts.rs`)
+  that does not flow through `LlmProvider::complete`.
+- `embeddings` — no shipped surface yet; defer until embeddings are a
+  first-class request type.
+
+The enum is closed (`#[non_exhaustive]` on the public surface so future
+variants do not break consumers, but exhaustively matched internally). New
+buckets require a typed enum addition and a config schema update — they are
+not arbitrary strings.
+
+## 2. Where capability routes live in config
+
+Primary form: dedicated map under `routes.byCapability.*`.
+
+```json5
+routes: {
+  fast: { model: "anthropic:claude-sonnet-4-20250514" },
+  smart: { model: "anthropic:claude-opus-4-20250514" },
+  byCapability: {
+    vision:             { route: "smart" },
+    imageGeneration:    { model: "venice:flux-1.1-pro" },
+    audioTranscription: { model: "openai:whisper-1" },
+    reasoning:          { route: "smart" },
+  },
+},
+```
+
+Each capability entry is a `RouteConfig`-shaped pointer that may carry either
+`route` (delegate to a named route) or `model` (direct provider:model). The
+existing `RouteConfig` shape from `src/config/routes.rs` is reused; capability
+entries are not a parallel type.
+
+Why this form, not per-agent overrides or `agents.defaults` chains:
+
+- **Single source of truth for "where do I route X":** an operator answers
+  "what model handles vision?" by reading one config block. With per-agent
+  overrides, the answer fans out across every agent.
+- **Composes cleanly with named routes:** capability routes can themselves
+  be `route` references, so an operator can say "vision uses our `smart`
+  route" without duplicating the model string.
+- **Backwards-compatible:** `routes.byCapability` is a new, optional sub-key
+  under the existing `routes` object. Configs that omit it behave exactly as
+  today.
+
+How the alternatives compose with this primary form:
+
+- **Per-agent capability overrides** (`agents.list[].capabilityRoutes.vision`)
+  remain valid and override the global default. They are a precedence level
+  above `routes.byCapability` (see §3), not an alternative storage location.
+- **`agents.defaults.capabilityRoutes`** is the lowest-priority fallback when
+  `routes.byCapability` is not set. This mirrors the existing
+  `agents.defaults.model` shape and keeps the onboarding contract
+  (`docs/architecture.md` "Shared Provider Onboarding Contract") intact.
+
+## 3. Resolution order at request time
+
+A request that declares a capability resolves through the existing
+`SelectorLevel` chain, augmented with a capability-route lookup that runs
+*before* the existing model lookup at each scope.
+
+Precedence, highest to lowest:
+
+1. Request override — caller passed `route` or `model` directly.
+2. Session override — session-pinned `route`/`model`.
+3. Agent override — `agent.capabilityRoutes.<bucket>` if set.
+4. Default capability route — `routes.byCapability.<bucket>`.
+5. Agent default — `agent.route` / `agent.model`.
+6. Defaults — `agents.defaults.route` / `agents.defaults.model`.
+
+Pseudocode (extends `resolve_execution_target` in `src/config/routes.rs`):
+
+```rust
+pub fn resolve_with_capability(
+    routes: &HashMap<String, RouteConfig>,
+    capability_routes: &HashMap<Capability, RouteConfig>,
+    requested_capability: Option<Capability>,
+    inputs: &RouteResolutionInputs<'_>,
+) -> Result<ResolvedRoute, AgentError> {
+    // 1. Request-level direct selectors win unconditionally.
+    if let Some(target) = resolve_level(routes, &inputs.request, RequestRoute, RequestModel)? {
+        return Ok(target);
+    }
+    // 2. Session-level direct selectors.
+    if let Some(target) = resolve_level(routes, &inputs.session, SessionRoute, SessionModel)? {
+        return Ok(target);
+    }
+    // 3-4. Capability-aware selection only fires if the caller declared one.
+    if let Some(cap) = requested_capability {
+        // 3. Per-agent capability override.
+        if let Some(target) = inputs.agent_capability_route(cap) {
+            return resolve_capability_pointer(routes, &target, AgentCapabilityRoute);
+        }
+        // 4. Global capability default.
+        if let Some(pointer) = capability_routes.get(&cap) {
+            return resolve_capability_pointer(routes, pointer, DefaultCapabilityRoute);
+        }
+        // 5. Hard error: capability declared, nothing configured. (See §5.)
+        return Err(AgentError::Provider(format!(
+            "no route configured for capability \"{cap}\"; \
+             set routes.byCapability.{cap} in config"
+        )));
+    }
+    // 6. Agent default + defaults fallback (current behavior).
+    resolve_remaining_levels(routes, inputs)
+}
+```
+
+Diagram:
+
+```mermaid
+flowchart TD
+    A[Request arrives] --> B{request.route or request.model set?}
+    B -- yes --> Z[Use request selector]
+    B -- no --> C{session selector set?}
+    C -- yes --> Z2[Use session selector]
+    C -- no --> D{capability declared?}
+    D -- no --> E[Agent route/model -> defaults]
+    D -- yes --> F{agent.capabilityRoutes has bucket?}
+    F -- yes --> Z3[Use agent capability override]
+    F -- no --> G{routes.byCapability has bucket?}
+    G -- yes --> Z4[Use default capability route]
+    G -- no --> H[Hard error: no capable route]
+    Z --> R[Resolved provider:model]
+    Z2 --> R
+    Z3 --> R
+    Z4 --> R
+    E --> R
+```
+
+Note: capability resolution is **scoped between session and agent**. The
+rationale is that an operator-provided per-request `model` always wins (§5
+fail-closed semantics still apply if the chosen model lacks the capability —
+that is the operator's call), but agent-level capability overrides should
+beat the global capability default.
+
+## 4. How capability is detected on a request
+
+**Initial slice: explicit declaration only.** The caller MUST pass a typed
+`capability` field on the request. There is no MIME sniffing, no inference
+from the presence of an image part, no fallback heuristic.
+
+Reasons:
+
+- **Predictability:** Capability routing is a billing-relevant decision (an
+  image-generation route may be on a different provider with different
+  costs). Auto-routing on payload heuristics gives operators no way to audit
+  why a particular request hit a particular backend.
+- **Security:** Implicit MIME-based routing turns the *content* of an
+  attacker-controlled message into a router input. That is a confused
+  deputy. Carapace already treats inbound content as untrusted
+  (`src/agent/prompt_guard/`); routing should not be steerable by it.
+- **Test surface:** Explicit declaration is a typed enum field. Implicit
+  detection requires a mime/parser whose behavior is hard to lock down
+  without snapshot tests on every supported channel's payload shape.
+- **Deferable:** Auto-detection can be layered on later as a separate
+  resolver step that *populates* the typed capability field before
+  `resolve_with_capability` runs. The boundary stays the same.
+
+This matches the typed-boundary discipline in `AGENTS.md`: the wire shape is
+a typed enum, not a sniff result.
+
+## 5. Failure mode: capability declared but unconfigured
+
+**Recommendation: hard error.** Pre-launch product, security-first defaults
+(see `AGENTS.md` "Security-First Design"). If a caller asks for `vision` and
+the operator has not configured it, returning a verbose error with the
+config key to set is more defensible than silently routing to a model that
+will reject the image content with a less-actionable provider error.
+
+Tradeoff acknowledged:
+
+- **Pro hard error:** Operators learn about misconfiguration at the first
+  request, not after a confusing provider 4xx. Mirrors the existing
+  fail-closed behavior of `resolve_execution_target` for an unknown named
+  route (`unknown route "foo"; define it in the top-level routes config map`).
+- **Pro fall-through:** "More forgiving" — request still gets a response.
+  Rejected because (a) the response will likely fail downstream anyway when
+  the chosen model rejects multimodal content, and (b) silent fallback hides
+  configuration drift.
+
+The error is structured so the Control UI can surface a one-click
+remediation ("configure a vision route") later — this is consistent with the
+shared onboarding contract noted in `docs/architecture.md`.
+
+## 6. Compatibility with named routes
+
+Capability routes are a **strict superset** of the named-routes feature
+shipped in `src/config/routes.rs`. Concretely:
+
+- `RouteConfig` is reused unchanged for capability entries. No new shape.
+- `routes.byCapability` is an optional sub-key under the existing `routes`
+  object. Configs that omit it produce zero behavior change.
+- A capability entry can carry either `route: "smart"` (delegate to an
+  existing named route) or `model: "venice:flux-1.1-pro"` (direct). When
+  `route` is set and points at an unknown name, the existing
+  `unknown route` error fires — same path, same fail-closed behavior.
+- Request-level `route`/`model` selectors continue to win over any
+  capability mapping. The capability path is only consulted between the
+  session and the agent default scopes (§3).
+- No deprecations. `agents.defaults.model`, `routes.fast`, and per-agent
+  `route` selectors all keep working unchanged.
+
+Migration note for the future Control UI / `cara setup` work: the onboarding
+contract (`docs/architecture.md` "Shared Provider Onboarding Contract") can
+write `routes.byCapability.vision` as an additional optional output column
+in the same way it currently writes `agents.defaults.model`. No status enum
+change needed (`ready`/`partial`/`invalid` semantics are unchanged).
+
+## 7. MVP slice
+
+Smallest user-visible change:
+
+- Two capability buckets: `vision`, `imageGeneration`.
+- Configured under `routes.byCapability` only (no per-agent override yet —
+  defer to a follow-up).
+- Request must declare capability via a typed `capability` field on the
+  agent.run / `/v1/chat/completions` extension.
+- Hard error if capability declared but no `routes.byCapability.<bucket>` is
+  set (no fall-through).
+- Session and per-agent `capabilityRoutes` overrides deferred to a follow-up
+  to keep the slice reviewable.
+
+Rationale:
+
+- Vision and image generation have shipped backing (Vision via Anthropic /
+  OpenAI; image generation via Venice). They are the two buckets where the
+  routing-UX gap is most concrete.
+- Two buckets is enough to validate that the typed enum + config shape
+  scales without committing to four.
+- Excluding per-agent overrides cuts ~50% of the precedence chain and
+  matrix-test surface for the first PR.
+
+## 8. Out of scope for first slice
+
+Explicit non-goals for the slice (kept here so reviewers do not relitigate):
+
+- Automatic capability detection (MIME sniffing, attachment inspection).
+- Automatic failover when a chosen capability route returns an error.
+- Cost-aware or latency-aware routing decisions.
+- Multi-capability requests (a single turn declaring `[vision, reasoning]`).
+  The first slice accepts a single capability per request.
+- Capability-route surfaces in the Control UI / `cara setup`.
+- Provider-advertised capability discovery (asking the provider what it
+  supports).
+
+## 9. Implementation issues this design implies
+
+Suggested follow-up GitHub issues, one-line scope each:
+
+1. **`feat: typed Capability enum + RouteResolutionInputs extension`** —
+   add `Capability` enum and `requested_capability: Option<Capability>` to
+   resolution inputs; no behavior change yet.
+2. **`feat: routes.byCapability config parsing`** — load
+   `routes.byCapability` into `HashMap<Capability, RouteConfig>`; warn-skip
+   malformed entries (mirror `load_routes`).
+3. **`feat: capability-aware resolve_execution_target`** — wire the
+   capability lookup into the precedence chain with hard-error semantics
+   when no route is configured.
+4. **`feat: agent.run capability declaration field`** — add typed
+   `capability` to the WS request shape and OpenAI-compat extension; reject
+   unknown variants at the boundary.
+5. **`feat: per-agent capabilityRoutes override`** — add
+   `agent.capabilityRoutes` and slot it above `routes.byCapability` in the
+   precedence chain.
+6. **`docs: cara setup writes routes.byCapability`** — extend the shared
+   onboarding contract so guided setup can populate vision and
+   image-generation routes; status semantics unchanged.
+
+## 10. Typed boundary check
+
+Per `AGENTS.md` "Typed Boundary Discipline" and `.claude/rules/rust-patterns.md`
+"Typed Boundary Discipline": the request shape that carries the capability
+declaration MUST be a typed enum, not a string blob or `serde_json::Value`.
+
+Concrete shape:
+
+```rust
+/// Closed set of routing capabilities. New variants require an enum and
+/// schema update. The serde rename keeps the wire form camelCase to match
+/// the rest of the JSON-RPC surface (e.g. `imageGeneration`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum Capability {
+    Vision,
+    ImageGeneration,
+    AudioTranscription,
+    Reasoning,
+}
+
+/// Optional capability declaration on a completion request.
+/// Absence == no capability routing (current behavior).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct CapabilityDeclaration {
+    pub capability: Option<Capability>,
+}
+```
+
+Boundary surfaces that take this type:
+
+- `agent.run` JSON-RPC payload (typed at the WS handler layer, not as
+  `serde_json::Value`).
+- `/v1/chat/completions` extension parameter (parsed into `Capability`
+  before reaching `resolve_with_capability`; unknown values rejected at the
+  HTTP boundary with a structured 400, not coerced).
+- `RouteResolutionInputs.requested_capability` (already typed as
+  `Option<Capability>`).
+- `routes.byCapability` config map (deserialized into
+  `HashMap<Capability, RouteConfig>` via serde, with malformed entries
+  warn-skipped consistent with `load_routes`).
+
+Anti-pattern to reject during review: a `String` field named `capability`
+that gets matched on inside the resolver. If review cycles request relaxing
+the enum to a string for "extensibility," treat that as evidence the
+boundary is under-typed and add a variant instead (per `AGENTS.md` "Review
+Churn / Seam Escalation").
+
+## Open questions deferred to follow-ups
+
+- Should capability declarations be visible in usage tracking
+  (`src/usage/`)? Likely yes — capability is a useful tag for cost
+  attribution. Tracked separately.
+- How does this interact with the future Anthropic/OpenAI batch APIs?
+  Unknown until batch APIs land.
+- Is `Capability::Reasoning` worth shipping in the first follow-up, or
+  should it wait until a "thinking" mode shape stabilizes across providers?
+  Defer the decision until the MVP is in.
+
+## References
+
+- `src/config/routes.rs` — current resolver and `SelectorLevel` chain.
+- `src/agent/provider.rs` — `MultiProvider::select_provider` (model-prefix dispatch).
+- `src/agent/factory.rs` — provider construction; same module will load
+  capability-route map from config.
+- `src/media/` — current Vision / Whisper paths (capability buckets line up
+  with these).
+- `docs/architecture.md` — Shared Provider Onboarding Contract.
+- `docs/feature-status.yaml` — current capability surface.
+- `AGENTS.md` — Typed Boundary Discipline, Security-First Design, Review
+  Churn / Seam Escalation.

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -140,11 +140,14 @@ at the boundary).
 
 ## Open questions (would need resolution before any implementation)
 
-Several review findings on the original draft of this document
-([PR #395](https://github.com/puremachinery/carapace/pull/395)) point at
-real correctness gaps. They are **left unresolved** here because a
-deferred design is more honest as a record of what was considered than as
-a polished spec for unbuilt work. Anyone reopening this should resolve
+The first draft of this document (April 2026) proposed a polished
+implementation blueprint. Review surfaced several real correctness
+gaps — `RouteConfig` shape, default-fallback consistency,
+error-variant taxonomy, exhaustiveness annotation, test matrix — and
+the document was reframed as a deferred record. Those gaps are kept
+**unresolved** below rather than silently fixed, because a deferred
+design is more honest as a record of what was considered than as a
+polished spec for unbuilt work. Anyone reopening this should resolve
 these first.
 
 ### O1. The `RouteConfig` shape would need to change (high)
@@ -189,26 +192,31 @@ path like `routes.byCapability.<bucket>` in the surfaced message leaks
 internal configuration topology to anyone who can probe the API — a
 low-value but real information leak in a security-first gateway.
 
-**This is a current-codebase concern, not just a future one.**
+**This is a current-codebase concern, not just a future one** — and
+it is being tracked separately at higher urgency than this deferred
+design doc implies.
+
 `src/config/routes.rs` already surfaces config-key-path remediation
 hints through `AgentError::Provider` for two error paths that reach
-external callers today:
+external callers today via `src/server/openai.rs:~742` and the
+streaming SSE path:
 
 - `unknown route "<name>"; define it in the top-level \`routes\` config
   map` (`src/config/routes.rs:~98`)
 - `no model configured; set \`route\` or \`model\` in agent config or
   defaults` (`src/config/routes.rs:~120`)
 
-Both messages flow to external callers via the OpenAI-compatible server
-layer today. Capability routing would extend the same pattern, not
-introduce it. The general invariant — internal config-key paths must
-not leak through `AgentError::Provider` to external clients — should
-be remediated in the existing routes resolver independently of whether
-capability routing is ever built. Track that as a separate issue (a
-`ConfigError`-family variant + a stable wire-format code mapped at the
-server boundary) and treat O3 here as an extension obligation: any
-revived capability-routing design must use the new variant family
-rather than adding to the existing leak surface.
+The remediation — introduce a `ConfigError`-family variant, surface a
+stable wire-format code at the server boundary, keep human-readable
+config hints in operator-facing surfaces (logs, Control UI) — is
+tracked as a standalone issue:
+
+- [puremachinery/carapace#398](https://github.com/puremachinery/carapace/issues/398)
+
+Capability routing would have extended the same leak pattern, not
+introduced it. If/when this design is revived, the implementation
+must use whatever `ConfigError`-family variant ships from #398 rather
+than adding to the existing surface.
 
 ### O4. `#[non_exhaustive]` vs "closed enum" (low)
 

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -204,8 +204,16 @@ external callers today. `resolve_execution_target` is called from
 `AgentError` is fmt-stringified to external callers via:
 
 - HTTP: `src/server/http.rs:~1308` (`AgentResponse::error(&e.to_string())`)
-- WebSocket: `src/server/ws/handlers/sessions.rs:~2097` and `~2502`
-  (`error_shape(ERROR_UNAVAILABLE, &e.to_string(), None)`)
+- WebSocket: `src/server/ws/handlers/sessions.rs:~2102`
+  (`error_shape(ERROR_UNAVAILABLE, &e.to_string(), None)`, called
+  from the `resolve_agent_model` site at line ~2091)
+
+The auto-reply background-trigger path in the same file (around
+line ~2502) also calls `resolve_agent_model`, but its error arm is
+`tracing::warn!(...)` followed by a generic `(None, "queued")` return
+— the error string is logged server-side only and never reaches the
+external caller. That path is **not** a leak surface and needs no
+remediation in #398.
 
 Note this is **not** the OpenAI-compat provider-error surface
 (`src/server/openai.rs`); that path handles errors from

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -181,12 +181,12 @@ was incorrect.
 
 ### O2. The default-capability fallback was inconsistent (high)
 
-The draft listed `agents.defaults.capabilityRoutes` as a low-priority
-fallback in §2 ("Where capability routes would live") but the §3
-pseudocode hard-errored before consulting it. The two surfaces must be
-reconciled — either the lookup is genuinely added as a checked level
-before the hard error, or `agents.defaults.capabilityRoutes` is dropped
-from the proposal and capability routing is documented as always
+An earlier iteration of the proposed design listed
+`agents.defaults.capabilityRoutes` as a low-priority fallback, but the
+resolver pseudocode hard-errored before consulting it. The two surfaces
+must be reconciled — either the lookup is genuinely added as a checked
+level before the hard error, or `agents.defaults.capabilityRoutes` is
+dropped from the proposal and capability routing is documented as always
 hard-fail when `routes.byCapability` is absent.
 
 This is the choice point that determines whether the system is "strict"
@@ -194,7 +194,7 @@ This is the choice point that determines whether the system is "strict"
 documented default). Both are defensible; pick one and reflect it in
 both the prose and the resolver pseudocode.
 
-### O3. Configuration error must not surface as `AgentError::Provider` (medium)
+### O3. Configuration errors need a topology-free public surface (medium)
 
 `AgentError::Provider` messages flow to external callers from the
 HTTP and WebSocket layers (concrete sites listed below). Including a
@@ -203,15 +203,16 @@ surfaced message leaks internal configuration topology to anyone who
 can probe the API — a low-value but real information leak in a
 security-first gateway.
 
-**This is a current-codebase concern, not just a future one** — and
-it is being tracked separately at higher urgency than this deferred
-design doc implies.
+The current route resolver now addresses the live version of this issue:
+`resolve_execution_target` in `src/config/routes.rs` returns
+`AgentError::Configuration(AgentConfigurationError)` for route
+configuration failures. Its `Display` string is stable and
+topology-free for external callers, while the detailed config-key
+remediation remains available through an operator hint.
 
-`resolve_execution_target` in `src/config/routes.rs` already surfaces
-config-key-path remediation hints through `AgentError::Provider` for
-two error paths that reach external callers today. The resolver is
-called from inside `resolve_agent_model` (in `src/agent/mod.rs`), and
-the resulting `AgentError` is fmt-stringified to external callers via:
+The resolver is called from inside `resolve_agent_model` (in
+`src/agent/mod.rs`), and the resulting `AgentError` is fmt-stringified
+to external callers via:
 
 - **HTTP** — the `AgentResponse::error(&e.to_string())` arm in
   `src/server/http.rs` after the request handler's
@@ -232,24 +233,22 @@ Note this is **not** the OpenAI-compat provider-error surface
 `call_llm_provider`, not route-resolution. The two surfaces are
 disjoint.
 
-The two leaking error messages from `resolve_execution_target`:
+Before the resolver fix, the two leaking error messages from
+`resolve_execution_target` were:
 
 - `unknown route "<name>"; define it in the top-level \`routes\` config
   map`
 - `no model configured; set \`route\` or \`model\` in agent config or
   defaults`
 
-The remediation — introduce a `ConfigError`-family variant, surface a
-stable wire-format code at the server boundary, keep human-readable
-config hints in operator-facing surfaces (logs, Control UI) — is
-tracked as a standalone issue:
+The active-codebase bug was tracked as a standalone issue:
 
 - [puremachinery/carapace#398](https://github.com/puremachinery/carapace/issues/398)
 
 Capability routing would have extended the same leak pattern, not
 introduced it. If/when this design is revived, the implementation
-must use whatever `ConfigError`-family variant ships from #398 rather
-than adding to the existing surface.
+must use the configuration-error family rather than adding a new
+provider-error surface.
 
 ### O4. `#[non_exhaustive]` vs "closed enum" (low)
 

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -1,63 +1,88 @@
-# Capability-Aware Routing for Multimodal Workflows
+# Capability-Aware Routing for Multimodal Workflows — Deferred
 
-Status: design proposal (issue #189)
-Owner: routes/agent layer (`src/config/routes.rs`, `src/agent/factory.rs`)
-Scope: gateway request resolution; no provider-side capability negotiation.
+**Status: Deferred.** No concrete user-driven workflow currently justifies
+building this. Carapace's canonical answer to "use a different model for
+this thing" is **tool-based multimodality** (the agent writes programs or
+calls APIs/CLI tools), not capability-based agent/model swapping. This
+document records the design space considered so a future contributor does
+not have to redo the analysis if a real workflow surfaces.
 
-## Problem
+Issue: [#189](https://github.com/puremachinery/carapace/issues/189).
 
-Carapace exposes a single execution target per agent through
-`agents.defaults.model` and the `routes` map (`src/config/routes.rs`,
-`src/agent/provider.rs`). Multimodal-adjacent work today is shipped at the
-*tool* layer: `src/media/` runs Claude Vision, GPT-4 Vision, and Whisper
-transcription as side calls (see `feature-status.yaml`, Media section). There
-is no first-class way to say "for this turn, route to a vision-capable model"
-or "use a different backend when the agent is asked to generate an image."
+## Why deferred
 
-The result is that an operator who configures `agents.defaults.route: "fast"`
-to a non-vision model has no recourse short of swapping agents or models
-manually at request time. That is the friction this design removes.
+- The closest concrete request came from @j-cray on
+  [#207](https://github.com/puremachinery/carapace/issues/207) /
+  [PR #322](https://github.com/puremachinery/carapace/pull/322) ("ask the
+  bot to generate an image and get an output without manually switching
+  models"). After discussion, j-cray acknowledged that the tool-based
+  framing — exposing image generation as a tool the agent can choose —
+  fits Carapace's model better than capability-aware routing, and has not
+  followed up with a workflow that doesn't fit that framing.
+- Agent identity is already separable from the underlying model
+  ([#188](https://github.com/puremachinery/carapace/issues/188)). An
+  operator who genuinely wants a different backend for a different agent
+  can do that today by configuring two agents and pointing each at the
+  intended model.
+- The "skills/onboarding UX and multi-agent routing" gap noted in the
+  README is more directly served by skills onboarding (separate work) and
+  by named routes (already shipped). Capability-aware routing is a
+  speculative extension, not a foundation piece.
+- Pre-launch product. Adding speculative complexity to a
+  security-sensitive resolver path costs review/maintenance time without a
+  user it serves.
 
-The proposal here defines a typed, explicit capability override that composes
-with the existing named-routes precedence chain rather than replacing it.
+## Conditions to revisit
 
-## Non-goals (first slice)
+Reopen this design (or supersede it with a fresh proposal) when **any** of
+the following lands:
 
-- Automatic capability detection from request payloads or MIME sniffing.
-- Automatic failover between models on capability mismatch.
-- Cost-aware or latency-aware routing.
-- Provider-side capability negotiation or feature flags discovered at
-  runtime.
-- A general-purpose multi-agent dispatcher.
+1. A concrete user workflow that does not fit the tool-based multimodal
+   approach — for example, a request shape where the *same logical agent*
+   needs to transparently switch backend providers between turns based on
+   declared intent, not based on tool selection.
+2. Cost-aware routing requirements (move "expensive" turns to a cheaper
+   backend) that demand an automatic mechanism beyond per-agent config.
+3. A multi-agent dispatcher feature that needs a typed capability
+   declaration as a sub-primitive.
+4. Provider-side capability negotiation that the gateway needs to surface
+   to callers in a uniform way.
 
-## 1. Capability buckets
+If only the **resolver-shape** improvements are wanted (typed capability
+on the request boundary, no auto-routing), prefer adding a tool-policy or
+exec-approval surface that lets the operator constrain which tools an
+agent may invoke for a given turn — that addresses the same operator
+control problem with the existing tool layer.
 
-Initial typed enum:
+## Design space considered
 
-| Capability | Reason in scope | Backed by today |
-|---|---|---|
-| `vision` | Already shipped via `src/media/` Claude Vision + GPT-4 Vision. Routing UX is the gap. | `feature-status.yaml` Media section |
-| `image_generation` | Carapace ships Venice provider but has no first-class generate-image route. Highest user-visible win for the slice. | `src/agent/venice.rs` |
-| `audio_transcription` | Whisper already shipped. Inclusion lets transcription runs target an OpenAI-compat or local backend distinct from chat. | `feature-status.yaml` Media |
-| `reasoning` | Listed as a candidate in the issue; included to validate that non-multimodal capabilities fit the same shape. Routes to higher-tier models (e.g. `anthropic:claude-opus-*`). | n/a (new) |
+The rest of this document records what was considered, what would need to
+change in the codebase, and what was left unresolved. None of it is
+committed work.
 
-Excluded from the typed enum for the first slice:
+### Capability buckets
 
-- `code_execution`, `web_browsing`, `function_calling` — already covered by
-  the tool dispatch and prompt-guard layers; no routing decision to make.
-- `tts` — TTS providers are an orthogonal abstraction (`src/server/ws/handlers/tts.rs`)
-  that does not flow through `LlmProvider::complete`.
-- `embeddings` — no shipped surface yet; defer until embeddings are a
-  first-class request type.
+If implemented, the candidate initial set would be:
 
-The enum is closed (`#[non_exhaustive]` on the public surface so future
-variants do not break consumers, but exhaustively matched internally). New
-buckets require a typed enum addition and a config schema update — they are
-not arbitrary strings.
+| Capability (camelCase wire form) | Backed by today |
+|---|---|
+| `vision` | `src/media/` Claude Vision + GPT-4 Vision |
+| `imageGeneration` | `src/agent/venice.rs` |
+| `audioTranscription` | Whisper via `src/media/` |
+| `reasoning` | n/a today |
 
-## 2. Where capability routes live in config
+Excluded for the first slice: `tts` (orthogonal abstraction in
+`src/server/ws/handlers/tts.rs`, doesn't flow through `LlmProvider`),
+`embeddings` (no shipped surface), `code_execution` / `web_browsing` /
+`function_calling` (already covered by tool dispatch and prompt-guard
+layers).
 
-Primary form: dedicated map under `routes.byCapability.*`.
+The wire form would be camelCase consistently to match the rest of the
+JSON-RPC surface (e.g. `imageGeneration`).
+
+### Where capability routes would live
+
+A new optional sub-key under the existing `routes` object:
 
 ```json5
 routes: {
@@ -72,316 +97,137 @@ routes: {
 },
 ```
 
-Each capability entry is a `RouteConfig`-shaped pointer that may carry either
-`route` (delegate to a named route) or `model` (direct provider:model). The
-existing `RouteConfig` shape from `src/config/routes.rs` is reused; capability
-entries are not a parallel type.
+This is the design as drafted. It carries the **open questions** below
+that would need resolution before this could ship.
 
-Why this form, not per-agent overrides or `agents.defaults` chains:
+### Resolution order (as drafted)
 
-- **Single source of truth for "where do I route X":** an operator answers
-  "what model handles vision?" by reading one config block. With per-agent
-  overrides, the answer fans out across every agent.
-- **Composes cleanly with named routes:** capability routes can themselves
-  be `route` references, so an operator can say "vision uses our `smart`
-  route" without duplicating the model string.
-- **Backwards-compatible:** `routes.byCapability` is a new, optional sub-key
-  under the existing `routes` object. Configs that omit it behave exactly as
-  today.
+Highest to lowest precedence:
 
-How the alternatives compose with this primary form:
+1. Request override (`route` / `model` directly on the request).
+2. Session override (session-pinned `route` / `model`).
+3. Per-agent capability override (`agent.capabilityRoutes.<bucket>`) —
+   would not exist today, would need to be added.
+4. Default capability route (`routes.byCapability.<bucket>`) — would not
+   exist today, would need to be added.
+5. Agent default (`agent.route` / `agent.model`).
+6. Defaults (`agents.defaults.route` / `agents.defaults.model`).
 
-- **Per-agent capability overrides** (`agents.list[].capabilityRoutes.vision`)
-  remain valid and override the global default. They are a precedence level
-  above `routes.byCapability` (see §3), not an alternative storage location.
-- **`agents.defaults.capabilityRoutes`** is the lowest-priority fallback when
-  `routes.byCapability` is not set. This mirrors the existing
-  `agents.defaults.model` shape and keeps the onboarding contract
-  (`docs/architecture.md` "Shared Provider Onboarding Contract") intact.
+If the caller declared a capability and no level 3 or 4 entry was
+configured, the as-drafted design would hard-error rather than fall
+through to levels 5–6 — see Open Question O3.
 
-## 3. Resolution order at request time
+### Detection
 
-A request that declares a capability resolves through the existing
-`SelectorLevel` chain, augmented with a capability-route lookup that runs
-*before* the existing model lookup at each scope.
+If implemented, the first slice would require **explicit caller
+declaration** of capability via a typed field on the request. No
+MIME-sniffing, no inference from message content. Reasons: predictability
+(billing-relevant decision), security (capability is not steerable by
+attacker-controlled content), and test surface (typed enum is enforceable
+at the boundary).
 
-Precedence, highest to lowest:
+## Open questions (would need resolution before any implementation)
 
-1. Request override — caller passed `route` or `model` directly.
-2. Session override — session-pinned `route`/`model`.
-3. Agent override — `agent.capabilityRoutes.<bucket>` if set.
-4. Default capability route — `routes.byCapability.<bucket>`.
-5. Agent default — `agent.route` / `agent.model`.
-6. Defaults — `agents.defaults.route` / `agents.defaults.model`.
+Several review findings on the original draft of this document
+([PR #395](https://github.com/puremachinery/carapace/pull/395)) point at
+real correctness gaps. They are **left unresolved** here because a
+deferred design is more honest as a record of what was considered than as
+a polished spec for unbuilt work. Anyone reopening this should resolve
+these first.
 
-Pseudocode (extends `resolve_execution_target` in `src/config/routes.rs`):
+### O1. The `RouteConfig` shape would need to change (high)
 
-```rust
-pub fn resolve_with_capability(
-    routes: &HashMap<String, RouteConfig>,
-    capability_routes: &HashMap<Capability, RouteConfig>,
-    requested_capability: Option<Capability>,
-    inputs: &RouteResolutionInputs<'_>,
-) -> Result<ResolvedRoute, AgentError> {
-    // 1. Request-level direct selectors win unconditionally.
-    if let Some(target) = resolve_level(routes, &inputs.request, RequestRoute, RequestModel)? {
-        return Ok(target);
-    }
-    // 2. Session-level direct selectors.
-    if let Some(target) = resolve_level(routes, &inputs.session, SessionRoute, SessionModel)? {
-        return Ok(target);
-    }
-    // 3-4. Capability-aware selection only fires if the caller declared one.
-    if let Some(cap) = requested_capability {
-        // 3. Per-agent capability override.
-        if let Some(target) = inputs.agent_capability_route(cap) {
-            return resolve_capability_pointer(routes, &target, AgentCapabilityRoute);
-        }
-        // 4. Global capability default.
-        if let Some(pointer) = capability_routes.get(&cap) {
-            return resolve_capability_pointer(routes, pointer, DefaultCapabilityRoute);
-        }
-        // 5. Hard error: capability declared, nothing configured. (See §5.)
-        return Err(AgentError::Provider(format!(
-            "no route configured for capability \"{cap}\"; \
-             set routes.byCapability.{cap} in config"
-        )));
-    }
-    // 6. Agent default + defaults fallback (current behavior).
-    resolve_remaining_levels(routes, inputs)
-}
-```
+Today `src/config/routes.rs` defines `RouteConfig` as `{ model: String,
+label: Option<String> }` with `model` required. The example above uses
+`{ route: "smart" }` (no `model`) for capability entries that delegate to
+a named route. That is **not** the existing `RouteConfig` — implementing
+this would require either:
 
-Diagram:
+- making `model` optional and adding `route: Option<String>`, plus
+  validation that exactly one of `model` / `route` is set; or
+- introducing a purpose-built capability pointer type and clarifying that
+  `routes.byCapability` parsing must not go through the current
+  `load_routes` deserialize-each-key-as-`RouteConfig` loop (which would
+  warn-skip `byCapability` today and / or reject `{ route: ... }` entries
+  as malformed).
 
-```mermaid
-flowchart TD
-    A[Request arrives] --> B{request.route or request.model set?}
-    B -- yes --> Z[Use request selector]
-    B -- no --> C{session selector set?}
-    C -- yes --> Z2[Use session selector]
-    C -- no --> D{capability declared?}
-    D -- no --> E[Agent route/model -> defaults]
-    D -- yes --> F{agent.capabilityRoutes has bucket?}
-    F -- yes --> Z3[Use agent capability override]
-    F -- no --> G{routes.byCapability has bucket?}
-    G -- yes --> Z4[Use default capability route]
-    G -- no --> H[Hard error: no capable route]
-    Z --> R[Resolved provider:model]
-    Z2 --> R
-    Z3 --> R
-    Z4 --> R
-    E --> R
-```
+The original draft claimed `RouteConfig` was reused unchanged. That claim
+was incorrect.
 
-Note: capability resolution is **scoped between session and agent**. The
-rationale is that an operator-provided per-request `model` always wins (§5
-fail-closed semantics still apply if the chosen model lacks the capability —
-that is the operator's call), but agent-level capability overrides should
-beat the global capability default.
+### O2. The default-capability fallback was inconsistent (high)
 
-## 4. How capability is detected on a request
+The draft listed `agents.defaults.capabilityRoutes` as a low-priority
+fallback in §2 ("Where capability routes would live") but the §3
+pseudocode hard-errored before consulting it. The two surfaces must be
+reconciled — either the lookup is genuinely added as a checked level
+before the hard error, or `agents.defaults.capabilityRoutes` is dropped
+from the proposal and capability routing is documented as always
+hard-fail when `routes.byCapability` is absent.
 
-**Initial slice: explicit declaration only.** The caller MUST pass a typed
-`capability` field on the request. There is no MIME sniffing, no inference
-from the presence of an image part, no fallback heuristic.
+This is the choice point that determines whether the system is "strict"
+(hard-fail when nothing matches) or "graceful" (fall through to a
+documented default). Both are defensible; pick one and reflect it in
+both the prose and the resolver pseudocode.
 
-Reasons:
+### O3. Configuration error must not surface as `AgentError::Provider` (medium)
 
-- **Predictability:** Capability routing is a billing-relevant decision (an
-  image-generation route may be on a different provider with different
-  costs). Auto-routing on payload heuristics gives operators no way to audit
-  why a particular request hit a particular backend.
-- **Security:** Implicit MIME-based routing turns the *content* of an
-  attacker-controlled message into a router input. That is a confused
-  deputy. Carapace already treats inbound content as untrusted
-  (`src/agent/prompt_guard/`); routing should not be steerable by it.
-- **Test surface:** Explicit declaration is a typed enum field. Implicit
-  detection requires a mime/parser whose behavior is hard to lock down
-  without snapshot tests on every supported channel's payload shape.
-- **Deferable:** Auto-detection can be layered on later as a separate
-  resolver step that *populates* the typed capability field before
-  `resolve_with_capability` runs. The boundary stays the same.
+`AgentError::Provider` messages flow to external callers via
+`src/server/openai.rs` and the WS layer. Including a literal config-key
+path like `routes.byCapability.<bucket>` in the surfaced message leaks
+internal configuration topology to anyone who can probe the API — a
+low-value but real information leak in a security-first gateway.
 
-This matches the typed-boundary discipline in `AGENTS.md`: the wire shape is
-a typed enum, not a sniff result.
+If this design is revived, the error must be a distinct variant (e.g. a
+`ConfigError::CapabilityNotConfigured { capability }` or similar) that
+the server layer maps to a generic, stable code (e.g.
+`"capability_not_configured"`) for external callers. The remediation
+hint with the exact config key belongs in server logs and the Control
+UI, not in the wire-format error string.
 
-## 5. Failure mode: capability declared but unconfigured
+### O4. `#[non_exhaustive]` vs "closed enum" (low)
 
-**Recommendation: hard error.** Pre-launch product, security-first defaults
-(see `AGENTS.md` "Security-First Design"). If a caller asks for `vision` and
-the operator has not configured it, returning a verbose error with the
-config key to set is more defensible than silently routing to a model that
-will reject the image content with a less-actionable provider error.
+The draft simultaneously called the `Capability` enum "closed" and
+proposed `#[non_exhaustive]` on it. Pick one:
 
-Tradeoff acknowledged:
+- Closed and fixed: drop `#[non_exhaustive]`, accept that adding a
+  variant is a breaking change for any future external consumer (likely
+  fine for a gateway-internal type).
+- Open and forward-compatible: keep `#[non_exhaustive]` but drop the
+  "closed" framing, and document that downstream consumers must use a
+  wildcard arm.
 
-- **Pro hard error:** Operators learn about misconfiguration at the first
-  request, not after a confusing provider 4xx. Mirrors the existing
-  fail-closed behavior of `resolve_execution_target` for an unknown named
-  route (`unknown route "foo"; define it in the top-level routes config map`).
-- **Pro fall-through:** "More forgiving" — request still gets a response.
-  Rejected because (a) the response will likely fail downstream anyway when
-  the chosen model rejects multimodal content, and (b) silent fallback hides
-  configuration drift.
+### O5. Test matrix for the precedence chain
 
-The error is structured so the Control UI can surface a one-click
-remediation ("configure a vision route") later — this is consistent with the
-shared onboarding contract noted in `docs/architecture.md`.
+A 6-level resolution chain with a hard-error terminator deserves an
+explicit truth-table-style test matrix before the first implementation
+PR — capability routing being a billing-relevant decision means that a
+precedence bug could silently route production traffic to an unintended
+backend. The existing `src/config/routes.rs` tests cover the current
+4-level chain and provide a reference shape.
 
-## 6. Compatibility with named routes
+## Typed boundary discipline
 
-Capability routes are a **strict superset** of the named-routes feature
-shipped in `src/config/routes.rs`. Concretely:
-
-- `RouteConfig` is reused unchanged for capability entries. No new shape.
-- `routes.byCapability` is an optional sub-key under the existing `routes`
-  object. Configs that omit it produce zero behavior change.
-- A capability entry can carry either `route: "smart"` (delegate to an
-  existing named route) or `model: "venice:flux-1.1-pro"` (direct). When
-  `route` is set and points at an unknown name, the existing
-  `unknown route` error fires — same path, same fail-closed behavior.
-- Request-level `route`/`model` selectors continue to win over any
-  capability mapping. The capability path is only consulted between the
-  session and the agent default scopes (§3).
-- No deprecations. `agents.defaults.model`, `routes.fast`, and per-agent
-  `route` selectors all keep working unchanged.
-
-Migration note for the future Control UI / `cara setup` work: the onboarding
-contract (`docs/architecture.md` "Shared Provider Onboarding Contract") can
-write `routes.byCapability.vision` as an additional optional output column
-in the same way it currently writes `agents.defaults.model`. No status enum
-change needed (`ready`/`partial`/`invalid` semantics are unchanged).
-
-## 7. MVP slice
-
-Smallest user-visible change:
-
-- Two capability buckets: `vision`, `imageGeneration`.
-- Configured under `routes.byCapability` only (no per-agent override yet —
-  defer to a follow-up).
-- Request must declare capability via a typed `capability` field on the
-  agent.run / `/v1/chat/completions` extension.
-- Hard error if capability declared but no `routes.byCapability.<bucket>` is
-  set (no fall-through).
-- Session and per-agent `capabilityRoutes` overrides deferred to a follow-up
-  to keep the slice reviewable.
-
-Rationale:
-
-- Vision and image generation have shipped backing (Vision via Anthropic /
-  OpenAI; image generation via Venice). They are the two buckets where the
-  routing-UX gap is most concrete.
-- Two buckets is enough to validate that the typed enum + config shape
-  scales without committing to four.
-- Excluding per-agent overrides cuts ~50% of the precedence chain and
-  matrix-test surface for the first PR.
-
-## 8. Out of scope for first slice
-
-Explicit non-goals for the slice (kept here so reviewers do not relitigate):
-
-- Automatic capability detection (MIME sniffing, attachment inspection).
-- Automatic failover when a chosen capability route returns an error.
-- Cost-aware or latency-aware routing decisions.
-- Multi-capability requests (a single turn declaring `[vision, reasoning]`).
-  The first slice accepts a single capability per request.
-- Capability-route surfaces in the Control UI / `cara setup`.
-- Provider-advertised capability discovery (asking the provider what it
-  supports).
-
-## 9. Implementation issues this design implies
-
-Suggested follow-up GitHub issues, one-line scope each:
-
-1. **`feat: typed Capability enum + RouteResolutionInputs extension`** —
-   add `Capability` enum and `requested_capability: Option<Capability>` to
-   resolution inputs; no behavior change yet.
-2. **`feat: routes.byCapability config parsing`** — load
-   `routes.byCapability` into `HashMap<Capability, RouteConfig>`; warn-skip
-   malformed entries (mirror `load_routes`).
-3. **`feat: capability-aware resolve_execution_target`** — wire the
-   capability lookup into the precedence chain with hard-error semantics
-   when no route is configured.
-4. **`feat: agent.run capability declaration field`** — add typed
-   `capability` to the WS request shape and OpenAI-compat extension; reject
-   unknown variants at the boundary.
-5. **`feat: per-agent capabilityRoutes override`** — add
-   `agent.capabilityRoutes` and slot it above `routes.byCapability` in the
-   precedence chain.
-6. **`docs: cara setup writes routes.byCapability`** — extend the shared
-   onboarding contract so guided setup can populate vision and
-   image-generation routes; status semantics unchanged.
-
-## 10. Typed boundary check
-
-Per `AGENTS.md` "Typed Boundary Discipline" and `.claude/rules/rust-patterns.md`
-"Typed Boundary Discipline": the request shape that carries the capability
-declaration MUST be a typed enum, not a string blob or `serde_json::Value`.
-
-Concrete shape:
-
-```rust
-/// Closed set of routing capabilities. New variants require an enum and
-/// schema update. The serde rename keeps the wire form camelCase to match
-/// the rest of the JSON-RPC surface (e.g. `imageGeneration`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub enum Capability {
-    Vision,
-    ImageGeneration,
-    AudioTranscription,
-    Reasoning,
-}
-
-/// Optional capability declaration on a completion request.
-/// Absence == no capability routing (current behavior).
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct CapabilityDeclaration {
-    pub capability: Option<Capability>,
-}
-```
-
-Boundary surfaces that take this type:
-
-- `agent.run` JSON-RPC payload (typed at the WS handler layer, not as
-  `serde_json::Value`).
-- `/v1/chat/completions` extension parameter (parsed into `Capability`
-  before reaching `resolve_with_capability`; unknown values rejected at the
-  HTTP boundary with a structured 400, not coerced).
-- `RouteResolutionInputs.requested_capability` (already typed as
-  `Option<Capability>`).
-- `routes.byCapability` config map (deserialized into
-  `HashMap<Capability, RouteConfig>` via serde, with malformed entries
-  warn-skipped consistent with `load_routes`).
-
-Anti-pattern to reject during review: a `String` field named `capability`
-that gets matched on inside the resolver. If review cycles request relaxing
-the enum to a string for "extensibility," treat that as evidence the
-boundary is under-typed and add a variant instead (per `AGENTS.md` "Review
-Churn / Seam Escalation").
-
-## Open questions deferred to follow-ups
-
-- Should capability declarations be visible in usage tracking
-  (`src/usage/`)? Likely yes — capability is a useful tag for cost
-  attribution. Tracked separately.
-- How does this interact with the future Anthropic/OpenAI batch APIs?
-  Unknown until batch APIs land.
-- Is `Capability::Reasoning` worth shipping in the first follow-up, or
-  should it wait until a "thinking" mode shape stabilizes across providers?
-  Defer the decision until the MVP is in.
+Independent of whether this design is ever built, the principle holds:
+any capability declaration that crosses the request boundary should be a
+closed, typed enum at the API edge, not a free-form string blob or
+`serde_json::Value`. Unknown values are rejected at deserialization time;
+adding a new value is an explicit enum + schema change. This matches the
+typed-boundary discipline documented in
+[`AGENTS.md`](../../AGENTS.md) ("Typed Boundary Discipline" section) and
+[`.claude/rules/rust-patterns.md`](../../.claude/rules/rust-patterns.md).
 
 ## References
 
-- `src/config/routes.rs` — current resolver and `SelectorLevel` chain.
-- `src/agent/provider.rs` — `MultiProvider::select_provider` (model-prefix dispatch).
-- `src/agent/factory.rs` — provider construction; same module will load
-  capability-route map from config.
-- `src/media/` — current Vision / Whisper paths (capability buckets line up
-  with these).
-- `docs/architecture.md` — Shared Provider Onboarding Contract.
-- `docs/feature-status.yaml` — current capability surface.
-- `AGENTS.md` — Typed Boundary Discipline, Security-First Design, Review
-  Churn / Seam Escalation.
+- Issue: [#189](https://github.com/puremachinery/carapace/issues/189)
+- Walk-back conversation: [#207](https://github.com/puremachinery/carapace/issues/207),
+  [PR #322](https://github.com/puremachinery/carapace/pull/322)
+- Agent identity separation (already shipped): [#188](https://github.com/puremachinery/carapace/issues/188)
+- Existing resolver: `src/config/routes.rs` (named-routes, `SelectorLevel`)
+- Provider abstraction: `src/agent/provider.rs`
+- Provider construction: `src/agent/factory.rs`
+- Multimodal-adjacent surfaces shipped today: `src/media/` (Vision,
+  Whisper), `src/agent/venice.rs` (Venice provider, image-capable models)
+- Architecture overview: [`docs/architecture.md`](../architecture.md)
+- Feature inventory: [`docs/feature-status.yaml`](../feature-status.yaml)
+- Repository conventions: [`AGENTS.md`](../../AGENTS.md),
+  [`.claude/rules/rust-patterns.md`](../../.claude/rules/rust-patterns.md)

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -233,13 +233,20 @@ Note this is **not** the OpenAI-compat provider-error surface
 `call_llm_provider`, not route-resolution. The two surfaces are
 disjoint.
 
-Before the resolver fix, the two leaking error messages from
-`resolve_execution_target` were:
+Before the resolver fix, the two external messages from
+`resolve_execution_target` mixed several disclosure classes:
 
 - `unknown route "<name>"; define it in the top-level \`routes\` config
-  map`
+  map` — reflected caller input (`<name>`) plus internal config
+  topology (`routes`).
 - `no model configured; set \`route\` or \`model\` in agent config or
-  defaults`
+  defaults (e.g. \`agents.defaults.route: "fast"\` or
+  \`agents.defaults.model: "anthropic:claude-sonnet-4-20250514"\`)` —
+  internal config-key names, a sample named-route identifier, and a
+  concrete provider/model ID.
+
+The current fix keeps all of those details out of `Display` and retains
+them only in the operator hint.
 
 The active-codebase bug was tracked as a standalone issue:
 

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -228,10 +228,12 @@ followed by `(None, "queued")` — the error string is logged
 server-side only and never reaches the external caller. That path is
 **not** a leak surface and needs no remediation in #398.
 
-Note this is **not** the OpenAI-compat provider-error surface
-(`src/server/openai.rs`); that path handles errors from
-`call_llm_provider`, not route-resolution. The two surfaces are
-disjoint.
+Note this route-resolution leak is **not** the OpenAI-compat
+`call_llm_provider` error surface (`src/server/openai.rs`); that path
+handles provider call failures, not route-resolution. The OpenAI-compat
+`carapace` / `agent:` alias path has its own missing-default-model
+guard, and the current code applies the same topology-free
+`AgentConfigurationError::missing_model()` message there.
 
 Before the resolver fix, the two external messages from
 `resolve_execution_target` mixed several disclosure classes:

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -117,6 +117,18 @@ If the caller declared a capability and no level 3 or 4 entry was
 configured, the as-drafted design would hard-error rather than fall
 through to levels 5–6 — see Open Question O2.
 
+**Note on intra-agent precedence (level 3 over level 5).** The
+as-drafted order puts per-agent capability override above the agent's
+own default `route` / `model`. That means a caller declaring `vision`
+on a request can silently redirect traffic away from the agent's named
+route to whatever `agent.capabilityRoutes.vision` points at. Capability
+routing is billing-relevant (see §5 and O5), so this is a deliberate
+precedence choice that any implementation must call out explicitly in
+operator-facing docs and in usage tracking. If this design is revived,
+the implementation issue should decide whether the operator gets at
+least an audit log entry when a capability override displaces the
+agent's default route.
+
 ### Detection
 
 If implemented, the first slice would require **explicit caller
@@ -177,12 +189,26 @@ path like `routes.byCapability.<bucket>` in the surfaced message leaks
 internal configuration topology to anyone who can probe the API — a
 low-value but real information leak in a security-first gateway.
 
-If this design is revived, the error must be a distinct variant (e.g. a
-`ConfigError::CapabilityNotConfigured { capability }` or similar) that
-the server layer maps to a generic, stable code (e.g.
-`"capability_not_configured"`) for external callers. The remediation
-hint with the exact config key belongs in server logs and the Control
-UI, not in the wire-format error string.
+**This is a current-codebase concern, not just a future one.**
+`src/config/routes.rs` already surfaces config-key-path remediation
+hints through `AgentError::Provider` for two error paths that reach
+external callers today:
+
+- `unknown route "<name>"; define it in the top-level \`routes\` config
+  map` (`src/config/routes.rs:~98`)
+- `no model configured; set \`route\` or \`model\` in agent config or
+  defaults` (`src/config/routes.rs:~120`)
+
+Both messages flow to external callers via the OpenAI-compatible server
+layer today. Capability routing would extend the same pattern, not
+introduce it. The general invariant — internal config-key paths must
+not leak through `AgentError::Provider` to external clients — should
+be remediated in the existing routes resolver independently of whether
+capability routing is ever built. Track that as a separate issue (a
+`ConfigError`-family variant + a stable wire-format code mapped at the
+server boundary) and treat O3 here as an extension obligation: any
+revived capability-routing design must use the new variant family
+rather than adding to the existing leak surface.
 
 ### O4. `#[non_exhaustive]` vs "closed enum" (low)
 

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -85,13 +85,15 @@ JSON-RPC surface (e.g. `imageGeneration`).
 A new optional sub-key under the existing `routes` object:
 
 ```json5
+// Model IDs are placeholders — substitute the current versioned IDs
+// for whatever providers a future implementation supports.
 routes: {
-  fast: { model: "anthropic:claude-sonnet-4-20250514" },
-  smart: { model: "anthropic:claude-opus-4-20250514" },
+  fast: { model: "anthropic:claude-sonnet" },
+  smart: { model: "anthropic:claude-opus" },
   byCapability: {
     vision:             { route: "smart" },
-    imageGeneration:    { model: "venice:flux-1.1-pro" },
-    audioTranscription: { model: "openai:whisper-1" },
+    imageGeneration:    { model: "venice:flux" },
+    audioTranscription: { model: "openai:whisper" },
     reasoning:          { route: "smart" },
   },
 },
@@ -130,7 +132,7 @@ as-drafted order puts per-agent capability override above the agent's
 own default `route` / `model`. That means a caller declaring `vision`
 on a request can silently redirect traffic away from the agent's named
 route to whatever `agent.capabilityRoutes.vision` points at. Capability
-routing is billing-relevant (see §5 and O5), so this is a deliberate
+routing is billing-relevant (see O5), so this is a deliberate
 precedence choice that any implementation must call out explicitly in
 operator-facing docs and in usage tracking. If this design is revived,
 the implementation issue should decide whether the operator gets at

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -186,11 +186,12 @@ both the prose and the resolver pseudocode.
 
 ### O3. Configuration error must not surface as `AgentError::Provider` (medium)
 
-`AgentError::Provider` messages flow to external callers via
-`src/server/openai.rs` and the WS layer. Including a literal config-key
-path like `routes.byCapability.<bucket>` in the surfaced message leaks
-internal configuration topology to anyone who can probe the API — a
-low-value but real information leak in a security-first gateway.
+`AgentError::Provider` messages flow to external callers from the
+HTTP and WebSocket layers (concrete sites listed below). Including a
+literal config-key path like `routes.byCapability.<bucket>` in the
+surfaced message leaks internal configuration topology to anyone who
+can probe the API — a low-value but real information leak in a
+security-first gateway.
 
 **This is a current-codebase concern, not just a future one** — and
 it is being tracked separately at higher urgency than this deferred
@@ -198,8 +199,20 @@ design doc implies.
 
 `src/config/routes.rs` already surfaces config-key-path remediation
 hints through `AgentError::Provider` for two error paths that reach
-external callers today via `src/server/openai.rs:~742` and the
-streaming SSE path:
+external callers today. `resolve_execution_target` is called from
+`resolve_agent_model` (`src/agent/mod.rs:254`), and the resulting
+`AgentError` is fmt-stringified to external callers via:
+
+- HTTP: `src/server/http.rs:~1308` (`AgentResponse::error(&e.to_string())`)
+- WebSocket: `src/server/ws/handlers/sessions.rs:~2097` and `~2502`
+  (`error_shape(ERROR_UNAVAILABLE, &e.to_string(), None)`)
+
+Note this is **not** the OpenAI-compat provider-error surface
+(`src/server/openai.rs`); that path handles errors from
+`call_llm_provider`, not route-resolution. The two surfaces are
+disjoint.
+
+The two leaking error messages:
 
 - `unknown route "<name>"; define it in the top-level \`routes\` config
   map` (`src/config/routes.rs:~98`)

--- a/docs/design/capability-aware-routing.md
+++ b/docs/design/capability-aware-routing.md
@@ -115,7 +115,7 @@ Highest to lowest precedence:
 
 If the caller declared a capability and no level 3 or 4 entry was
 configured, the as-drafted design would hard-error rather than fall
-through to levels 5–6 — see Open Question O3.
+through to levels 5–6 — see Open Question O2.
 
 ### Detection
 
@@ -209,12 +209,23 @@ backend. The existing `src/config/routes.rs` tests cover the current
 
 Independent of whether this design is ever built, the principle holds:
 any capability declaration that crosses the request boundary should be a
-closed, typed enum at the API edge, not a free-form string blob or
-`serde_json::Value`. Unknown values are rejected at deserialization time;
-adding a new value is an explicit enum + schema change. This matches the
-typed-boundary discipline documented in
-[`AGENTS.md`](../../AGENTS.md) ("Typed Boundary Discipline" section) and
-[`.claude/rules/rust-patterns.md`](../../.claude/rules/rust-patterns.md).
+**closed, typed enum** at the API edge, not a free-form string blob or
+`serde_json::Value`. Concretely:
+
+- Unknown enum values are rejected at deserialization / boundary
+  validation time, not silently accepted and re-validated downstream.
+- Adding a new variant is an explicit enum + schema update — never an
+  arbitrary new string.
+- Downstream resolver code matches on a known set of variants, not on ad
+  hoc string parsing.
+
+If review cycles repeatedly request relaxing the enum to a string for
+"extensibility," treat that as evidence that the boundary is
+under-typed and add a variant instead, not a sanitizer or allowlist.
+
+(This principle is repo-internal contributor convention — Carapace's
+`AGENTS.md` and `.claude/rules/` are gitignored, so the relevant guidance
+is summarized inline here rather than linked.)
 
 ## References
 
@@ -229,5 +240,3 @@ typed-boundary discipline documented in
   Whisper), `src/agent/venice.rs` (Venice provider, image-capable models)
 - Architecture overview: [`docs/architecture.md`](../architecture.md)
 - Feature inventory: [`docs/feature-status.yaml`](../feature-status.yaml)
-- Repository conventions: [`AGENTS.md`](../../AGENTS.md),
-  [`.claude/rules/rust-patterns.md`](../../.claude/rules/rust-patterns.md)

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -83,7 +83,7 @@ impl AgentConfigurationError {
             operator_hint:
                 "no model configured; set `route` or `model` in agent config or defaults \
                  (e.g. `agents.defaults.route: \"fast\"` or \
-                 `agents.defaults.model: \"anthropic:claude-sonnet-4-20250514\"`)"
+                 `agents.defaults.model: \"provider:model\"`)"
                     .to_string(),
         }
     }
@@ -98,6 +98,14 @@ impl AgentConfigurationError {
 
     pub fn operator_hint(&self) -> &str {
         &self.operator_hint
+    }
+
+    pub fn log_operator_hint(&self) {
+        warn!(
+            code = self.code.as_str(),
+            operator_hint = %self.operator_hint,
+            "agent configuration error"
+        );
     }
 }
 
@@ -147,6 +155,14 @@ pub enum AgentError {
 
     #[error("classifier blocked message ({0}): {1}")]
     ClassifierBlocked(String, String),
+}
+
+impl AgentError {
+    pub fn log_configuration_hint(&self) {
+        if let Self::Configuration(error) = self {
+            error.log_operator_hint();
+        }
+    }
 }
 
 /// Configuration for an agent run.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -96,7 +96,8 @@ impl AgentConfigurationError {
         self.public_message
     }
 
-    pub fn operator_hint(&self) -> &str {
+    #[cfg(test)]
+    pub(crate) fn operator_hint(&self) -> &str {
         &self.operator_hint
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -41,11 +41,82 @@ pub use provider::{LlmProvider, StreamEvent};
 use tokio_util::sync::CancellationToken;
 pub use tool_policy::ToolPolicy;
 
+/// Stable categories for configuration failures surfaced through `AgentError`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentConfigurationErrorCode {
+    UnknownRoute,
+    MissingModel,
+}
+
+impl AgentConfigurationErrorCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UnknownRoute => "unknown_route",
+            Self::MissingModel => "missing_model",
+        }
+    }
+}
+
+/// Configuration resolution error with an external-safe display message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentConfigurationError {
+    code: AgentConfigurationErrorCode,
+    public_message: &'static str,
+    operator_hint: String,
+}
+
+impl AgentConfigurationError {
+    pub fn unknown_route(route_name: &str) -> Self {
+        Self {
+            code: AgentConfigurationErrorCode::UnknownRoute,
+            public_message: "requested route is not configured",
+            operator_hint: format!(
+                "unknown route \"{route_name}\"; define it in the top-level `routes` config map"
+            ),
+        }
+    }
+
+    pub fn missing_model() -> Self {
+        Self {
+            code: AgentConfigurationErrorCode::MissingModel,
+            public_message: "agent model is not configured",
+            operator_hint:
+                "no model configured; set `route` or `model` in agent config or defaults \
+                 (e.g. `agents.defaults.route: \"fast\"` or \
+                 `agents.defaults.model: \"anthropic:claude-sonnet-4-20250514\"`)"
+                    .to_string(),
+        }
+    }
+
+    pub fn code(&self) -> AgentConfigurationErrorCode {
+        self.code
+    }
+
+    pub fn public_message(&self) -> &'static str {
+        self.public_message
+    }
+
+    pub fn operator_hint(&self) -> &str {
+        &self.operator_hint
+    }
+}
+
+impl std::fmt::Display for AgentConfigurationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.public_message)
+    }
+}
+
+impl std::error::Error for AgentConfigurationError {}
+
 /// Errors that can occur during agent execution.
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
     #[error("LLM provider error: {0}")]
     Provider(String),
+
+    #[error("{0}")]
+    Configuration(AgentConfigurationError),
 
     #[error("session not found: {0}")]
     SessionNotFound(String),

--- a/src/agent/provider.rs
+++ b/src/agent/provider.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use crate::agent::AgentError;
+use crate::agent::{AgentConfigurationError, AgentError};
 use crate::auth::profiles::{AuthProfile, AuthProfileCredentialKind};
 
 /// A streaming event from the LLM.
@@ -395,11 +395,9 @@ impl MultiProvider {
     /// Bare models without a prefix are rejected.
     fn select_provider(&self, model: &str) -> Result<&dyn LlmProvider, AgentError> {
         if model.is_empty() {
-            return Err(AgentError::Provider(
-                "no model configured; set `agents.defaults.model` in your config \
-                 (e.g. `anthropic:claude-sonnet-4-20250514`)"
-                    .to_string(),
-            ));
+            let error = AgentConfigurationError::missing_model();
+            error.log_operator_hint();
+            return Err(AgentError::Configuration(error));
         }
 
         // Check for provider prefix with empty model name (e.g. "openai:" or "anthropic:")
@@ -835,14 +833,15 @@ mod tests {
         let provider = MultiProvider::new(None, None);
         let err = provider.select_provider("");
         assert!(err.is_err());
-        let msg = match err {
-            Err(e) => e.to_string(),
+        let error = match err {
+            Err(e) => e,
             Ok(_) => panic!("expected error"),
         };
-        assert!(
-            msg.contains("no model configured"),
-            "empty model should give configuration guidance: {msg}"
-        );
+        let msg = error.to_string();
+        assert_eq!(msg, "agent model is not configured");
+        assert!(!msg.contains("agents.defaults.model"), "got: {msg}");
+        assert!(!msg.contains("anthropic:"), "got: {msg}");
+        assert!(matches!(error, AgentError::Configuration(_)));
     }
 
     #[test]

--- a/src/config/routes.rs
+++ b/src/config/routes.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::agent::AgentError;
+use crate::agent::{AgentConfigurationError, AgentError};
 
 /// A named route — backend target + optional metadata.
 #[derive(Debug, Clone, Deserialize)]
@@ -95,10 +95,7 @@ pub fn resolve_execution_target(
             let route_name = route_name.trim();
             if !route_name.is_empty() {
                 let config = routes.get(route_name).ok_or_else(|| {
-                    AgentError::Provider(format!(
-                        "unknown route \"{route_name}\"; \
-                         define it in the top-level `routes` config map"
-                    ))
+                    AgentError::Configuration(AgentConfigurationError::unknown_route(route_name))
                 })?;
                 return Ok(ResolvedRoute {
                     model: config.model.clone(),
@@ -117,11 +114,8 @@ pub fn resolve_execution_target(
         }
     }
 
-    Err(AgentError::Provider(
-        "no model configured; set `route` or `model` in agent config or defaults \
-         (e.g. `agents.defaults.route: \"fast\"` or \
-         `agents.defaults.model: \"anthropic:claude-sonnet-4-20250514\"`)"
-            .to_string(),
+    Err(AgentError::Configuration(
+        AgentConfigurationError::missing_model(),
     ))
 }
 
@@ -309,8 +303,21 @@ mod tests {
         };
         let err = resolve_execution_target(&routes, &inputs).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("unknown route"), "got: {msg}");
-        assert!(msg.contains("nonexistent"), "got: {msg}");
+        assert_eq!(msg, "requested route is not configured");
+        assert!(!msg.contains("nonexistent"), "got: {msg}");
+        assert!(!msg.contains("routes"), "got: {msg}");
+
+        let AgentError::Configuration(config_error) = err else {
+            panic!("expected configuration error");
+        };
+        assert_eq!(
+            config_error.code().as_str(),
+            "unknown_route",
+            "got: {:?}",
+            config_error.code()
+        );
+        assert!(config_error.operator_hint().contains("nonexistent"));
+        assert!(config_error.operator_hint().contains("`routes`"));
     }
 
     #[test]
@@ -338,7 +345,20 @@ mod tests {
         let inputs = RouteResolutionInputs::default();
         let err = resolve_execution_target(&routes, &inputs).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("no model configured"), "got: {msg}");
+        assert_eq!(msg, "agent model is not configured");
+        assert!(!msg.contains("agents.defaults"), "got: {msg}");
+        assert!(!msg.contains("route"), "got: {msg}");
+
+        let AgentError::Configuration(config_error) = err else {
+            panic!("expected configuration error");
+        };
+        assert_eq!(
+            config_error.code().as_str(),
+            "missing_model",
+            "got: {:?}",
+            config_error.code()
+        );
+        assert!(config_error.operator_hint().contains("agents.defaults"));
     }
 
     #[test]

--- a/src/cron/executor.rs
+++ b/src/cron/executor.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use crate::agent::AgentConfigurationError;
 use crate::cron::CronPayload;
 use crate::messages::outbound::{
     MessageContent, MessageMetadata, OutboundContext, OutboundMessage,
@@ -19,6 +20,7 @@ pub const NO_LLM_PROVIDER_CONFIGURED_ERROR: &str = "no LLM provider configured";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CronExecuteError {
     LlmNotConfigured,
+    Configuration(AgentConfigurationError),
     Other(String),
 }
 
@@ -26,6 +28,7 @@ impl std::fmt::Display for CronExecuteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CronExecuteError::LlmNotConfigured => f.write_str(NO_LLM_PROVIDER_CONFIGURED_ERROR),
+            CronExecuteError::Configuration(error) => write!(f, "{error}"),
             CronExecuteError::Other(message) => f.write_str(message),
         }
     }
@@ -183,9 +186,9 @@ async fn execute_agent_turn(
         .llm_provider()
         .ok_or(CronExecuteError::LlmNotConfigured)?;
     if config.model.trim().is_empty() {
-        return Err(CronExecuteError::Other(
-            "no model configured; set `agents.defaults.model` in config or provide a model in the cron task".to_string(),
-        ));
+        let error = AgentConfigurationError::missing_model();
+        error.log_operator_hint();
+        return Err(CronExecuteError::Configuration(error));
     }
 
     let cancel_token = CancellationToken::new();
@@ -506,7 +509,23 @@ mod tests {
     use crate::cron::CronPayload;
     use crate::server::ws::{WsServerConfig, WsServerState};
     use crate::sessions;
+    use async_trait::async_trait;
     use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    struct NeverCalledProvider;
+
+    #[async_trait]
+    impl crate::agent::LlmProvider for NeverCalledProvider {
+        async fn complete(
+            &self,
+            _request: crate::agent::provider::CompletionRequest,
+            _cancel_token: CancellationToken,
+        ) -> Result<mpsc::Receiver<crate::agent::StreamEvent>, crate::agent::AgentError> {
+            panic!("cron missing-model guard should run before provider.complete");
+        }
+    }
 
     /// Create a WsServerState backed by a temp directory so tests work on all
     /// platforms (including Windows CI where writing to ~/.config/carapace may fail).
@@ -553,6 +572,40 @@ mod tests {
         let result = execute_payload("job-2", &payload, &state, ExecutionLimits::default()).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), CronExecuteError::LlmNotConfigured);
+    }
+
+    #[tokio::test]
+    async fn test_execute_agent_turn_missing_model_returns_safe_error() {
+        let (state, _tmp) = make_test_state();
+        state.set_llm_provider(Some(Arc::new(NeverCalledProvider)));
+
+        let payload = CronPayload::AgentTurn {
+            message: "do something".to_string(),
+            model: None,
+            route: None,
+            thinking: None,
+            timeout_seconds: None,
+            allow_unsafe_external_content: None,
+            deliver: None,
+            channel: None,
+            to: None,
+            best_effort_deliver: None,
+        };
+
+        let result = execute_payload(
+            "job-missing-model",
+            &payload,
+            &state,
+            ExecutionLimits::default(),
+        )
+        .await;
+        let error = result.unwrap_err();
+        assert!(matches!(error, CronExecuteError::Configuration(_)));
+
+        let message = error.to_string();
+        assert_eq!(message, "agent model is not configured");
+        assert!(!message.contains("agents.defaults.model"), "got: {message}");
+        assert!(!message.contains("anthropic:"), "got: {message}");
     }
 
     #[tokio::test]

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -39,7 +39,7 @@ use crate::server::headers::{security_headers_middleware, SecurityHeadersConfig}
 use crate::server::openai::{self, OpenAiState};
 use crate::server::ratelimit::{rate_limit_middleware, RateLimitConfig, RateLimiter};
 
-use crate::agent::LlmProvider;
+use crate::agent::{AgentConfigurationError, AgentError, LlmProvider};
 use crate::auth;
 use crate::channels::{inbound, slack_inbound, telegram_inbound, ChannelRegistry};
 use crate::hooks::auth::{extract_hooks_token, validate_hooks_token};
@@ -1303,6 +1303,7 @@ async fn dispatch_agent_run(
             session_model: session.metadata.model.as_deref(),
         },
     ) {
+        e.log_configuration_hint();
         return Err((
             StatusCode::BAD_REQUEST,
             Json(AgentResponse::error(&e.to_string())),
@@ -1311,11 +1312,11 @@ async fn dispatch_agent_run(
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, None);
     if config.model.trim().is_empty() {
+        let error = AgentError::Configuration(AgentConfigurationError::missing_model());
+        error.log_configuration_hint();
         return Err((
             StatusCode::BAD_REQUEST,
-            Json(AgentResponse::error(
-                "no model configured; set `agents.defaults.model` in config or provide a model in the request",
-            )),
+            Json(AgentResponse::error(&error.to_string())),
         )
             .into_response());
     }

--- a/src/server/openai.rs
+++ b/src/server/openai.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 use crate::agent::provider::{
     CompletionRequest, ContentBlock, LlmMessage, LlmRole, StopReason, StreamEvent, TokenUsage,
 };
+use crate::agent::AgentConfigurationError;
 use crate::agent::LlmProvider;
 use crate::auth;
 use crate::server::connect_info::MaybeConnectInfo;
@@ -225,10 +226,10 @@ pub struct OpenAiState {
     pub llm_provider: Option<Arc<dyn LlmProvider>>,
 }
 
-/// Resolve the model from the user's `agents.defaults.model` config setting.
+/// Resolve the model from the user's default agent model config setting.
 ///
-/// Returns an empty string if no model is configured — `select_provider`
-/// will produce a clear "no model configured" error downstream.
+/// Returns an empty string if no model is configured; callers translate that
+/// to a topology-free public error and log the operator remediation hint.
 fn resolve_configured_model() -> String {
     crate::config::load_config_shared()
         .ok()
@@ -240,6 +241,16 @@ fn resolve_configured_model() -> String {
                 .map(|s| s.to_string())
         })
         .unwrap_or_default()
+}
+
+fn missing_model_openai_response() -> Response {
+    let error = AgentConfigurationError::missing_model();
+    error.log_operator_hint();
+    (
+        StatusCode::UNPROCESSABLE_ENTITY,
+        Json(OpenAiError::invalid_request(error.to_string())),
+    )
+        .into_response()
 }
 
 /// Parse agent ID from model string
@@ -682,14 +693,7 @@ pub async fn chat_completions_handler(
     let model = if is_alias {
         let resolved = resolve_configured_model();
         if resolved.is_empty() {
-            return (
-                StatusCode::UNPROCESSABLE_ENTITY,
-                Json(OpenAiError::invalid_request(
-                    "no model configured; set `agents.defaults.model` in your config \
-                     (e.g. `anthropic:claude-sonnet-4-20250514`)",
-                )),
-            )
-                .into_response();
+            return missing_model_openai_response();
         }
         resolved
     } else {
@@ -1053,14 +1057,7 @@ pub async fn responses_handler(
     let model = if is_alias {
         let resolved = resolve_configured_model();
         if resolved.is_empty() {
-            return (
-                StatusCode::UNPROCESSABLE_ENTITY,
-                Json(OpenAiError::invalid_request(
-                    "no model configured; set `agents.defaults.model` in your config \
-                     (e.g. `anthropic:claude-sonnet-4-20250514`)",
-                )),
-            )
-                .into_response();
+            return missing_model_openai_response();
         }
         resolved
     } else {
@@ -1971,9 +1968,18 @@ mod tests {
         )
         .await;
 
-        // Without agents.defaults.model in config, the carapace alias resolves
-        // to empty — returns 422 with a configuration guidance message.
+        // Without a default agent model in config, the carapace alias resolves
+        // to empty and returns a topology-free public error.
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(parsed["error"]["message"], "agent model is not configured");
+        let message = parsed["error"]["message"].as_str().unwrap();
+        assert!(!message.contains("agents.defaults.model"), "got: {message}");
+        assert!(!message.contains("anthropic:"), "got: {message}");
     }
 
     #[tokio::test]
@@ -2409,6 +2415,45 @@ mod tests {
         assert_eq!(parsed["usage"]["input_tokens"], 80);
         assert_eq!(parsed["usage"]["output_tokens"], 20);
         assert_eq!(parsed["usage"]["total_tokens"], 100);
+    }
+
+    #[tokio::test]
+    async fn test_responses_carapace_alias_without_config_returns_safe_error() {
+        let provider = Arc::new(MockLlmProvider::text_response("ok", 10, 5));
+        let state = OpenAiState {
+            responses_enabled: true,
+            llm_provider: Some(provider),
+            gateway_token: Some("test-token".to_string()),
+            ..Default::default()
+        };
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "model": "carapace",
+            "input": "Hello"
+        }))
+        .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer test-token".parse().unwrap());
+
+        let response = responses_handler(
+            State(state),
+            loopback_connect_info(),
+            headers,
+            axum::body::Bytes::from(body),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(parsed["error"]["message"], "agent model is not configured");
+        let message = parsed["error"]["message"].as_str().unwrap();
+        assert!(!message.contains("agents.defaults.model"), "got: {message}");
+        assert!(!message.contains("anthropic:"), "got: {message}");
     }
 
     #[tokio::test]

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -153,6 +153,12 @@ impl TaskExecutor for RuntimeTaskExecutor {
                     }
                 }
             }
+            Err(crate::cron::executor::CronExecuteError::Configuration(error)) => {
+                TaskExecutionOutcome::Blocked {
+                    category: TaskBlockedReason::ConfigMissing,
+                    reason: error.to_string(),
+                }
+            }
             Err(crate::cron::executor::CronExecuteError::Other(error)) => {
                 TaskExecutionOutcome::Failed { error }
             }

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -2510,12 +2510,15 @@ fn trigger_agent_if_enabled(
             ..Default::default()
         },
     ) {
+        e.log_configuration_hint();
         tracing::warn!(error = %e, "agent auto-reply skipped: model resolution failed");
         return (None, "queued");
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, None);
     if config.model.trim().is_empty() {
-        tracing::warn!("agent auto-reply skipped: no model configured");
+        let error = crate::agent::AgentConfigurationError::missing_model();
+        error.log_operator_hint();
+        tracing::warn!(error = %error, "agent auto-reply skipped: no model configured");
         return (None, "queued");
     }
     config.deliver = true;

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -2099,15 +2099,16 @@ pub(super) fn handle_agent(
             session_model: session.metadata.model.as_deref(),
         },
     ) {
+        e.log_configuration_hint();
         return Err(error_shape(ERROR_UNAVAILABLE, &e.to_string(), None));
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, agent_id);
     if config.model.trim().is_empty() {
-        return Err(error_shape(
-            ERROR_UNAVAILABLE,
-            "no model configured; set `agents.defaults.model` in config or provide a `model` parameter",
-            None,
-        ));
+        let error = crate::agent::AgentError::Configuration(
+            crate::agent::AgentConfigurationError::missing_model(),
+        );
+        error.log_configuration_hint();
+        return Err(error_shape(ERROR_UNAVAILABLE, &error.to_string(), None));
     }
 
     let (run_id, session_key_out, cancel_token) = setup_agent_session(


### PR DESCRIPTION
**Status: Deferred design record** (rewritten from the original implementation-blueprint draft).

## Why deferred

No concrete user-driven workflow currently justifies building capability-aware routing. The closest demand — @j-cray on [#207](https://github.com/puremachinery/carapace/issues/207) / [PR #322](https://github.com/puremachinery/carapace/pull/322) — was walked back when the tool-based multimodal framing was clarified ("ask the bot to generate an image" is solved by exposing image generation as a tool, not by capability-aware backend swapping). j-cray hasn't followed up with a workflow that doesn't fit that framing. Agent identity separation ([#188](https://github.com/puremachinery/carapace/issues/188)) already covers the operator case of "different backend for different agent."

Tool-based multimodality is Carapace's canonical answer to multimodal workflows. Adding a parallel capability-routing layer to a security-sensitive resolver path would be speculative complexity in a pre-launch product.

## What this PR now is

A record of the design space considered, written as a deferred-design doc so a future contributor doesn't have to redo the analysis if a real workflow surfaces. Includes:

- Conditions to revisit (4 concrete triggers).
- Capability buckets considered.
- Where routes would live + resolution order — labeled as "as drafted," not as committed spec.
- **Open questions O1–O5** that any future implementation must resolve first. These are not "fixed" silently because the design isn't being built; they're flagged so the next reader sees them.

## How review feedback was addressed

| Finding | Addressed in deferred rewrite |
|---|---|
| F1 — `RouteConfig` reused unchanged claim is wrong | Captured as **O1**: explicit acknowledgement that the existing `{model: String, label: Option<String>}` shape doesn't fit, with two concrete options for what would need to change. |
| F2 — `agents.defaults.capabilityRoutes` fallback in §2 vs absent in §3 pseudocode | Captured as **O2**: the strict-vs-graceful choice point is named, both are defensible, must be picked before any implementation. |
| F3 — `AgentError::Provider` leaks internal config-key path to external callers | Captured as **O3**: must be a distinct `ConfigError`-family variant, mapped to a stable code at the server boundary, with the remediation hint kept to logs / Control UI. |
| F4 — wrong error variant family (gemini) | Same root as F3, addressed under **O3**. |
| F5 — `#[non_exhaustive]` contradicts "closed enum" | Captured as **O4**: pick one of closed-and-fixed or open-and-forward-compatible. |
| F6 — snake_case vs camelCase inconsistency | **Fixed** — camelCase consistently throughout to match the JSON-RPC wire form. |
| F7 — `routes.byCapability` would clash with `load_routes` deserialize loop | Same root as F1, addressed under **O1** (purpose-built pointer type or explicit reserve of the `byCapability` key). |
| F8 — "remain valid" implies feature exists today | **Fixed** — rephrased as "would not exist today, would need to be added." |
| F9 (copilot) — `AGENTS.md` and `.claude/rules/rust-patterns.md` don't exist | **My round-1 dismissal was wrong.** Both files exist on the contributor's local filesystem but are explicitly gitignored (`.gitignore` lines 10 and 13), so neither is visible to anyone reading the repo on GitHub. The links were dead from any consumer's perspective. **Fixed** in the round-2 commit `0b1c338`: the broken links were removed and the typed-boundary principle is now summarized inline in the doc, with a note that the source convention files are repo-internal. |
| O5 (claude out-of-scope) — no test strategy for the precedence chain | Added as an explicit obligation for any future implementation. |

The high/medium findings (F1, F2, F3) are real correctness issues and would have to be resolved before any implementation could ship. Calling them out as open questions in a deferred doc is more honest than polishing the pseudocode for unbuilt work.

Closes-in-spirit #189 (the issue stays open as a backlog tracker; the deferred doc is the authoritative record of the considered design).

