### PR TITLE
refactor: shared AEAD blob helpers (#348)

### DIFF
--- a/src/cli/backup_crypto.rs
+++ b/src/cli/backup_crypto.rs
@@ -228,12 +228,8 @@ pub fn decrypt_backup(
 
     let key = Zeroizing::new(derive_key(version, passphrase.as_bytes(), salt)?);
 
-    // The preceding `split_at(NONCE_LEN)` constructs `nonce_bytes` as
-    // exactly `NONCE_LEN` bytes when the earlier header-length check
-    // (`HEADER_LEN`) has already passed, so this conversion is provably
-    // infallible. `expect` is appropriate here — mapping to a header-shape
-    // error variant would be misleading because the magic and version were
-    // already validated above.
+    // `HEADER_LEN` was already verified above and `split_at(NONCE_LEN)`
+    // yields exactly `NONCE_LEN` bytes, so this conversion cannot fail.
     let nonce: [u8; NONCE_LEN] = nonce_bytes
         .try_into()
         .expect("split_at(NONCE_LEN) yields exactly NONCE_LEN bytes after header validation");
@@ -721,12 +717,13 @@ mod tests {
 
     #[test]
     fn test_crpc_enc_persisted_layout_golden_vector() {
-        // True golden vector: pins the full canonical `CRPC_ENC` byte
-        // sequence to a hardcoded literal `&[u8]` for a fixed key + salt +
-        // nonce + plaintext. The actual bytes come from the *production*
-        // envelope-writer (`build_encrypted_backup_bytes_for_test`), so any
-        // drift in MAGIC, FORMAT_VERSION, segment ordering, or AEAD output
-        // would break the assertion against the literal.
+        // Golden vector: pin the canonical `CRPC_ENC` byte sequence for
+        // fixed key + salt + nonce + plaintext, with the actual bytes
+        // produced via the production envelope writer
+        // (`build_encrypted_backup_bytes_for_test` shares
+        // `write_encrypted_backup_bytes` with `encrypt_backup`). Drift in
+        // MAGIC, FORMAT_VERSION, segment ordering, or AEAD output fails
+        // this test.
         let key: [u8; KEY_LEN] = sha2::Sha256::digest(b"carapace-backup-golden-key").into();
         let salt_digest = sha2::Sha256::digest(b"carapace-backup-golden-salt");
         let salt: [u8; SALT_LEN] = salt_digest.into();

--- a/src/cli/backup_crypto.rs
+++ b/src/cli/backup_crypto.rs
@@ -13,11 +13,12 @@ use std::fmt;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use aes_gcm::aead::{Aead, KeyInit};
-use aes_gcm::{Aes256Gcm, Nonce};
 use zeroize::Zeroizing;
 
-use crate::crypto::{derive_key_argon2id, derive_key_pbkdf2_sha256, PASSWORD_DERIVED_KEY_LEN};
+use crate::crypto::{
+    decrypt_aead_blob, derive_key_argon2id, derive_key_pbkdf2_sha256, encrypt_aead_blob, AeadBlob,
+    CryptoEnvelopeError, PASSWORD_DERIVED_KEY_LEN,
+};
 
 /// Magic bytes at the start of every encrypted backup file.
 pub const MAGIC: &[u8; 8] = b"CRPC_ENC";
@@ -85,6 +86,26 @@ impl From<std::io::Error> for BackupCryptoError {
     }
 }
 
+fn map_envelope_error(error: CryptoEnvelopeError) -> BackupCryptoError {
+    match error {
+        CryptoEnvelopeError::EncryptionFailed => {
+            BackupCryptoError::IoError("encryption failed".to_string())
+        }
+        CryptoEnvelopeError::DecryptionFailed => BackupCryptoError::DecryptionFailed,
+        CryptoEnvelopeError::RandomFailure(message) => BackupCryptoError::RandomFailure(message),
+        CryptoEnvelopeError::Base64Decode { field, message } => {
+            BackupCryptoError::IoError(format!("base64 decode for '{field}': {message}"))
+        }
+        CryptoEnvelopeError::FieldLength {
+            field,
+            expected,
+            got,
+        } => BackupCryptoError::IoError(format!(
+            "field '{field}' has wrong length: expected {expected}, got {got}"
+        )),
+    }
+}
+
 /// Derive a 256-bit key from a passphrase and salt for a specific backup
 /// format version.
 fn derive_key(
@@ -115,18 +136,11 @@ pub fn encrypt_backup(
     })?;
 
     let mut salt = [0u8; SALT_LEN];
-    let mut nonce_bytes = [0u8; NONCE_LEN];
     getrandom::fill(&mut salt).map_err(|e| BackupCryptoError::RandomFailure(e.to_string()))?;
-    getrandom::fill(&mut nonce_bytes)
-        .map_err(|e| BackupCryptoError::RandomFailure(e.to_string()))?;
 
     let key = Zeroizing::new(derive_key(FORMAT_VERSION, passphrase.as_bytes(), &salt)?);
 
-    let cipher = Aes256Gcm::new(key.as_ref().into());
-    let nonce = Nonce::from_slice(&nonce_bytes);
-    let ciphertext = cipher
-        .encrypt(nonce, plaintext.as_ref())
-        .map_err(|_| BackupCryptoError::IoError("encryption failed".to_string()))?;
+    let blob = encrypt_aead_blob(&key, plaintext.as_ref(), &[]).map_err(map_envelope_error)?;
 
     let mut file = std::fs::File::create(output).map_err(|e| {
         BackupCryptoError::IoError(format!(
@@ -139,8 +153,8 @@ pub fn encrypt_backup(
     file.write_all(MAGIC)?;
     file.write_all(&[FORMAT_VERSION])?;
     file.write_all(&salt)?;
-    file.write_all(&nonce_bytes)?;
-    file.write_all(&ciphertext)?;
+    file.write_all(&blob.nonce)?;
+    file.write_all(&blob.ciphertext)?;
     file.flush()?;
 
     let metadata = std::fs::metadata(output)?;
@@ -181,11 +195,14 @@ pub fn decrypt_backup(
 
     let key = Zeroizing::new(derive_key(version, passphrase.as_bytes(), salt)?);
 
-    let cipher = Aes256Gcm::new(key.as_ref().into());
-    let nonce = Nonce::from_slice(nonce_bytes);
-    let plaintext = cipher
-        .decrypt(nonce, ciphertext)
-        .map_err(|_| BackupCryptoError::DecryptionFailed)?;
+    let nonce: [u8; NONCE_LEN] = nonce_bytes
+        .try_into()
+        .expect("split_at(NONCE_LEN) produces exactly NONCE_LEN bytes");
+    let blob = AeadBlob {
+        nonce,
+        ciphertext: ciphertext.to_vec(),
+    };
+    let plaintext = decrypt_aead_blob(&key, &blob, &[]).map_err(map_envelope_error)?;
 
     std::fs::write(output, &plaintext).map_err(|e| {
         BackupCryptoError::IoError(format!(
@@ -201,6 +218,8 @@ pub fn decrypt_backup(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Nonce};
     use hmac::{Hmac, KeyInit as _, Mac};
     use sha2::Digest;
     use sha2::Sha256 as HmacSha256Digest;
@@ -663,6 +682,60 @@ mod tests {
         let crypto_err: BackupCryptoError = io_err.into();
         assert!(matches!(crypto_err, BackupCryptoError::IoError(_)));
         assert!(crypto_err.to_string().contains("file not found"));
+    }
+
+    #[test]
+    fn test_crpc_enc_persisted_layout_golden_vector() {
+        // Golden vector pinning the full `CRPC_ENC` byte sequence for a fixed
+        // key + salt + nonce + plaintext. Bypasses Argon2id (uses a pre-derived
+        // key) so the test stays fast. Guards against drift in the persisted
+        // header layout (magic + version + salt + nonce + ciphertext).
+        let key: [u8; KEY_LEN] = sha2::Sha256::digest(b"carapace-backup-golden-key").into();
+        let salt_digest = sha2::Sha256::digest(b"carapace-backup-golden-salt");
+        let salt: [u8; SALT_LEN] = salt_digest.into();
+        let nonce_digest = sha2::Sha256::digest(b"carapace-backup-golden-nonce");
+        let nonce_bytes: [u8; NONCE_LEN] = nonce_digest[..NONCE_LEN]
+            .try_into()
+            .expect("nonce slice length");
+        let plaintext = b"carapace backup golden plaintext";
+
+        // Independently compute expected ciphertext using the raw `Aes256Gcm`
+        // API. If this assertion ever fails, the inner crypto-envelope bytes
+        // for the backup format have drifted.
+        let cipher = Aes256Gcm::new((&key).into());
+        let expected_ct = cipher
+            .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_ref())
+            .expect("golden backup encryption");
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(MAGIC);
+        expected.push(FORMAT_VERSION_V2);
+        expected.extend_from_slice(&salt);
+        expected.extend_from_slice(&nonce_bytes);
+        expected.extend_from_slice(&expected_ct);
+
+        // Decode the golden bytes through the same parsing logic that
+        // `decrypt_backup` uses to confirm round-trip works.
+        assert_eq!(&expected[..MAGIC.len()], MAGIC.as_slice());
+        assert_eq!(expected[MAGIC.len()], FORMAT_VERSION_V2);
+        let header_offset = MAGIC.len() + 1;
+        assert_eq!(
+            &expected[header_offset..header_offset + SALT_LEN],
+            salt.as_slice()
+        );
+        let nonce_offset = header_offset + SALT_LEN;
+        assert_eq!(
+            &expected[nonce_offset..nonce_offset + NONCE_LEN],
+            nonce_bytes.as_slice()
+        );
+        let ct_offset = nonce_offset + NONCE_LEN;
+        let recovered = cipher
+            .decrypt(
+                Nonce::from_slice(&nonce_bytes),
+                expected[ct_offset..].as_ref(),
+            )
+            .expect("golden backup decryption");
+        assert_eq!(recovered, plaintext);
     }
 
     #[test]

--- a/src/cli/backup_crypto.rs
+++ b/src/cli/backup_crypto.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
 use crate::crypto::{
-    decrypt_aead_blob, derive_key_argon2id, derive_key_pbkdf2_sha256, encrypt_aead_blob, AeadBlob,
+    decrypt_aead_blob, derive_key_argon2id, derive_key_pbkdf2_sha256, encrypt_aead_blob,
     CryptoEnvelopeError, PASSWORD_DERIVED_KEY_LEN,
 };
 
@@ -122,6 +122,43 @@ fn derive_key(
     }
 }
 
+/// Write the canonical `CRPC_ENC` envelope (magic + version + salt + nonce +
+/// ciphertext-with-tag) to `writer`. Shared between the production
+/// `encrypt_backup` path and the test-only golden-vector helper so any drift
+/// in this layout fails both call sites at once.
+fn write_encrypted_backup_bytes<W: std::io::Write>(
+    writer: &mut W,
+    salt: &[u8; SALT_LEN],
+    nonce: &[u8; NONCE_LEN],
+    ciphertext: &[u8],
+) -> std::io::Result<()> {
+    writer.write_all(MAGIC)?;
+    writer.write_all(&[FORMAT_VERSION])?;
+    writer.write_all(salt)?;
+    writer.write_all(nonce)?;
+    writer.write_all(ciphertext)?;
+    Ok(())
+}
+
+/// Test-only helper that runs the production envelope-byte path with a
+/// caller-supplied key + salt + nonce so golden-vector tests can pin
+/// canonical persisted bytes against what production actually writes.
+#[cfg(test)]
+pub(crate) fn build_encrypted_backup_bytes_for_test(
+    key: &[u8; KEY_LEN],
+    salt: &[u8; SALT_LEN],
+    plaintext: &[u8],
+    nonce: &[u8; NONCE_LEN],
+) -> Result<Vec<u8>, BackupCryptoError> {
+    let blob = crate::crypto::encrypt_aead_blob_with_nonce_for_test(key, nonce, plaintext, &[])
+        .map_err(map_envelope_error)?;
+    let mut out =
+        Vec::with_capacity(MAGIC.len() + 1 + SALT_LEN + NONCE_LEN + blob.ciphertext.len());
+    write_encrypted_backup_bytes(&mut out, salt, &blob.nonce, &blob.ciphertext)
+        .map_err(BackupCryptoError::from)?;
+    Ok(out)
+}
+
 /// Encrypt a backup file with AES-256-GCM.
 ///
 /// Reads `input`, encrypts with a key derived from `passphrase`, and writes
@@ -150,11 +187,7 @@ pub fn encrypt_backup(
         ))
     })?;
 
-    file.write_all(MAGIC)?;
-    file.write_all(&[FORMAT_VERSION])?;
-    file.write_all(&salt)?;
-    file.write_all(&blob.nonce)?;
-    file.write_all(&blob.ciphertext)?;
+    write_encrypted_backup_bytes(&mut file, &salt, &blob.nonce, &blob.ciphertext)?;
     file.flush()?;
 
     let metadata = std::fs::metadata(output)?;
@@ -195,14 +228,13 @@ pub fn decrypt_backup(
 
     let key = Zeroizing::new(derive_key(version, passphrase.as_bytes(), salt)?);
 
+    // `split_at(NONCE_LEN)` already guaranteed the slice length, but use
+    // `try_into` rather than `expect` so a future refactor of the parser
+    // cannot turn this into a panic in a user-facing decrypt path.
     let nonce: [u8; NONCE_LEN] = nonce_bytes
         .try_into()
-        .expect("split_at(NONCE_LEN) produces exactly NONCE_LEN bytes");
-    let blob = AeadBlob {
-        nonce,
-        ciphertext: ciphertext.to_vec(),
-    };
-    let plaintext = decrypt_aead_blob(&key, &blob, &[]).map_err(map_envelope_error)?;
+        .map_err(|_| BackupCryptoError::InvalidMagic)?;
+    let plaintext = decrypt_aead_blob(&key, &nonce, ciphertext, &[]).map_err(map_envelope_error)?;
 
     std::fs::write(output, &plaintext).map_err(|e| {
         BackupCryptoError::IoError(format!(
@@ -686,10 +718,12 @@ mod tests {
 
     #[test]
     fn test_crpc_enc_persisted_layout_golden_vector() {
-        // Golden vector pinning the full `CRPC_ENC` byte sequence for a fixed
-        // key + salt + nonce + plaintext. Bypasses Argon2id (uses a pre-derived
-        // key) so the test stays fast. Guards against drift in the persisted
-        // header layout (magic + version + salt + nonce + ciphertext).
+        // True golden vector: pins the full canonical `CRPC_ENC` byte
+        // sequence to a hardcoded literal `&[u8]` for a fixed key + salt +
+        // nonce + plaintext. The actual bytes come from the *production*
+        // envelope-writer (`build_encrypted_backup_bytes_for_test`), so any
+        // drift in MAGIC, FORMAT_VERSION, segment ordering, or AEAD output
+        // would break the assertion against the literal.
         let key: [u8; KEY_LEN] = sha2::Sha256::digest(b"carapace-backup-golden-key").into();
         let salt_digest = sha2::Sha256::digest(b"carapace-backup-golden-salt");
         let salt: [u8; SALT_LEN] = salt_digest.into();
@@ -699,42 +733,47 @@ mod tests {
             .expect("nonce slice length");
         let plaintext = b"carapace backup golden plaintext";
 
-        // Independently compute expected ciphertext using the raw `Aes256Gcm`
-        // API. If this assertion ever fails, the inner crypto-envelope bytes
-        // for the backup format have drifted.
-        let cipher = Aes256Gcm::new((&key).into());
-        let expected_ct = cipher
-            .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_ref())
-            .expect("golden backup encryption");
+        // Pinned canonical CRPC_ENC bytes for the inputs above. Layout:
+        //   bytes  0..8  : MAGIC ("CRPC_ENC")
+        //   byte      8  : FORMAT_VERSION_V2 (0x02)
+        //   bytes  9..41 : salt (32 bytes)
+        //   bytes 41..53 : nonce (12 bytes)
+        //   bytes 53..   : AES-256-GCM ciphertext-with-tag
+        // Regenerate by replacing this with `&[]`, running the test, and
+        // copying the value from the assertion's "actual" panic message.
+        // Any deliberate persisted-format change must update this constant.
+        const EXPECTED_CRPC_BYTES: &[u8] = &[
+            67, 82, 80, 67, 95, 69, 78, 67, 2, 86, 219, 5, 152, 182, 223, 204, 105, 158, 92, 27,
+            245, 226, 163, 65, 202, 169, 5, 60, 96, 165, 203, 239, 47, 46, 105, 131, 248, 164, 120,
+            17, 24, 141, 133, 102, 77, 194, 3, 51, 33, 145, 148, 0, 32, 173, 226, 28, 57, 88, 99,
+            213, 105, 120, 109, 73, 249, 113, 243, 203, 230, 22, 129, 179, 75, 47, 255, 137, 207,
+            64, 245, 147, 169, 143, 74, 182, 252, 214, 85, 185, 66, 150, 74, 144, 38, 49, 44, 107,
+            139, 147, 215, 93, 128,
+        ];
 
-        let mut expected = Vec::new();
-        expected.extend_from_slice(MAGIC);
-        expected.push(FORMAT_VERSION_V2);
-        expected.extend_from_slice(&salt);
-        expected.extend_from_slice(&nonce_bytes);
-        expected.extend_from_slice(&expected_ct);
+        let actual_bytes =
+            build_encrypted_backup_bytes_for_test(&key, &salt, plaintext, &nonce_bytes)
+                .expect("production backup envelope build");
+        assert_eq!(actual_bytes, EXPECTED_CRPC_BYTES);
 
-        // Decode the golden bytes through the same parsing logic that
-        // `decrypt_backup` uses to confirm round-trip works.
-        assert_eq!(&expected[..MAGIC.len()], MAGIC.as_slice());
-        assert_eq!(expected[MAGIC.len()], FORMAT_VERSION_V2);
+        // Round-trip via the production decrypt path: parse magic / version /
+        // salt / nonce, derive key (pre-derived here), and AEAD-decrypt.
         let header_offset = MAGIC.len() + 1;
+        let nonce_offset = header_offset + SALT_LEN;
+        let ct_offset = nonce_offset + NONCE_LEN;
+        assert_eq!(&actual_bytes[..MAGIC.len()], MAGIC.as_slice());
+        assert_eq!(actual_bytes[MAGIC.len()], FORMAT_VERSION_V2);
         assert_eq!(
-            &expected[header_offset..header_offset + SALT_LEN],
+            &actual_bytes[header_offset..header_offset + SALT_LEN],
             salt.as_slice()
         );
-        let nonce_offset = header_offset + SALT_LEN;
         assert_eq!(
-            &expected[nonce_offset..nonce_offset + NONCE_LEN],
+            &actual_bytes[nonce_offset..nonce_offset + NONCE_LEN],
             nonce_bytes.as_slice()
         );
-        let ct_offset = nonce_offset + NONCE_LEN;
-        let recovered = cipher
-            .decrypt(
-                Nonce::from_slice(&nonce_bytes),
-                expected[ct_offset..].as_ref(),
-            )
-            .expect("golden backup decryption");
+        let recovered =
+            crate::crypto::decrypt_aead_blob(&key, &nonce_bytes, &actual_bytes[ct_offset..], &[])
+                .expect("golden backup decryption via shared helper");
         assert_eq!(recovered, plaintext);
     }
 

--- a/src/cli/backup_crypto.rs
+++ b/src/cli/backup_crypto.rs
@@ -144,7 +144,7 @@ fn write_encrypted_backup_bytes<W: std::io::Write>(
 /// caller-supplied key + salt + nonce so golden-vector tests can pin
 /// canonical persisted bytes against what production actually writes.
 #[cfg(test)]
-pub(crate) fn build_encrypted_backup_bytes_for_test(
+fn build_encrypted_backup_bytes_for_test(
     key: &[u8; KEY_LEN],
     salt: &[u8; SALT_LEN],
     plaintext: &[u8],
@@ -228,12 +228,15 @@ pub fn decrypt_backup(
 
     let key = Zeroizing::new(derive_key(version, passphrase.as_bytes(), salt)?);
 
-    // `split_at(NONCE_LEN)` already guaranteed the slice length, but use
-    // `try_into` rather than `expect` so a future refactor of the parser
-    // cannot turn this into a panic in a user-facing decrypt path.
+    // The preceding `split_at(NONCE_LEN)` constructs `nonce_bytes` as
+    // exactly `NONCE_LEN` bytes when the earlier header-length check
+    // (`HEADER_LEN`) has already passed, so this conversion is provably
+    // infallible. `expect` is appropriate here — mapping to a header-shape
+    // error variant would be misleading because the magic and version were
+    // already validated above.
     let nonce: [u8; NONCE_LEN] = nonce_bytes
         .try_into()
-        .map_err(|_| BackupCryptoError::InvalidMagic)?;
+        .expect("split_at(NONCE_LEN) yields exactly NONCE_LEN bytes after header validation");
     let plaintext = decrypt_aead_blob(&key, &nonce, ciphertext, &[]).map_err(map_envelope_error)?;
 
     std::fs::write(output, &plaintext).map_err(|e| {

--- a/src/cli/backup_crypto.rs
+++ b/src/cli/backup_crypto.rs
@@ -756,8 +756,11 @@ mod tests {
                 .expect("production backup envelope build");
         assert_eq!(actual_bytes, EXPECTED_CRPC_BYTES);
 
-        // Round-trip via the production decrypt path: parse magic / version /
-        // salt / nonce, derive key (pre-derived here), and AEAD-decrypt.
+        // Validates the byte layout and the shared AEAD helper by slicing the
+        // pinned bytes against the documented offsets and decrypting with the
+        // pre-derived key. This deliberately does NOT call `decrypt_backup`
+        // — that function's parsing path (file I/O + Argon2id) is exercised
+        // by the encrypt/decrypt round-trip tests elsewhere in this file.
         let header_offset = MAGIC.len() + 1;
         let nonce_offset = header_offset + SALT_LEN;
         let ct_offset = nonce_offset + NONCE_LEN;

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -190,7 +190,7 @@ impl SecretStore {
     /// material directly. Used by golden-vector tests that need a fast,
     /// deterministic store without paying the Argon2id cost.
     #[cfg(test)]
-    pub(crate) fn from_raw_key_and_salt_for_test(
+    fn from_raw_key_and_salt_for_test(
         key: [u8; PASSWORD_DERIVED_KEY_LEN],
         salt: [u8; SALT_LEN],
     ) -> Self {
@@ -238,7 +238,7 @@ impl SecretStore {
     /// bytes against the *production* envelope formatter rather than a
     /// reconstructed copy.
     #[cfg(test)]
-    pub(crate) fn encrypt_with_nonce_for_test(
+    fn encrypt_with_nonce_for_test(
         &self,
         plaintext: &str,
         nonce: &[u8; NONCE_LEN],

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -1382,13 +1382,11 @@ mod tests {
 
     #[test]
     fn test_enc_v2_persisted_format_golden_vector() {
-        // True golden vector: pins the canonical `enc:v2:` envelope to a
-        // hardcoded literal string for a fixed key + salt + nonce +
-        // plaintext, and computes the actual envelope through the
-        // *production* `SecretStore` write path (with a test-only nonce
-        // override). Any drift in the helper's AEAD bytes, the envelope
-        // segment ordering, the base64 alphabet, or the prefix would change
-        // the literal and the assertion would fail.
+        // Golden vector: pin the canonical `enc:v2:` envelope for fixed
+        // key + salt + nonce + plaintext, with the actual envelope produced
+        // via the production `SecretStore::encrypt` path (test-only nonce
+        // override). Drift in AEAD bytes, segment ordering, base64
+        // alphabet, or prefix all change the literal and fail this test.
         let key: [u8; PASSWORD_DERIVED_KEY_LEN] =
             sha2::Sha256::digest(b"carapace-secrets-golden-key").into();
         let salt_digest = sha2::Sha256::digest(b"carapace-secrets-golden-salt");

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -16,7 +16,7 @@ use zeroize::Zeroizing;
 
 use crate::crypto::{
     decode_b64_fixed, decrypt_aead_blob, derive_key_argon2id, derive_key_pbkdf2_sha256,
-    encrypt_aead_blob, AeadBlob, CryptoEnvelopeError, PasswordKdfError, PASSWORD_DERIVED_KEY_LEN,
+    encrypt_aead_blob, CryptoEnvelopeError, PasswordKdfError, PASSWORD_DERIVED_KEY_LEN,
 };
 
 const ENC_PREFIX_V1: &str = "enc:v1:";
@@ -186,6 +186,24 @@ impl SecretStore {
         })
     }
 
+    /// Test-only constructor that bypasses KDF and uses caller-supplied key
+    /// material directly. Used by golden-vector tests that need a fast,
+    /// deterministic store without paying the Argon2id cost.
+    #[cfg(test)]
+    pub(crate) fn from_raw_key_and_salt_for_test(
+        key: [u8; PASSWORD_DERIVED_KEY_LEN],
+        salt: [u8; SALT_LEN],
+    ) -> Self {
+        Self {
+            access: SecretStoreAccess::Ready {
+                key: Zeroizing::new(key),
+                mode: SecretStoreMode::Full,
+            },
+            salt,
+            write_version: SecretEnvelopeVersion::current(),
+        }
+    }
+
     /// Create a store for rekey-based decryption without random salt generation.
     ///
     /// Note: `decrypt()` will always fail for real ciphertexts because the
@@ -210,36 +228,56 @@ impl SecretStore {
 
     /// Encrypt a plaintext string, returning the current `enc:v2:...` format.
     pub fn encrypt(&self, plaintext: &str) -> Result<String, SecretError> {
-        let key = match &self.access {
+        let key = self.encrypt_key()?;
+        let blob = encrypt_aead_blob(key, plaintext.as_bytes(), &[]).map_err(map_envelope_error)?;
+        Ok(self.format_envelope(blob.nonce, &blob.ciphertext))
+    }
+
+    /// Test-only encrypt path that pins the AEAD nonce instead of generating
+    /// a random one, so golden-vector tests can pin canonical persisted
+    /// bytes against the *production* envelope formatter rather than a
+    /// reconstructed copy.
+    #[cfg(test)]
+    pub(crate) fn encrypt_with_nonce_for_test(
+        &self,
+        plaintext: &str,
+        nonce: &[u8; NONCE_LEN],
+    ) -> Result<String, SecretError> {
+        let key = self.encrypt_key()?;
+        let blob = crate::crypto::encrypt_aead_blob_with_nonce_for_test(
+            key,
+            nonce,
+            plaintext.as_bytes(),
+            &[],
+        )
+        .map_err(map_envelope_error)?;
+        Ok(self.format_envelope(blob.nonce, &blob.ciphertext))
+    }
+
+    fn encrypt_key(&self) -> Result<&[u8; PASSWORD_DERIVED_KEY_LEN], SecretError> {
+        match &self.access {
             SecretStoreAccess::Ready {
                 key,
                 mode: SecretStoreMode::Full,
-            } => key,
+            } => Ok(key),
             SecretStoreAccess::Ready {
                 mode: SecretStoreMode::DecryptOnly,
                 ..
-            } => {
-                return Err(SecretError::EncryptionFailed(
-                    "decrypt-only secret store cannot encrypt".to_string(),
-                ));
-            }
-            SecretStoreAccess::InitFailed(err) => return Err(err.clone()),
-        };
+            } => Err(SecretError::EncryptionFailed(
+                "decrypt-only secret store cannot encrypt".to_string(),
+            )),
+            SecretStoreAccess::InitFailed(err) => Err(err.clone()),
+        }
+    }
 
-        let blob =
-            encrypt_aead_blob(key, plaintext.as_bytes(), &[]).map_err(map_envelope_error)?;
-
-        let nonce_b64 = BASE64.encode(blob.nonce);
-        let ct_b64 = BASE64.encode(&blob.ciphertext);
-        let salt_b64 = BASE64.encode(self.salt);
-
-        Ok(format!(
+    fn format_envelope(&self, nonce: [u8; NONCE_LEN], ciphertext: &[u8]) -> String {
+        format!(
             "{}{}:{}:{}",
             self.write_version.prefix(),
-            nonce_b64,
-            ct_b64,
-            salt_b64
-        ))
+            BASE64.encode(nonce),
+            BASE64.encode(ciphertext),
+            BASE64.encode(self.salt),
+        )
     }
 
     /// Decrypt a supported `enc:v1:` or `enc:v2:` string back to plaintext
@@ -323,16 +361,17 @@ pub(crate) fn parse_encrypted(encrypted: &str) -> Result<EncryptedParts, SecretE
         )));
     }
 
-    let nonce: [u8; NONCE_LEN] = decode_b64_fixed("nonce", segments[0]).map_err(|err| match err {
-        CryptoEnvelopeError::Base64Decode { field, message } => SecretError::Base64Decode {
-            field: field.to_string(),
-            message,
-        },
-        CryptoEnvelopeError::FieldLength { expected, got, .. } => {
-            SecretError::InvalidNonceLength { expected, got }
-        }
-        other => SecretError::BadFormat(other.to_string()),
-    })?;
+    let nonce: [u8; NONCE_LEN] =
+        decode_b64_fixed("nonce", segments[0]).map_err(|err| match err {
+            CryptoEnvelopeError::Base64Decode { field, message } => SecretError::Base64Decode {
+                field: field.to_string(),
+                message,
+            },
+            CryptoEnvelopeError::FieldLength { expected, got, .. } => {
+                SecretError::InvalidNonceLength { expected, got }
+            }
+            other => SecretError::BadFormat(other.to_string()),
+        })?;
 
     let ciphertext = BASE64
         .decode(segments[1])
@@ -366,11 +405,8 @@ fn decrypt_with_key(
     nonce: &[u8; NONCE_LEN],
     ciphertext: &[u8],
 ) -> Result<String, SecretError> {
-    let blob = AeadBlob {
-        nonce: *nonce,
-        ciphertext: ciphertext.to_vec(),
-    };
-    let plaintext_bytes = decrypt_aead_blob(key, &blob, &[]).map_err(map_envelope_error)?;
+    let plaintext_bytes =
+        decrypt_aead_blob(key, nonce, ciphertext, &[]).map_err(map_envelope_error)?;
     String::from_utf8(plaintext_bytes).map_err(|_| SecretError::DecryptionFailed)
 }
 
@@ -1346,13 +1382,13 @@ mod tests {
 
     #[test]
     fn test_enc_v2_persisted_format_golden_vector() {
-        // Golden vector pinning the canonical `enc:v2:` envelope for a fixed
-        // key + salt + nonce + plaintext. Guards against silent drift in the
-        // persisted format (segment ordering, base64 encoding, AES-GCM bytes).
-        // The key and salt are hashed labels; the nonce is also derived
-        // deterministically. The expected ciphertext is computed independently
-        // with the underlying `Aes256Gcm` API (not the helper) so any future
-        // helper change that altered persisted bytes would flag here.
+        // True golden vector: pins the canonical `enc:v2:` envelope to a
+        // hardcoded literal string for a fixed key + salt + nonce +
+        // plaintext, and computes the actual envelope through the
+        // *production* `SecretStore` write path (with a test-only nonce
+        // override). Any drift in the helper's AEAD bytes, the envelope
+        // segment ordering, the base64 alphabet, or the prefix would change
+        // the literal and the assertion would fail.
         let key: [u8; PASSWORD_DERIVED_KEY_LEN] =
             sha2::Sha256::digest(b"carapace-secrets-golden-key").into();
         let salt_digest = sha2::Sha256::digest(b"carapace-secrets-golden-salt");
@@ -1365,38 +1401,25 @@ mod tests {
             .expect("nonce slice length");
         let plaintext = "sk-live-golden-secret";
 
-        // Independently compute the expected canonical ciphertext bytes.
-        let cipher = Aes256Gcm::new((&key).into());
-        let expected_ct = cipher
-            .encrypt(Nonce::from_slice(&nonce), plaintext.as_bytes())
-            .expect("golden encryption");
-        let expected_envelope = format!(
-            "enc:v2:{}:{}:{}",
-            BASE64.encode(nonce),
-            BASE64.encode(&expected_ct),
-            BASE64.encode(salt)
-        );
+        // Pinned canonical `enc:v2:` envelope for the fixed inputs above.
+        // Regenerate by replacing this constant with `""`, running the test,
+        // and copying the value from the assertion's "actual" panic message.
+        // Any deliberate persisted-format change must update this constant.
+        const EXPECTED_ENVELOPE: &str =
+            "enc:v2:HVld7esM3b11YwFS:/wAwmf1W35FauNExFxCqEMI+C6VcAxWkJ8TRWp69uF/85BSPBw==:WysQE5dy+IR3iQR5+ynVZQ==";
 
-        // Build the same envelope through the public store path with a fixed
-        // key+salt store, but injecting the same nonce. The store's `encrypt`
-        // generates its own random nonce, so we exercise the persisted-format
-        // path explicitly here using `encrypt_with_raw_key_and_salt`-style
-        // construction that pins all inputs.
-        let actual_ct = Aes256Gcm::new((&key).into())
-            .encrypt(Nonce::from_slice(&nonce), plaintext.as_bytes())
-            .expect("actual encryption");
-        let actual_envelope = format!(
-            "enc:v2:{}:{}:{}",
-            BASE64.encode(nonce),
-            BASE64.encode(&actual_ct),
-            BASE64.encode(salt)
-        );
-        assert_eq!(actual_envelope, expected_envelope);
+        // Build the actual envelope through the production write path with a
+        // test-only nonce override. This exercises `SecretStore::encrypt`'s
+        // formatter, helper call, and prefix selection — not a reconstruction.
+        let store = SecretStore::from_raw_key_and_salt_for_test(key, salt);
+        let actual_envelope = store
+            .encrypt_with_nonce_for_test(plaintext, &nonce)
+            .expect("production encrypt with test nonce");
+        assert_eq!(actual_envelope, EXPECTED_ENVELOPE);
 
-        // Round-trip via the public parser/decrypt path to confirm the
-        // canonical envelope decodes back to the same plaintext under this
-        // fixed key.
-        let parts = parse_encrypted(&expected_envelope).expect("parse golden envelope");
+        // Round-trip via the public parser + decrypt path to confirm the
+        // canonical envelope decodes back to the same plaintext.
+        let parts = parse_encrypted(EXPECTED_ENVELOPE).expect("parse golden envelope");
         assert_eq!(parts.version, SecretEnvelopeVersion::V2);
         assert_eq!(parts.nonce, nonce);
         assert_eq!(parts.salt, salt);

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -7,8 +7,6 @@
 //! - `enc:v1:BASE64_NONCE:BASE64_CIPHERTEXT:BASE64_SALT` for legacy PBKDF2
 //! - `enc:v2:BASE64_NONCE:BASE64_CIPHERTEXT:BASE64_SALT` for current Argon2id
 
-use aes_gcm::aead::{Aead, KeyInit};
-use aes_gcm::{Aes256Gcm, Nonce};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use serde_json::Value;
@@ -17,7 +15,8 @@ use thiserror::Error;
 use zeroize::Zeroizing;
 
 use crate::crypto::{
-    derive_key_argon2id, derive_key_pbkdf2_sha256, PasswordKdfError, PASSWORD_DERIVED_KEY_LEN,
+    decode_b64_fixed, decrypt_aead_blob, derive_key_argon2id, derive_key_pbkdf2_sha256,
+    encrypt_aead_blob, AeadBlob, CryptoEnvelopeError, PasswordKdfError, PASSWORD_DERIVED_KEY_LEN,
 };
 
 const ENC_PREFIX_V1: &str = "enc:v1:";
@@ -227,17 +226,11 @@ impl SecretStore {
             SecretStoreAccess::InitFailed(err) => return Err(err.clone()),
         };
 
-        let mut nonce_bytes = [0u8; NONCE_LEN];
-        getrandom::fill(&mut nonce_bytes).map_err(|e| SecretError::RandomFailure(e.to_string()))?;
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        let blob =
+            encrypt_aead_blob(key, plaintext.as_bytes(), &[]).map_err(map_envelope_error)?;
 
-        let cipher = Aes256Gcm::new(key.as_ref().into());
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext.as_bytes())
-            .map_err(|e| SecretError::EncryptionFailed(e.to_string()))?;
-
-        let nonce_b64 = BASE64.encode(nonce_bytes);
-        let ct_b64 = BASE64.encode(&ciphertext);
+        let nonce_b64 = BASE64.encode(blob.nonce);
+        let ct_b64 = BASE64.encode(&blob.ciphertext);
         let salt_b64 = BASE64.encode(self.salt);
 
         Ok(format!(
@@ -330,12 +323,16 @@ pub(crate) fn parse_encrypted(encrypted: &str) -> Result<EncryptedParts, SecretE
         )));
     }
 
-    let nonce_bytes = BASE64
-        .decode(segments[0])
-        .map_err(|e| SecretError::Base64Decode {
-            field: "nonce".to_string(),
-            message: e.to_string(),
-        })?;
+    let nonce: [u8; NONCE_LEN] = decode_b64_fixed("nonce", segments[0]).map_err(|err| match err {
+        CryptoEnvelopeError::Base64Decode { field, message } => SecretError::Base64Decode {
+            field: field.to_string(),
+            message,
+        },
+        CryptoEnvelopeError::FieldLength { expected, got, .. } => {
+            SecretError::InvalidNonceLength { expected, got }
+        }
+        other => SecretError::BadFormat(other.to_string()),
+    })?;
 
     let ciphertext = BASE64
         .decode(segments[1])
@@ -344,44 +341,16 @@ pub(crate) fn parse_encrypted(encrypted: &str) -> Result<EncryptedParts, SecretE
             message: e.to_string(),
         })?;
 
-    let salt_bytes = BASE64
-        .decode(segments[2])
-        .map_err(|e| SecretError::Base64Decode {
-            field: "salt".to_string(),
-            message: e.to_string(),
-        })?;
-
-    if nonce_bytes.len() != NONCE_LEN {
-        return Err(SecretError::InvalidNonceLength {
-            expected: NONCE_LEN,
-            got: nonce_bytes.len(),
-        });
-    }
-
-    if salt_bytes.len() != SALT_LEN {
-        return Err(SecretError::InvalidSaltLength {
-            expected: SALT_LEN,
-            got: salt_bytes.len(),
-        });
-    }
-
-    let nonce: [u8; NONCE_LEN] =
-        nonce_bytes
-            .as_slice()
-            .try_into()
-            .map_err(|_| SecretError::InvalidNonceLength {
-                expected: NONCE_LEN,
-                got: nonce_bytes.len(),
-            })?;
-
-    let salt: [u8; SALT_LEN] =
-        salt_bytes
-            .as_slice()
-            .try_into()
-            .map_err(|_| SecretError::InvalidSaltLength {
-                expected: SALT_LEN,
-                got: salt_bytes.len(),
-            })?;
+    let salt: [u8; SALT_LEN] = decode_b64_fixed("salt", segments[2]).map_err(|err| match err {
+        CryptoEnvelopeError::Base64Decode { field, message } => SecretError::Base64Decode {
+            field: field.to_string(),
+            message,
+        },
+        CryptoEnvelopeError::FieldLength { expected, got, .. } => {
+            SecretError::InvalidSaltLength { expected, got }
+        }
+        other => SecretError::BadFormat(other.to_string()),
+    })?;
 
     Ok(EncryptedParts {
         version,
@@ -397,13 +366,11 @@ fn decrypt_with_key(
     nonce: &[u8; NONCE_LEN],
     ciphertext: &[u8],
 ) -> Result<String, SecretError> {
-    let cipher = Aes256Gcm::new(key.into());
-    let nonce = Nonce::from_slice(nonce);
-
-    let plaintext_bytes = cipher
-        .decrypt(nonce, ciphertext)
-        .map_err(|_| SecretError::DecryptionFailed)?;
-
+    let blob = AeadBlob {
+        nonce: *nonce,
+        ciphertext: ciphertext.to_vec(),
+    };
+    let plaintext_bytes = decrypt_aead_blob(key, &blob, &[]).map_err(map_envelope_error)?;
     String::from_utf8(plaintext_bytes).map_err(|_| SecretError::DecryptionFailed)
 }
 
@@ -423,6 +390,31 @@ fn derive_decrypt_sentinel_salt(password: &[u8]) -> [u8; SALT_LEN] {
 
 fn map_kdf_error(error: PasswordKdfError) -> SecretError {
     SecretError::KeyDerivationFailed(error.to_string())
+}
+
+fn map_envelope_error(error: CryptoEnvelopeError) -> SecretError {
+    match error {
+        CryptoEnvelopeError::EncryptionFailed => {
+            SecretError::EncryptionFailed("AEAD encryption failed".to_string())
+        }
+        CryptoEnvelopeError::DecryptionFailed => SecretError::DecryptionFailed,
+        CryptoEnvelopeError::RandomFailure(message) => SecretError::RandomFailure(message),
+        CryptoEnvelopeError::Base64Decode { field, message } => SecretError::Base64Decode {
+            field: field.to_string(),
+            message,
+        },
+        CryptoEnvelopeError::FieldLength {
+            field,
+            expected,
+            got,
+        } => match field {
+            "nonce" => SecretError::InvalidNonceLength { expected, got },
+            "salt" => SecretError::InvalidSaltLength { expected, got },
+            other => SecretError::BadFormat(format!(
+                "field '{other}' has wrong length: expected {expected}, got {got}"
+            )),
+        },
+    }
 }
 
 /// Check whether a string value is in encrypted format.
@@ -572,6 +564,8 @@ pub fn seal_secrets(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Nonce};
     use serde_json::json;
 
     fn random_password() -> Vec<u8> {
@@ -1348,5 +1342,66 @@ mod tests {
 
         let plain = json!({ "apiKey": "plaintext", "name": "bot" });
         assert!(!contains_encrypted_values(&plain));
+    }
+
+    #[test]
+    fn test_enc_v2_persisted_format_golden_vector() {
+        // Golden vector pinning the canonical `enc:v2:` envelope for a fixed
+        // key + salt + nonce + plaintext. Guards against silent drift in the
+        // persisted format (segment ordering, base64 encoding, AES-GCM bytes).
+        // The key and salt are hashed labels; the nonce is also derived
+        // deterministically. The expected ciphertext is computed independently
+        // with the underlying `Aes256Gcm` API (not the helper) so any future
+        // helper change that altered persisted bytes would flag here.
+        let key: [u8; PASSWORD_DERIVED_KEY_LEN] =
+            sha2::Sha256::digest(b"carapace-secrets-golden-key").into();
+        let salt_digest = sha2::Sha256::digest(b"carapace-secrets-golden-salt");
+        let salt: [u8; SALT_LEN] = salt_digest[..SALT_LEN]
+            .try_into()
+            .expect("salt slice length");
+        let nonce_digest = sha2::Sha256::digest(b"carapace-secrets-golden-nonce");
+        let nonce: [u8; NONCE_LEN] = nonce_digest[..NONCE_LEN]
+            .try_into()
+            .expect("nonce slice length");
+        let plaintext = "sk-live-golden-secret";
+
+        // Independently compute the expected canonical ciphertext bytes.
+        let cipher = Aes256Gcm::new((&key).into());
+        let expected_ct = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext.as_bytes())
+            .expect("golden encryption");
+        let expected_envelope = format!(
+            "enc:v2:{}:{}:{}",
+            BASE64.encode(nonce),
+            BASE64.encode(&expected_ct),
+            BASE64.encode(salt)
+        );
+
+        // Build the same envelope through the public store path with a fixed
+        // key+salt store, but injecting the same nonce. The store's `encrypt`
+        // generates its own random nonce, so we exercise the persisted-format
+        // path explicitly here using `encrypt_with_raw_key_and_salt`-style
+        // construction that pins all inputs.
+        let actual_ct = Aes256Gcm::new((&key).into())
+            .encrypt(Nonce::from_slice(&nonce), plaintext.as_bytes())
+            .expect("actual encryption");
+        let actual_envelope = format!(
+            "enc:v2:{}:{}:{}",
+            BASE64.encode(nonce),
+            BASE64.encode(&actual_ct),
+            BASE64.encode(salt)
+        );
+        assert_eq!(actual_envelope, expected_envelope);
+
+        // Round-trip via the public parser/decrypt path to confirm the
+        // canonical envelope decodes back to the same plaintext under this
+        // fixed key.
+        let parts = parse_encrypted(&expected_envelope).expect("parse golden envelope");
+        assert_eq!(parts.version, SecretEnvelopeVersion::V2);
+        assert_eq!(parts.nonce, nonce);
+        assert_eq!(parts.salt, salt);
+        let recovered =
+            decrypt_with_key(&key, &parts.nonce, &parts.ciphertext).expect("recover plaintext");
+        assert_eq!(recovered, plaintext);
     }
 }

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -435,10 +435,7 @@ fn map_envelope_error(error: CryptoEnvelopeError) -> SecretError {
         }
         CryptoEnvelopeError::DecryptionFailed => SecretError::DecryptionFailed,
         CryptoEnvelopeError::RandomFailure(message) => SecretError::RandomFailure(message),
-        other @ CryptoEnvelopeError::Base64Decode { .. }
-        | other @ CryptoEnvelopeError::FieldLength { .. } => {
-            SecretError::BadFormat(format!("unexpected envelope parsing error: {other}"))
-        }
+        other => SecretError::BadFormat(format!("unexpected envelope parsing error: {other}")),
     }
 }
 

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -435,21 +435,10 @@ fn map_envelope_error(error: CryptoEnvelopeError) -> SecretError {
         }
         CryptoEnvelopeError::DecryptionFailed => SecretError::DecryptionFailed,
         CryptoEnvelopeError::RandomFailure(message) => SecretError::RandomFailure(message),
-        CryptoEnvelopeError::Base64Decode { field, message } => SecretError::Base64Decode {
-            field: field.to_string(),
-            message,
-        },
-        CryptoEnvelopeError::FieldLength {
-            field,
-            expected,
-            got,
-        } => match field {
-            "nonce" => SecretError::InvalidNonceLength { expected, got },
-            "salt" => SecretError::InvalidSaltLength { expected, got },
-            other => SecretError::BadFormat(format!(
-                "field '{other}' has wrong length: expected {expected}, got {got}"
-            )),
-        },
+        other @ CryptoEnvelopeError::Base64Decode { .. }
+        | other @ CryptoEnvelopeError::FieldLength { .. } => {
+            SecretError::BadFormat(format!("unexpected envelope parsing error: {other}"))
+        }
     }
 }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -41,8 +41,11 @@ pub(crate) enum PasswordKdfError {
 /// AEAD-blob length, in bytes, of the AES-256-GCM 96-bit nonce.
 pub(crate) const AEAD_NONCE_LEN: usize = 12;
 
-/// AES-256-GCM encryption-key length in bytes.
-pub(crate) const AEAD_KEY_LEN: usize = 32;
+/// AES-256-GCM encryption-key length in bytes. Aliased to
+/// `PASSWORD_DERIVED_KEY_LEN` so the KDF and AEAD layers share one
+/// source of truth for the key size; if either side ever needs a
+/// different size, that change should be deliberate, not silent.
+pub(crate) const AEAD_KEY_LEN: usize = PASSWORD_DERIVED_KEY_LEN;
 
 /// Inner AEAD blob produced by [`encrypt_aead_blob`].
 ///
@@ -131,19 +134,26 @@ fn encrypt_aead_blob_inner(
 
 /// Decrypt an AEAD blob under `key` and `aad`, returning the plaintext.
 ///
+/// Takes slices for both `nonce` and `ciphertext` so callers that already
+/// own borrowed views (parsed from a string segment, sliced from a file
+/// buffer) can pass them through without a `to_vec()` clone. For large
+/// payloads (backup files, session histories) avoiding that clone is a
+/// noticeable memory-pressure win.
+///
 /// Returns [`CryptoEnvelopeError::DecryptionFailed`] for any AEAD failure
 /// (wrong key, wrong AAD, tampered ciphertext, or truncated tag).
 pub(crate) fn decrypt_aead_blob(
     key: &[u8; AEAD_KEY_LEN],
-    blob: &AeadBlob,
+    nonce: &[u8; AEAD_NONCE_LEN],
+    ciphertext: &[u8],
     aad: &[u8],
 ) -> Result<Vec<u8>, CryptoEnvelopeError> {
     let cipher = Aes256Gcm::new(key.into());
     cipher
         .decrypt(
-            Nonce::from_slice(&blob.nonce),
+            Nonce::from_slice(nonce),
             Payload {
-                msg: blob.ciphertext.as_ref(),
+                msg: ciphertext,
                 aad,
             },
         )
@@ -248,7 +258,7 @@ mod tests {
         let key = aead_kat_key();
         let plaintext = b"hello AEAD world".to_vec();
         let blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
-        let recovered = decrypt_aead_blob(&key, &blob, &[]).unwrap();
+        let recovered = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, &[]).unwrap();
         assert_eq!(recovered, plaintext);
     }
 
@@ -258,7 +268,7 @@ mod tests {
         let aad = b"carapace:aead-aad-bind:v1".as_slice();
         let plaintext = b"this is bound to AAD".to_vec();
         let blob = encrypt_aead_blob(&key, &plaintext, aad).unwrap();
-        let recovered = decrypt_aead_blob(&key, &blob, aad).unwrap();
+        let recovered = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, aad).unwrap();
         assert_eq!(recovered, plaintext);
     }
 
@@ -269,7 +279,7 @@ mod tests {
         let plaintext = b"this is bound to AAD".to_vec();
         let blob = encrypt_aead_blob(&key, &plaintext, aad).unwrap();
         let wrong_aad = b"carapace:aead-aad-bind:v2".as_slice();
-        let err = decrypt_aead_blob(&key, &blob, wrong_aad).unwrap_err();
+        let err = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, wrong_aad).unwrap_err();
         assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
     }
 
@@ -280,7 +290,7 @@ mod tests {
         let blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
         let mut wrong_key = key;
         wrong_key[0] ^= 0xFF;
-        let err = decrypt_aead_blob(&wrong_key, &blob, &[]).unwrap_err();
+        let err = decrypt_aead_blob(&wrong_key, &blob.nonce, &blob.ciphertext, &[]).unwrap_err();
         assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
     }
 
@@ -292,7 +302,7 @@ mod tests {
         if let Some(byte) = blob.ciphertext.first_mut() {
             *byte ^= 0xFF;
         }
-        let err = decrypt_aead_blob(&key, &blob, &[]).unwrap_err();
+        let err = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, &[]).unwrap_err();
         assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
     }
 
@@ -332,7 +342,7 @@ mod tests {
         let plaintext = b"carapace-shared-aead-helper".as_slice();
         let aad = b"carapace:aead-blob-helper-aad:v1".as_slice();
         let blob = encrypt_aead_blob_with_nonce_for_test(&key, &nonce, plaintext, aad).unwrap();
-        let recovered = decrypt_aead_blob(&key, &blob, aad).unwrap();
+        let recovered = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, aad).unwrap();
         assert_eq!(recovered, plaintext);
         // AAD-bound ciphertext must differ from the empty-AAD KAT above.
         let no_aad_blob =

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -312,6 +312,9 @@ mod tests {
         let plaintext = b"same plaintext".to_vec();
         let blob_a = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
         let blob_b = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        // This is a probabilistic smoke check over 96-bit random nonces; it
+        // catches fixed or broken RNG behavior, not a deterministic uniqueness
+        // proof.
         assert_ne!(
             blob_a.nonce, blob_b.nonce,
             "each encrypt call must produce a fresh nonce"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -344,11 +344,26 @@ mod tests {
 
     #[test]
     fn test_aead_blob_known_answer_vector_with_aad() {
+        // True KAT: pin the canonical AES-256-GCM ciphertext-with-tag bytes
+        // for fixed key + nonce + plaintext + AAD to a hardcoded literal. A
+        // round-trip assertion alone could pass even if `msg` and `aad` were
+        // silently swapped at the AEAD boundary, so this also pins the
+        // exact wire bytes against drift.
+        //
+        // Regenerate by replacing this with `&[0xDE, 0xAD]`, running the
+        // test, and copying the value from the assertion's "actual" panic.
+        const EXPECTED_CIPHERTEXT_WITH_AAD: &[u8] = &[
+            223, 106, 180, 182, 174, 173, 98, 110, 145, 103, 141, 196, 65, 138, 204, 55, 177, 128,
+            130, 170, 2, 209, 220, 213, 236, 81, 45, 212, 153, 81, 215, 125, 195, 204, 219, 130,
+            66, 62, 236, 190, 166, 28, 72,
+        ];
         let key = aead_kat_key();
         let nonce = aead_kat_nonce();
         let plaintext = b"carapace-shared-aead-helper".as_slice();
         let aad = b"carapace:aead-blob-helper-aad:v1".as_slice();
         let blob = encrypt_aead_blob_with_nonce_for_test(&key, &nonce, plaintext, aad).unwrap();
+        assert_eq!(blob.ciphertext, EXPECTED_CIPHERTEXT_WITH_AAD);
+
         let recovered = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, aad).unwrap();
         assert_eq!(recovered, plaintext);
         // AAD-bound ciphertext must differ from the empty-AAD KAT above.

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -3,7 +3,11 @@
 #[cfg(test)]
 use std::sync::{LazyLock, Mutex};
 
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Nonce};
 use argon2::{Algorithm, Argon2, Params, Version};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
 use pbkdf2::pbkdf2_hmac;
 use sha2::Sha256;
 use thiserror::Error;
@@ -32,6 +36,140 @@ pub(crate) enum PasswordKdfError {
     InvalidSaltLength { minimum: usize, got: usize },
     #[error("Argon2 derivation failed: {0}")]
     DerivationFailed(String),
+}
+
+/// AEAD-blob length, in bytes, of the AES-256-GCM 96-bit nonce.
+pub(crate) const AEAD_NONCE_LEN: usize = 12;
+
+/// AES-256-GCM encryption-key length in bytes.
+pub(crate) const AEAD_KEY_LEN: usize = 32;
+
+/// Inner AEAD blob produced by [`encrypt_aead_blob`].
+///
+/// Holds the random 96-bit nonce and the AES-256-GCM ciphertext-with-tag.
+/// Outer persisted formats serialize these fields however they like
+/// (`enc:vN:` strings, binary headers, JSON envelopes).
+pub(crate) struct AeadBlob {
+    pub nonce: [u8; AEAD_NONCE_LEN],
+    pub ciphertext: Vec<u8>,
+}
+
+/// Errors from the shared AEAD-blob helpers.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub(crate) enum CryptoEnvelopeError {
+    #[error("AEAD encryption failed")]
+    EncryptionFailed,
+    #[error("AEAD decryption failed")]
+    DecryptionFailed,
+    #[error("random generation failed: {0}")]
+    RandomFailure(String),
+    #[error("field '{field}' base64 decode: {message}")]
+    Base64Decode {
+        field: &'static str,
+        message: String,
+    },
+    #[error("field '{field}' has wrong length: expected {expected}, got {got}")]
+    FieldLength {
+        field: &'static str,
+        expected: usize,
+        got: usize,
+    },
+}
+
+/// Encrypt `plaintext` under `key` with AES-256-GCM and a freshly generated
+/// random 96-bit nonce.
+///
+/// The helper owns nonce generation: callers cannot supply their own nonce
+/// because nonce-uniqueness under a fixed AEAD key is a critical correctness
+/// invariant. `aad` is authenticated but not encrypted; pass `&[]` when the
+/// outer format does not bind any associated data.
+pub(crate) fn encrypt_aead_blob(
+    key: &[u8; AEAD_KEY_LEN],
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<AeadBlob, CryptoEnvelopeError> {
+    let mut nonce_bytes = [0u8; AEAD_NONCE_LEN];
+    getrandom::fill(&mut nonce_bytes)
+        .map_err(|err| CryptoEnvelopeError::RandomFailure(err.to_string()))?;
+    encrypt_aead_blob_inner(key, &nonce_bytes, plaintext, aad)
+}
+
+/// Test-only variant of [`encrypt_aead_blob`] that takes a fixed nonce so
+/// golden vectors can pin canonical persisted bytes without changing the
+/// runtime nonce-generation contract.
+#[cfg(test)]
+pub(crate) fn encrypt_aead_blob_with_nonce_for_test(
+    key: &[u8; AEAD_KEY_LEN],
+    nonce: &[u8; AEAD_NONCE_LEN],
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<AeadBlob, CryptoEnvelopeError> {
+    encrypt_aead_blob_inner(key, nonce, plaintext, aad)
+}
+
+fn encrypt_aead_blob_inner(
+    key: &[u8; AEAD_KEY_LEN],
+    nonce_bytes: &[u8; AEAD_NONCE_LEN],
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<AeadBlob, CryptoEnvelopeError> {
+    let cipher = Aes256Gcm::new(key.into());
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(nonce_bytes),
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|_| CryptoEnvelopeError::EncryptionFailed)?;
+    Ok(AeadBlob {
+        nonce: *nonce_bytes,
+        ciphertext,
+    })
+}
+
+/// Decrypt an AEAD blob under `key` and `aad`, returning the plaintext.
+///
+/// Returns [`CryptoEnvelopeError::DecryptionFailed`] for any AEAD failure
+/// (wrong key, wrong AAD, tampered ciphertext, or truncated tag).
+pub(crate) fn decrypt_aead_blob(
+    key: &[u8; AEAD_KEY_LEN],
+    blob: &AeadBlob,
+    aad: &[u8],
+) -> Result<Vec<u8>, CryptoEnvelopeError> {
+    let cipher = Aes256Gcm::new(key.into());
+    cipher
+        .decrypt(
+            Nonce::from_slice(&blob.nonce),
+            Payload {
+                msg: blob.ciphertext.as_ref(),
+                aad,
+            },
+        )
+        .map_err(|_| CryptoEnvelopeError::DecryptionFailed)
+}
+
+/// Decode a base64-encoded fixed-size byte field, attributing any error to
+/// `field` for consistent error messages across persisted formats.
+pub(crate) fn decode_b64_fixed<const N: usize>(
+    field: &'static str,
+    value: &str,
+) -> Result<[u8; N], CryptoEnvelopeError> {
+    let decoded = BASE64
+        .decode(value)
+        .map_err(|err| CryptoEnvelopeError::Base64Decode {
+            field,
+            message: err.to_string(),
+        })?;
+    let got = decoded.len();
+    decoded
+        .try_into()
+        .map_err(|_: Vec<u8>| CryptoEnvelopeError::FieldLength {
+            field,
+            expected: N,
+            got,
+        })
 }
 
 /// Generate a random secret encoded as lowercase hex.
@@ -93,6 +231,146 @@ pub(crate) fn derive_key_argon2id(
 mod tests {
     use super::*;
     use sha2::Digest;
+
+    fn aead_kat_key() -> [u8; AEAD_KEY_LEN] {
+        Sha256::digest(b"carapace-aead-blob-helper-kat-key").into()
+    }
+
+    fn aead_kat_nonce() -> [u8; AEAD_NONCE_LEN] {
+        let digest = Sha256::digest(b"carapace-aead-blob-helper-kat-nonce");
+        digest[..AEAD_NONCE_LEN]
+            .try_into()
+            .expect("AEAD nonce length")
+    }
+
+    #[test]
+    fn test_aead_blob_round_trip_empty_aad() {
+        let key = aead_kat_key();
+        let plaintext = b"hello AEAD world".to_vec();
+        let blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        let recovered = decrypt_aead_blob(&key, &blob, &[]).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn test_aead_blob_round_trip_with_aad() {
+        let key = aead_kat_key();
+        let aad = b"carapace:aead-aad-bind:v1".as_slice();
+        let plaintext = b"this is bound to AAD".to_vec();
+        let blob = encrypt_aead_blob(&key, &plaintext, aad).unwrap();
+        let recovered = decrypt_aead_blob(&key, &blob, aad).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn test_aead_blob_decryption_rejects_wrong_aad() {
+        let key = aead_kat_key();
+        let aad = b"carapace:aead-aad-bind:v1".as_slice();
+        let plaintext = b"this is bound to AAD".to_vec();
+        let blob = encrypt_aead_blob(&key, &plaintext, aad).unwrap();
+        let wrong_aad = b"carapace:aead-aad-bind:v2".as_slice();
+        let err = decrypt_aead_blob(&key, &blob, wrong_aad).unwrap_err();
+        assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
+    }
+
+    #[test]
+    fn test_aead_blob_decryption_rejects_wrong_key() {
+        let key = aead_kat_key();
+        let plaintext = b"hello AEAD world".to_vec();
+        let blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        let mut wrong_key = key;
+        wrong_key[0] ^= 0xFF;
+        let err = decrypt_aead_blob(&wrong_key, &blob, &[]).unwrap_err();
+        assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
+    }
+
+    #[test]
+    fn test_aead_blob_decryption_rejects_tampered_ciphertext() {
+        let key = aead_kat_key();
+        let plaintext = b"hello AEAD world".to_vec();
+        let mut blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        if let Some(byte) = blob.ciphertext.first_mut() {
+            *byte ^= 0xFF;
+        }
+        let err = decrypt_aead_blob(&key, &blob, &[]).unwrap_err();
+        assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
+    }
+
+    #[test]
+    fn test_aead_blob_uses_unique_nonce_per_call() {
+        let key = aead_kat_key();
+        let plaintext = b"same plaintext".to_vec();
+        let blob_a = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        let blob_b = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        assert_ne!(
+            blob_a.nonce, blob_b.nonce,
+            "each encrypt call must produce a fresh nonce"
+        );
+    }
+
+    #[test]
+    fn test_aead_blob_known_answer_vector_empty_aad() {
+        // Pinned canonical bytes for fixed key + nonce + plaintext + empty AAD.
+        // Computed independently below using the underlying `Aes256Gcm` API
+        // directly. If this assertion ever changes, the helper's nonce-inside,
+        // empty-AAD path has drifted from raw `Aes256Gcm` semantics.
+        let key = aead_kat_key();
+        let nonce = aead_kat_nonce();
+        let plaintext = b"carapace-shared-aead-helper".as_slice();
+        let blob = encrypt_aead_blob_with_nonce_for_test(&key, &nonce, plaintext, &[]).unwrap();
+        let cipher = Aes256Gcm::new((&key).into());
+        let expected = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext)
+            .expect("KAT reference encryption");
+        assert_eq!(blob.ciphertext, expected);
+    }
+
+    #[test]
+    fn test_aead_blob_known_answer_vector_with_aad() {
+        let key = aead_kat_key();
+        let nonce = aead_kat_nonce();
+        let plaintext = b"carapace-shared-aead-helper".as_slice();
+        let aad = b"carapace:aead-blob-helper-aad:v1".as_slice();
+        let blob = encrypt_aead_blob_with_nonce_for_test(&key, &nonce, plaintext, aad).unwrap();
+        let recovered = decrypt_aead_blob(&key, &blob, aad).unwrap();
+        assert_eq!(recovered, plaintext);
+        // AAD-bound ciphertext must differ from the empty-AAD KAT above.
+        let no_aad_blob =
+            encrypt_aead_blob_with_nonce_for_test(&key, &nonce, plaintext, &[]).unwrap();
+        assert_ne!(blob.ciphertext, no_aad_blob.ciphertext);
+    }
+
+    #[test]
+    fn test_decode_b64_fixed_round_trip() {
+        let bytes: [u8; 5] = [1, 2, 3, 4, 5];
+        let encoded = BASE64.encode(bytes);
+        let decoded = decode_b64_fixed::<5>("test", &encoded).unwrap();
+        assert_eq!(decoded, bytes);
+    }
+
+    #[test]
+    fn test_decode_b64_fixed_invalid_base64() {
+        let err = decode_b64_fixed::<5>("nonce", "not!valid!b64").unwrap_err();
+        assert!(matches!(
+            err,
+            CryptoEnvelopeError::Base64Decode { field: "nonce", .. }
+        ));
+    }
+
+    #[test]
+    fn test_decode_b64_fixed_wrong_length() {
+        let bytes: [u8; 3] = [1, 2, 3];
+        let encoded = BASE64.encode(bytes);
+        let err = decode_b64_fixed::<5>("nonce", &encoded).unwrap_err();
+        assert_eq!(
+            err,
+            CryptoEnvelopeError::FieldLength {
+                field: "nonce",
+                expected: 5,
+                got: 3,
+            }
+        );
+    }
 
     #[test]
     fn test_derive_key_pbkdf2_sha256_rejects_short_salt() {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -320,16 +320,10 @@ mod tests {
 
     #[test]
     fn test_aead_blob_known_answer_vector_empty_aad() {
-        // True KAT: pin the canonical AES-256-GCM ciphertext-with-tag bytes
-        // for fixed key + nonce + plaintext + empty AAD to a hardcoded
-        // literal. The previous version computed expected via raw
-        // `Aes256Gcm::encrypt` on the right side and `encrypt_aead_blob_with_nonce_for_test`
-        // (which itself calls raw `Aes256Gcm::encrypt`) on the left, so any
-        // crate-level drift in `aes-gcm` would have moved both sides
-        // together and the assertion would still have passed.
-        //
-        // Regenerate by replacing this with `&[]`, running the test, and
-        // copying the value from the assertion's "actual" panic message.
+        // KAT: pin the AES-256-GCM ciphertext-with-tag bytes for fixed
+        // key + nonce + plaintext + empty AAD. To regenerate, replace
+        // EXPECTED_CIPHERTEXT with `&[]`, run the test, and copy the
+        // "actual" value from the assertion panic.
         const EXPECTED_CIPHERTEXT: &[u8] = &[
             223, 106, 180, 182, 174, 173, 98, 110, 145, 103, 141, 196, 65, 138, 204, 55, 177, 128,
             130, 170, 2, 209, 220, 213, 236, 81, 45, 35, 87, 3, 35, 237, 247, 103, 127, 125, 150,
@@ -344,14 +338,11 @@ mod tests {
 
     #[test]
     fn test_aead_blob_known_answer_vector_with_aad() {
-        // True KAT: pin the canonical AES-256-GCM ciphertext-with-tag bytes
-        // for fixed key + nonce + plaintext + AAD to a hardcoded literal. A
-        // round-trip assertion alone could pass even if `msg` and `aad` were
-        // silently swapped at the AEAD boundary, so this also pins the
-        // exact wire bytes against drift.
-        //
-        // Regenerate by replacing this with `&[0xDE, 0xAD]`, running the
-        // test, and copying the value from the assertion's "actual" panic.
+        // KAT: pin the AAD-bound ciphertext-with-tag bytes. Pinning the
+        // literal (rather than only round-tripping) catches a regression
+        // that silently swapped `msg` and `aad` at the AEAD boundary —
+        // round-trip alone would still pass under a swapped convention.
+        // Regenerate as for the empty-AAD KAT above.
         const EXPECTED_CIPHERTEXT_WITH_AAD: &[u8] = &[
             223, 106, 180, 182, 174, 173, 98, 110, 145, 103, 141, 196, 65, 138, 204, 55, 177, 128,
             130, 170, 2, 209, 220, 213, 236, 81, 45, 212, 153, 81, 215, 125, 195, 204, 219, 130,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -310,9 +310,12 @@ mod tests {
     fn test_aead_blob_decryption_rejects_tampered_nonce() {
         let key = aead_kat_key();
         let plaintext = b"hello AEAD world".to_vec();
-        let mut blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
-        blob.nonce[0] ^= 0xFF;
-        let err = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, &[]).unwrap_err();
+        let blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        let wrong_nonce = encrypt_aead_blob(&key, b"different nonce source", &[])
+            .unwrap()
+            .nonce;
+        assert_ne!(wrong_nonce, blob.nonce);
+        let err = decrypt_aead_blob(&key, &wrong_nonce, &blob.ciphertext, &[]).unwrap_err();
         assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
     }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -307,6 +307,16 @@ mod tests {
     }
 
     #[test]
+    fn test_aead_blob_decryption_rejects_tampered_nonce() {
+        let key = aead_kat_key();
+        let plaintext = b"hello AEAD world".to_vec();
+        let mut blob = encrypt_aead_blob(&key, &plaintext, &[]).unwrap();
+        blob.nonce[0] ^= 0xFF;
+        let err = decrypt_aead_blob(&key, &blob.nonce, &blob.ciphertext, &[]).unwrap_err();
+        assert_eq!(err, CryptoEnvelopeError::DecryptionFailed);
+    }
+
+    #[test]
     fn test_aead_blob_uses_unique_nonce_per_call() {
         let key = aead_kat_key();
         let plaintext = b"same plaintext".to_vec();

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -320,19 +320,26 @@ mod tests {
 
     #[test]
     fn test_aead_blob_known_answer_vector_empty_aad() {
-        // Pinned canonical bytes for fixed key + nonce + plaintext + empty AAD.
-        // Computed independently below using the underlying `Aes256Gcm` API
-        // directly. If this assertion ever changes, the helper's nonce-inside,
-        // empty-AAD path has drifted from raw `Aes256Gcm` semantics.
+        // True KAT: pin the canonical AES-256-GCM ciphertext-with-tag bytes
+        // for fixed key + nonce + plaintext + empty AAD to a hardcoded
+        // literal. The previous version computed expected via raw
+        // `Aes256Gcm::encrypt` on the right side and `encrypt_aead_blob_with_nonce_for_test`
+        // (which itself calls raw `Aes256Gcm::encrypt`) on the left, so any
+        // crate-level drift in `aes-gcm` would have moved both sides
+        // together and the assertion would still have passed.
+        //
+        // Regenerate by replacing this with `&[]`, running the test, and
+        // copying the value from the assertion's "actual" panic message.
+        const EXPECTED_CIPHERTEXT: &[u8] = &[
+            223, 106, 180, 182, 174, 173, 98, 110, 145, 103, 141, 196, 65, 138, 204, 55, 177, 128,
+            130, 170, 2, 209, 220, 213, 236, 81, 45, 35, 87, 3, 35, 237, 247, 103, 127, 125, 150,
+            146, 250, 33, 182, 179, 201,
+        ];
         let key = aead_kat_key();
         let nonce = aead_kat_nonce();
         let plaintext = b"carapace-shared-aead-helper".as_slice();
         let blob = encrypt_aead_blob_with_nonce_for_test(&key, &nonce, plaintext, &[]).unwrap();
-        let cipher = Aes256Gcm::new((&key).into());
-        let expected = cipher
-            .encrypt(Nonce::from_slice(&nonce), plaintext)
-            .expect("KAT reference encryption");
-        assert_eq!(blob.ciphertext, expected);
+        assert_eq!(blob.ciphertext, EXPECTED_CIPHERTEXT);
     }
 
     #[test]

--- a/src/sessions/crypto.rs
+++ b/src/sessions/crypto.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 
 use crate::crypto::{
     decode_b64_fixed as decode_envelope_b64_fixed, decrypt_aead_blob, derive_key_argon2id,
-    encrypt_aead_blob, AeadBlob, CryptoEnvelopeError, PasswordKdfError, ARGON2ID_V2_ITERATIONS,
+    encrypt_aead_blob, CryptoEnvelopeError, PasswordKdfError, ARGON2ID_V2_ITERATIONS,
     ARGON2ID_V2_LANES, ARGON2ID_V2_MEMORY_KIB, PASSWORD_DERIVED_KEY_LEN,
 };
 use crate::sessions::file_lock::FileLock;
@@ -138,12 +138,10 @@ fn map_envelope_error(err: CryptoEnvelopeError) -> SessionCryptoError {
         }
         CryptoEnvelopeError::DecryptionFailed => SessionCryptoError::DecryptionFailed,
         CryptoEnvelopeError::RandomFailure(message) => SessionCryptoError::RandomFailure(message),
-        CryptoEnvelopeError::Base64Decode { field, message } => {
-            SessionCryptoError::Base64Decode {
-                field: field.to_string(),
-                message,
-            }
-        }
+        CryptoEnvelopeError::Base64Decode { field, message } => SessionCryptoError::Base64Decode {
+            field: field.to_string(),
+            message,
+        },
         CryptoEnvelopeError::FieldLength {
             field,
             expected,
@@ -197,12 +195,10 @@ fn decode_b64<const N: usize>(
     value: &str,
 ) -> Result<[u8; N], SessionCryptoError> {
     decode_envelope_b64_fixed::<N>(field, value).map_err(|err| match err {
-        CryptoEnvelopeError::Base64Decode { field, message } => {
-            SessionCryptoError::Base64Decode {
-                field: field.to_string(),
-                message,
-            }
-        }
+        CryptoEnvelopeError::Base64Decode { field, message } => SessionCryptoError::Base64Decode {
+            field: field.to_string(),
+            message,
+        },
         CryptoEnvelopeError::FieldLength {
             field,
             expected,
@@ -277,8 +273,7 @@ fn decrypt_prefixed_bytes_with_master_key(
             })?;
     let key = derive_session_key_from_master(master_key, session_id, purpose)?;
     let aad = aad_bytes(session_id, purpose);
-    let blob = AeadBlob { nonce, ciphertext };
-    decrypt_aead_blob(&key, &blob, &aad).map_err(map_envelope_error)
+    decrypt_aead_blob(&key, &nonce, &ciphertext, &aad).map_err(map_envelope_error)
 }
 
 fn read_prefixed_file_bytes(path: &Path) -> Result<Option<Vec<u8>>, SessionCryptoError> {
@@ -477,6 +472,20 @@ impl fmt::Debug for SessionCryptoContext {
 }
 
 impl SessionCryptoContext {
+    /// Test-only constructor that bypasses KDF and manifest I/O. Used by
+    /// golden-vector tests that need a fast, deterministic context.
+    #[cfg(test)]
+    pub(crate) fn from_master_key_for_test(
+        master_key: [u8; PASSWORD_DERIVED_KEY_LEN],
+    ) -> Result<Self, SessionCryptoError> {
+        let integrity_hmac_key = expand_hkdf(&master_key, SESSION_INTEGRITY_INFO)?;
+        Ok(Self {
+            master_key: Zeroizing::new(master_key),
+            integrity_hmac_key,
+            manifest_integrity_valid: true,
+        })
+    }
+
     /// Load or create the session crypto manifest and derive the root key.
     pub fn load_or_create(base_path: &Path, password: &[u8]) -> Result<Self, SessionCryptoError> {
         fs::create_dir_all(base_path)?;
@@ -599,17 +608,27 @@ impl SessionCryptoContext {
         let key = self.derive_session_key(session_id, purpose)?;
         let aad = aad_bytes(session_id, purpose);
         let blob = encrypt_aead_blob(&key, plaintext, &aad).map_err(map_envelope_error)?;
+        wrap_session_envelope(blob.nonce, &blob.ciphertext)
+    }
 
-        let envelope = EncryptedEnvelope {
-            format: SESSION_ENCRYPTED_FORMAT_V1.to_string(),
-            n: BASE64.encode(blob.nonce),
-            c: BASE64.encode(&blob.ciphertext),
-        };
-        let envelope = serde_json::to_vec(&envelope).map_err(SessionCryptoError::from)?;
-        let mut out = Vec::with_capacity(SESSION_ENCRYPTED_PREFIX_V1.len() + envelope.len());
-        out.extend_from_slice(SESSION_ENCRYPTED_PREFIX_V1);
-        out.extend_from_slice(&envelope);
-        Ok(out)
+    /// Test-only variant of [`encrypt_bytes`] that pins the AEAD nonce so
+    /// golden-vector tests can assert the exact persisted `cse1:` payload
+    /// bytes against the production write path (key derivation + AEAD +
+    /// envelope wrapping) rather than a reconstruction.
+    #[cfg(test)]
+    pub(crate) fn encrypt_bytes_with_nonce_for_test(
+        &self,
+        session_id: &str,
+        purpose: &str,
+        plaintext: &[u8],
+        nonce: &[u8; NONCE_LEN],
+    ) -> Result<Vec<u8>, SessionCryptoError> {
+        let key = self.derive_session_key(session_id, purpose)?;
+        let aad = aad_bytes(session_id, purpose);
+        let blob =
+            crate::crypto::encrypt_aead_blob_with_nonce_for_test(&key, nonce, plaintext, &aad)
+                .map_err(map_envelope_error)?;
+        wrap_session_envelope(blob.nonce, &blob.ciphertext)
     }
 
     pub fn decrypt_bytes(
@@ -648,6 +667,26 @@ impl SessionCryptoContext {
     }
 }
 
+/// Build the canonical `cse1:` payload bytes from an AEAD nonce and
+/// ciphertext. Shared between the production `encrypt_bytes` path and the
+/// test-only `encrypt_bytes_with_nonce_for_test` so any drift in the
+/// envelope JSON layout, prefix, or field ordering fails both at once.
+fn wrap_session_envelope(
+    nonce: [u8; NONCE_LEN],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, SessionCryptoError> {
+    let envelope = EncryptedEnvelope {
+        format: SESSION_ENCRYPTED_FORMAT_V1.to_string(),
+        n: BASE64.encode(nonce),
+        c: BASE64.encode(ciphertext),
+    };
+    let envelope = serde_json::to_vec(&envelope).map_err(SessionCryptoError::from)?;
+    let mut out = Vec::with_capacity(SESSION_ENCRYPTED_PREFIX_V1.len() + envelope.len());
+    out.extend_from_slice(SESSION_ENCRYPTED_PREFIX_V1);
+    out.extend_from_slice(&envelope);
+    Ok(out)
+}
+
 pub fn has_encrypted_payload_prefix(data: &[u8]) -> bool {
     has_prefix(data)
 }
@@ -664,8 +703,6 @@ pub fn is_encrypted_payload(data: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aes_gcm::aead::{Aead, KeyInit, Payload};
-    use aes_gcm::{Aes256Gcm, Nonce};
     use serde_json::Value;
     use sha2::Digest;
 
@@ -1014,11 +1051,13 @@ mod tests {
 
     #[test]
     fn test_cse1_persisted_payload_and_aad_golden_vector() {
-        // Golden vector pinning the canonical `cse1:` envelope plus the
-        // manifest-bound AAD construction for a fixed master_key + session_id
-        // + purpose + nonce + plaintext. Guards against drift in the persisted
-        // payload layout *and* the AAD derivation: any change in either side
-        // would break this test.
+        // True golden vector: pins the canonical `cse1:` payload bytes to a
+        // hardcoded literal `&[u8]` for a fixed master_key + session_id +
+        // purpose + nonce + plaintext, AND exercises
+        // `SessionCryptoContext::encrypt_bytes` (via the test-only nonce
+        // override) so the full production write path is asserted —
+        // session-key derivation, manifest-bound AAD, AEAD, JSON envelope,
+        // prefix. Drift in any of those would change the literal.
         let master_key: [u8; PASSWORD_DERIVED_KEY_LEN] =
             Sha256::digest(b"carapace-sessions-golden-master-key").into();
         let session_id = "session-golden-fixture";
@@ -1029,57 +1068,48 @@ mod tests {
             .expect("nonce slice length");
         let plaintext = br#"{"hello":"golden"}"#;
 
-        // Pin AAD construction.
+        // Pin AAD construction explicitly so a future change to
+        // `aad_bytes()` is caught even if it kept the same byte length.
         let aad = aad_bytes(session_id, purpose);
         let expected_aad = format!("carapace:session:{}:v1:{}", purpose, session_id);
         assert_eq!(aad, expected_aad.as_bytes());
 
-        // Derive per-session key and encrypt independently with raw
-        // `Aes256Gcm`. This pins the inner crypto-envelope under AAD.
-        let key = derive_session_key_from_master(&master_key, session_id, purpose).unwrap();
-        let cipher = Aes256Gcm::new((&*key).into());
-        let expected_ct = cipher
-            .encrypt(
-                Nonce::from_slice(&nonce_bytes),
-                Payload {
-                    msg: plaintext.as_ref(),
-                    aad: &aad,
-                },
-            )
-            .expect("golden session encryption");
+        // Pinned canonical `cse1:` payload bytes for the inputs above.
+        // First 5 bytes are the `cse1:` prefix; the rest is a UTF-8 JSON
+        // object `{"format":"session-enc-v1","n":"<b64-nonce>","c":"<b64-ct>"}`.
+        // Regenerate by replacing this with `&[]`, running the test, and
+        // copying the value from the assertion's "actual" panic message.
+        // Any deliberate persisted-format change must update this constant.
+        const EXPECTED_CSE1_PAYLOAD: &[u8] = &[
+            99, 115, 101, 49, 58, 123, 34, 102, 111, 114, 109, 97, 116, 34, 58, 34, 115, 101, 115,
+            115, 105, 111, 110, 45, 101, 110, 99, 45, 118, 49, 34, 44, 34, 110, 34, 58, 34, 57, 49,
+            74, 90, 110, 79, 89, 97, 118, 77, 76, 86, 106, 120, 107, 120, 34, 44, 34, 99, 34, 58,
+            34, 111, 106, 101, 71, 51, 103, 98, 111, 115, 118, 70, 100, 69, 47, 76, 51, 87, 113,
+            114, 48, 113, 75, 98, 50, 43, 52, 98, 65, 117, 68, 109, 49, 87, 108, 71, 78, 50, 97,
+            69, 71, 89, 103, 83, 71, 116, 81, 61, 61, 34, 125,
+        ];
 
-        // Reconstruct the canonical `cse1:` payload bytes.
-        let envelope = EncryptedEnvelope {
-            format: SESSION_ENCRYPTED_FORMAT_V1.to_string(),
-            n: BASE64.encode(nonce_bytes),
-            c: BASE64.encode(&expected_ct),
-        };
-        let envelope_bytes = serde_json::to_vec(&envelope).expect("serialize envelope");
-        let mut expected_payload = Vec::new();
-        expected_payload.extend_from_slice(SESSION_ENCRYPTED_PREFIX_V1);
-        expected_payload.extend_from_slice(&envelope_bytes);
+        let ctx = SessionCryptoContext::from_master_key_for_test(master_key)
+            .expect("construct deterministic SessionCryptoContext");
+        let actual_payload = ctx
+            .encrypt_bytes_with_nonce_for_test(session_id, purpose, plaintext, &nonce_bytes)
+            .expect("production encrypt_bytes with test nonce");
+        assert_eq!(actual_payload, EXPECTED_CSE1_PAYLOAD);
 
-        // Round-trip through the public decrypt path to confirm the canonical
-        // payload decodes back to the same plaintext with the same AAD.
-        let recovered = decrypt_prefixed_bytes_with_master_key(
-            &master_key,
-            session_id,
-            purpose,
-            &expected_payload,
-        )
-        .expect("golden session decryption");
+        // Round-trip through the production decrypt path to confirm the
+        // canonical payload decodes back to the same plaintext with the same
+        // master-key-derived session key and AAD.
+        let recovered = ctx
+            .decrypt_bytes(session_id, purpose, &actual_payload)
+            .expect("golden session decryption");
         assert_eq!(recovered, plaintext);
 
         // Wrong AAD (different session_id) must fail to decrypt the same
         // ciphertext, demonstrating that AAD is bound through the envelope.
         let wrong_session = "session-not-golden";
-        let err = decrypt_prefixed_bytes_with_master_key(
-            &master_key,
-            wrong_session,
-            purpose,
-            &expected_payload,
-        )
-        .unwrap_err();
+        let err = ctx
+            .decrypt_bytes(wrong_session, purpose, &actual_payload)
+            .unwrap_err();
         assert_eq!(err, SessionCryptoError::DecryptionFailed);
     }
 

--- a/src/sessions/crypto.rs
+++ b/src/sessions/crypto.rs
@@ -475,7 +475,7 @@ impl SessionCryptoContext {
     /// Test-only constructor that bypasses KDF and manifest I/O. Used by
     /// golden-vector tests that need a fast, deterministic context.
     #[cfg(test)]
-    pub(crate) fn from_master_key_for_test(
+    fn from_master_key_for_test(
         master_key: [u8; PASSWORD_DERIVED_KEY_LEN],
     ) -> Result<Self, SessionCryptoError> {
         let integrity_hmac_key = expand_hkdf(&master_key, SESSION_INTEGRITY_INFO)?;
@@ -616,7 +616,7 @@ impl SessionCryptoContext {
     /// bytes against the production write path (key derivation + AEAD +
     /// envelope wrapping) rather than a reconstruction.
     #[cfg(test)]
-    pub(crate) fn encrypt_bytes_with_nonce_for_test(
+    fn encrypt_bytes_with_nonce_for_test(
         &self,
         session_id: &str,
         purpose: &str,

--- a/src/sessions/crypto.rs
+++ b/src/sessions/crypto.rs
@@ -1051,13 +1051,11 @@ mod tests {
 
     #[test]
     fn test_cse1_persisted_payload_and_aad_golden_vector() {
-        // True golden vector: pins the canonical `cse1:` payload bytes to a
-        // hardcoded literal `&[u8]` for a fixed master_key + session_id +
-        // purpose + nonce + plaintext, AND exercises
-        // `SessionCryptoContext::encrypt_bytes` (via the test-only nonce
-        // override) so the full production write path is asserted —
-        // session-key derivation, manifest-bound AAD, AEAD, JSON envelope,
-        // prefix. Drift in any of those would change the literal.
+        // Golden vector: pin the canonical `cse1:` payload bytes for fixed
+        // master_key + session_id + purpose + nonce + plaintext, exercised
+        // through the production `encrypt_bytes` path (test-only nonce
+        // override). The full chain is asserted: session-key derivation,
+        // manifest-bound AAD, AEAD, JSON envelope, prefix.
         let master_key: [u8; PASSWORD_DERIVED_KEY_LEN] =
             Sha256::digest(b"carapace-sessions-golden-master-key").into();
         let session_id = "session-golden-fixture";

--- a/src/sessions/crypto.rs
+++ b/src/sessions/crypto.rs
@@ -10,8 +10,6 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
-use aes_gcm::aead::{Aead, KeyInit, Payload};
-use aes_gcm::{Aes256Gcm, Nonce};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use hkdf::Hkdf;
@@ -23,8 +21,9 @@ use thiserror::Error;
 use zeroize::Zeroizing;
 
 use crate::crypto::{
-    derive_key_argon2id, PasswordKdfError, ARGON2ID_V2_ITERATIONS, ARGON2ID_V2_LANES,
-    ARGON2ID_V2_MEMORY_KIB, PASSWORD_DERIVED_KEY_LEN,
+    decode_b64_fixed as decode_envelope_b64_fixed, decrypt_aead_blob, derive_key_argon2id,
+    encrypt_aead_blob, AeadBlob, CryptoEnvelopeError, PasswordKdfError, ARGON2ID_V2_ITERATIONS,
+    ARGON2ID_V2_LANES, ARGON2ID_V2_MEMORY_KIB, PASSWORD_DERIVED_KEY_LEN,
 };
 use crate::sessions::file_lock::FileLock;
 
@@ -132,6 +131,29 @@ fn map_kdf_error(err: PasswordKdfError) -> SessionCryptoError {
     SessionCryptoError::KeyDerivation(err.to_string())
 }
 
+fn map_envelope_error(err: CryptoEnvelopeError) -> SessionCryptoError {
+    match err {
+        CryptoEnvelopeError::EncryptionFailed => {
+            SessionCryptoError::EncryptionFailed("AEAD encryption failed".to_string())
+        }
+        CryptoEnvelopeError::DecryptionFailed => SessionCryptoError::DecryptionFailed,
+        CryptoEnvelopeError::RandomFailure(message) => SessionCryptoError::RandomFailure(message),
+        CryptoEnvelopeError::Base64Decode { field, message } => {
+            SessionCryptoError::Base64Decode {
+                field: field.to_string(),
+                message,
+            }
+        }
+        CryptoEnvelopeError::FieldLength {
+            field,
+            expected,
+            got,
+        } => SessionCryptoError::BadFormat(format!(
+            "field '{field}' has wrong length: expected {expected}, got {got}"
+        )),
+    }
+}
+
 fn manifest_path(base_path: &Path) -> PathBuf {
     base_path.join(CRYPTO_MANIFEST_PATH)
 }
@@ -174,17 +196,21 @@ fn decode_b64<const N: usize>(
     field: &'static str,
     value: &str,
 ) -> Result<[u8; N], SessionCryptoError> {
-    let decoded = BASE64
-        .decode(value)
-        .map_err(|err| SessionCryptoError::Base64Decode {
-            field: field.to_string(),
-            message: err.to_string(),
-        })?;
-    decoded.try_into().map_err(|got: Vec<u8>| {
-        SessionCryptoError::BadFormat(format!(
-            "field '{field}' has wrong length: expected {N}, got {}",
-            got.len()
-        ))
+    decode_envelope_b64_fixed::<N>(field, value).map_err(|err| match err {
+        CryptoEnvelopeError::Base64Decode { field, message } => {
+            SessionCryptoError::Base64Decode {
+                field: field.to_string(),
+                message,
+            }
+        }
+        CryptoEnvelopeError::FieldLength {
+            field,
+            expected,
+            got,
+        } => SessionCryptoError::BadFormat(format!(
+            "field '{field}' has wrong length: expected {expected}, got {got}"
+        )),
+        other => SessionCryptoError::BadFormat(other.to_string()),
     })
 }
 
@@ -241,7 +267,7 @@ fn decrypt_prefixed_bytes_with_master_key(
         )));
     }
 
-    let nonce_bytes = decode_b64::<NONCE_LEN>("n", &envelope.n)?;
+    let nonce = decode_b64::<NONCE_LEN>("n", &envelope.n)?;
     let ciphertext =
         BASE64
             .decode(&envelope.c)
@@ -250,17 +276,9 @@ fn decrypt_prefixed_bytes_with_master_key(
                 message: err.to_string(),
             })?;
     let key = derive_session_key_from_master(master_key, session_id, purpose)?;
-    let cipher = Aes256Gcm::new((&*key).into());
     let aad = aad_bytes(session_id, purpose);
-    cipher
-        .decrypt(
-            Nonce::from_slice(&nonce_bytes),
-            Payload {
-                msg: ciphertext.as_ref(),
-                aad: &aad,
-            },
-        )
-        .map_err(|_| SessionCryptoError::DecryptionFailed)
+    let blob = AeadBlob { nonce, ciphertext };
+    decrypt_aead_blob(&key, &blob, &aad).map_err(map_envelope_error)
 }
 
 fn read_prefixed_file_bytes(path: &Path) -> Result<Option<Vec<u8>>, SessionCryptoError> {
@@ -579,27 +597,13 @@ impl SessionCryptoContext {
         plaintext: &[u8],
     ) -> Result<Vec<u8>, SessionCryptoError> {
         let key = self.derive_session_key(session_id, purpose)?;
-        let cipher = Aes256Gcm::new((&*key).into());
-
-        let mut nonce_bytes = [0u8; NONCE_LEN];
-        getrandom::fill(&mut nonce_bytes)
-            .map_err(|err| SessionCryptoError::RandomFailure(err.to_string()))?;
-        let nonce = Nonce::from_slice(&nonce_bytes);
         let aad = aad_bytes(session_id, purpose);
-        let ciphertext = cipher
-            .encrypt(
-                nonce,
-                Payload {
-                    msg: plaintext,
-                    aad: &aad,
-                },
-            )
-            .map_err(|err| SessionCryptoError::EncryptionFailed(err.to_string()))?;
+        let blob = encrypt_aead_blob(&key, plaintext, &aad).map_err(map_envelope_error)?;
 
         let envelope = EncryptedEnvelope {
             format: SESSION_ENCRYPTED_FORMAT_V1.to_string(),
-            n: BASE64.encode(nonce_bytes),
-            c: BASE64.encode(ciphertext),
+            n: BASE64.encode(blob.nonce),
+            c: BASE64.encode(&blob.ciphertext),
         };
         let envelope = serde_json::to_vec(&envelope).map_err(SessionCryptoError::from)?;
         let mut out = Vec::with_capacity(SESSION_ENCRYPTED_PREFIX_V1.len() + envelope.len());
@@ -660,7 +664,10 @@ pub fn is_encrypted_payload(data: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aes_gcm::aead::{Aead, KeyInit, Payload};
+    use aes_gcm::{Aes256Gcm, Nonce};
     use serde_json::Value;
+    use sha2::Digest;
 
     fn test_key_material() -> Vec<u8> {
         format!("fixture-{}", uuid::Uuid::new_v4()).into_bytes()
@@ -1003,6 +1010,77 @@ mod tests {
 
         assert!(!has_encrypted_payload_prefix(unprefixed));
         assert!(!is_encrypted_payload(unprefixed));
+    }
+
+    #[test]
+    fn test_cse1_persisted_payload_and_aad_golden_vector() {
+        // Golden vector pinning the canonical `cse1:` envelope plus the
+        // manifest-bound AAD construction for a fixed master_key + session_id
+        // + purpose + nonce + plaintext. Guards against drift in the persisted
+        // payload layout *and* the AAD derivation: any change in either side
+        // would break this test.
+        let master_key: [u8; PASSWORD_DERIVED_KEY_LEN] =
+            Sha256::digest(b"carapace-sessions-golden-master-key").into();
+        let session_id = "session-golden-fixture";
+        let purpose = SESSION_METADATA_PURPOSE;
+        let nonce_digest = Sha256::digest(b"carapace-sessions-golden-nonce");
+        let nonce_bytes: [u8; NONCE_LEN] = nonce_digest[..NONCE_LEN]
+            .try_into()
+            .expect("nonce slice length");
+        let plaintext = br#"{"hello":"golden"}"#;
+
+        // Pin AAD construction.
+        let aad = aad_bytes(session_id, purpose);
+        let expected_aad = format!("carapace:session:{}:v1:{}", purpose, session_id);
+        assert_eq!(aad, expected_aad.as_bytes());
+
+        // Derive per-session key and encrypt independently with raw
+        // `Aes256Gcm`. This pins the inner crypto-envelope under AAD.
+        let key = derive_session_key_from_master(&master_key, session_id, purpose).unwrap();
+        let cipher = Aes256Gcm::new((&*key).into());
+        let expected_ct = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce_bytes),
+                Payload {
+                    msg: plaintext.as_ref(),
+                    aad: &aad,
+                },
+            )
+            .expect("golden session encryption");
+
+        // Reconstruct the canonical `cse1:` payload bytes.
+        let envelope = EncryptedEnvelope {
+            format: SESSION_ENCRYPTED_FORMAT_V1.to_string(),
+            n: BASE64.encode(nonce_bytes),
+            c: BASE64.encode(&expected_ct),
+        };
+        let envelope_bytes = serde_json::to_vec(&envelope).expect("serialize envelope");
+        let mut expected_payload = Vec::new();
+        expected_payload.extend_from_slice(SESSION_ENCRYPTED_PREFIX_V1);
+        expected_payload.extend_from_slice(&envelope_bytes);
+
+        // Round-trip through the public decrypt path to confirm the canonical
+        // payload decodes back to the same plaintext with the same AAD.
+        let recovered = decrypt_prefixed_bytes_with_master_key(
+            &master_key,
+            session_id,
+            purpose,
+            &expected_payload,
+        )
+        .expect("golden session decryption");
+        assert_eq!(recovered, plaintext);
+
+        // Wrong AAD (different session_id) must fail to decrypt the same
+        // ciphertext, demonstrating that AAD is bound through the envelope.
+        let wrong_session = "session-not-golden";
+        let err = decrypt_prefixed_bytes_with_master_key(
+            &master_key,
+            wrong_session,
+            purpose,
+            &expected_payload,
+        )
+        .unwrap_err();
+        assert_eq!(err, SessionCryptoError::DecryptionFailed);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Closes #348.

Centralizes the AES-256-GCM inner crypto envelope into three `pub(crate)` helpers in `src/crypto.rs` and migrates the three duplicate call sites onto them. Outer persisted formats are unchanged.

### Shared helpers (in `src/crypto.rs`)

- `encrypt_aead_blob(key, plaintext, aad) -> AeadBlob` — owns 96-bit nonce generation via `getrandom::fill`. Callers cannot supply a nonce; nonce-uniqueness under a fixed key is the helper's invariant.
- `decrypt_aead_blob(key, &AeadBlob, aad) -> Vec<u8>` — opaque AAD pass-through.
- `decode_b64_fixed::<N>(field, value) -> [u8; N]` — fixed-size base64 decode with attributed error messages.
- `CryptoEnvelopeError` covering `EncryptionFailed`, `DecryptionFailed`, `RandomFailure`, `Base64Decode { field, message }`, `FieldLength { field, expected, got }`.
- `#[cfg(test)] encrypt_aead_blob_with_nonce_for_test` lets golden vectors pin canonical bytes without touching the runtime nonce path.

### Migrated sites

| Site | Outer format (unchanged) | AAD |
|---|---|---|
| `src/config/secrets.rs` | `enc:v2:NONCE:CT:SALT` (and `enc:v1:` decode) | empty |
| `src/cli/backup_crypto.rs` | `CRPC_ENC` magic + version + salt + nonce + ct | empty |
| `src/sessions/crypto.rs` | `cse1:` + JSON `{format,n,c}` | `carapace:session:{purpose}:v1:{session_id}` |

### Golden vectors (added before migration)

- `config::secrets::tests::test_enc_v2_persisted_format_golden_vector`
- `cli::backup_crypto::tests::test_crpc_enc_persisted_layout_golden_vector` (uses pre-derived key to bypass Argon2id cost)
- `sessions::crypto::tests::test_cse1_persisted_payload_and_aad_golden_vector` (pins both payload bytes and AAD construction)

Plus 11 helper-level tests in `src/crypto.rs` (round-trip, KAT, AAD/key/nonce-tamper rejection, base64 helper).

### Validation

- `scripts/cargo-serial nextest run`: 3681 / 3681 passing.
- `scripts/cargo-serial clippy --all-targets -- -D warnings`: clean.
- Visually re-diffed: `enc:vN:` segments, `CRPC_ENC` byte layout, and `cse1:` JSON envelope are byte-for-byte unchanged. Nonces still come from `getrandom::fill` (now inside the helper). AAD construction `format!("carapace:session:{purpose}:v1:{session_id}")` is unchanged. Legacy `enc:v1:` PBKDF2 KAT and legacy `CRPC_ENC` v1 round-trip both still pass.

### No persisted-format changes

- `enc:v2:NONCE:CT:SALT` — same colon-delimited layout, same base64 alphabet, same AES-GCM bytes.
- `CRPC_ENC` — same magic + version + salt(32) + nonce(12) + ct layout.
- `cse1:` + `{format:"session-enc-v1", n, c}` — same prefix and JSON shape; manifest-bound AAD passed opaquely.

## Test plan

- [x] `scripts/cargo-serial nextest run` (3681 pass)
- [x] `scripts/cargo-serial clippy --all-targets -- -D warnings`
- [x] Three new golden-vector tests pass before and after migration
- [x] Legacy `enc:v1:` decrypt path and `CRPC_ENC` v1 fixture round-trip still pass
