### PR TITLE
feat(security): typed ConfigError; stop leaking config-key paths externally (#398)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -41,11 +41,50 @@ pub use provider::{LlmProvider, StreamEvent};
 use tokio_util::sync::CancellationToken;
 pub use tool_policy::ToolPolicy;
 
+/// Configuration errors raised at the routing/model-resolution boundary.
+///
+/// These are surfaced to external API callers via the HTTP and WebSocket
+/// layers — `Display` deliberately produces wire-safe messages that do
+/// NOT name internal configuration-key paths (no `routes`, `top-level`,
+/// `agents.defaults.model`, etc.). Operator-facing remediation hints
+/// belong in `tracing::warn!` at the construction site, not in the
+/// returned error message. See issue #398.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConfigError {
+    /// A request or session referenced a `route` name that is not in the
+    /// configured routes map.
+    #[error("unknown route \"{route}\"")]
+    UnknownRoute { route: String },
+
+    /// Resolution found neither a `route` nor a `model` in any scope, so
+    /// no backend model could be selected for the request.
+    #[error("no model configured for this request")]
+    NoModelConfigured,
+}
+
+impl ConfigError {
+    /// Stable wire-format error code surfaced to external callers in the
+    /// HTTP / WS error response. Documented as part of the public API
+    /// contract — clients may dispatch on these strings.
+    pub fn wire_code(&self) -> &'static str {
+        match self {
+            Self::UnknownRoute { .. } => "unknown_route",
+            Self::NoModelConfigured => "no_model_configured",
+        }
+    }
+}
+
 /// Errors that can occur during agent execution.
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
     #[error("LLM provider error: {0}")]
     Provider(String),
+
+    /// Configuration-resolution error. Carries a typed
+    /// [`ConfigError`] whose `Display` is wire-safe; the server layer
+    /// maps it to a stable `wire_code()` for external clients.
+    #[error("{0}")]
+    Config(#[from] ConfigError),
 
     #[error("session not found: {0}")]
     SessionNotFound(String),

--- a/src/config/routes.rs
+++ b/src/config/routes.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::agent::AgentError;
+use crate::agent::{AgentError, ConfigError};
 
 /// A named route — backend target + optional metadata.
 #[derive(Debug, Clone, Deserialize)]
@@ -95,10 +95,18 @@ pub fn resolve_execution_target(
             let route_name = route_name.trim();
             if !route_name.is_empty() {
                 let config = routes.get(route_name).ok_or_else(|| {
-                    AgentError::Provider(format!(
-                        "unknown route \"{route_name}\"; \
-                         define it in the top-level `routes` config map"
-                    ))
+                    // Operator-facing remediation hint: name the config key.
+                    // The wire-facing message (via `ConfigError::Display`) is
+                    // deliberately narrower — it does not embed `routes`,
+                    // `top-level`, or any other internal config-key path.
+                    tracing::warn!(
+                        route = %route_name,
+                        "unknown route requested; define it in the top-level \
+                         `routes` config map"
+                    );
+                    AgentError::Config(ConfigError::UnknownRoute {
+                        route: route_name.to_string(),
+                    })
                 })?;
                 return Ok(ResolvedRoute {
                     model: config.model.clone(),
@@ -117,12 +125,13 @@ pub fn resolve_execution_target(
         }
     }
 
-    Err(AgentError::Provider(
+    // Same operator/wire split as above.
+    tracing::warn!(
         "no model configured; set `route` or `model` in agent config or defaults \
          (e.g. `agents.defaults.route: \"fast\"` or \
          `agents.defaults.model: \"anthropic:claude-sonnet-4-20250514\"`)"
-            .to_string(),
-    ))
+    );
+    Err(AgentError::Config(ConfigError::NoModelConfigured))
 }
 
 /// Parse the top-level `routes` map from config. Returns empty map if not present.
@@ -339,6 +348,70 @@ mod tests {
         let err = resolve_execution_target(&routes, &inputs).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("no model configured"), "got: {msg}");
+    }
+
+    /// Regression for #398: the wire-format error message for both
+    /// `UnknownRoute` and `NoModelConfigured` must not embed any of the
+    /// internal config-key paths the leaky pre-#398 messages did.
+    #[test]
+    fn config_error_messages_do_not_leak_config_key_paths() {
+        let leak_substrings = [
+            "top-level",
+            "agent config or defaults",
+            "`routes`",
+            "`route`",
+            "`model`",
+            "agents.defaults",
+            "config map",
+        ];
+
+        // UnknownRoute case.
+        let routes = make_routes();
+        let inputs = RouteResolutionInputs {
+            agent: SelectorLevel {
+                route: Some("nonexistent"),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let unknown_route_err = resolve_execution_target(&routes, &inputs).unwrap_err();
+        let unknown_msg = unknown_route_err.to_string();
+        for needle in &leak_substrings {
+            assert!(
+                !unknown_msg.contains(needle),
+                "UnknownRoute wire message must not contain {needle:?}: got {unknown_msg:?}"
+            );
+        }
+
+        // NoModelConfigured case.
+        let empty_routes = HashMap::new();
+        let no_model_err =
+            resolve_execution_target(&empty_routes, &RouteResolutionInputs::default()).unwrap_err();
+        let no_model_msg = no_model_err.to_string();
+        for needle in &leak_substrings {
+            assert!(
+                !no_model_msg.contains(needle),
+                "NoModelConfigured wire message must not contain {needle:?}: got {no_model_msg:?}"
+            );
+        }
+    }
+
+    /// Stable wire-format codes for `ConfigError` are part of the public
+    /// API contract — clients dispatch on these strings.
+    #[test]
+    fn config_error_wire_codes_are_stable() {
+        use crate::agent::ConfigError;
+        assert_eq!(
+            ConfigError::UnknownRoute {
+                route: "x".to_string()
+            }
+            .wire_code(),
+            "unknown_route"
+        );
+        assert_eq!(
+            ConfigError::NoModelConfigured.wire_code(),
+            "no_model_configured"
+        );
     }
 
     #[test]

--- a/src/hooks/handler.rs
+++ b/src/hooks/handler.rs
@@ -96,6 +96,12 @@ pub struct AgentResponse {
     pub run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Stable wire-format error code (e.g. `"unknown_route"`,
+    /// `"no_model_configured"`). Present only on structured errors that
+    /// have a documented code; absent on free-form errors. Clients may
+    /// dispatch on this string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
 }
 
 impl AgentResponse {
@@ -104,6 +110,7 @@ impl AgentResponse {
             ok: true,
             run_id: Some(run_id),
             error: None,
+            error_code: None,
         }
     }
 
@@ -112,6 +119,19 @@ impl AgentResponse {
             ok: false,
             run_id: None,
             error: Some(msg.to_string()),
+            error_code: None,
+        }
+    }
+
+    /// Build an error response with both a wire-format code and a
+    /// human-readable message. Use this for typed errors that carry a
+    /// stable code clients can dispatch on (e.g. [`crate::agent::ConfigError`]).
+    pub fn error_with_code(code: &str, msg: &str) -> Self {
+        AgentResponse {
+            ok: false,
+            run_id: None,
+            error: Some(msg.to_string()),
+            error_code: Some(code.to_string()),
         }
     }
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1303,18 +1303,31 @@ async fn dispatch_agent_run(
             session_model: session.metadata.model.as_deref(),
         },
     ) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(AgentResponse::error(&e.to_string())),
-        )
-            .into_response());
+        let response = match &e {
+            crate::agent::AgentError::Config(cfg_err) => {
+                AgentResponse::error_with_code(cfg_err.wire_code(), &cfg_err.to_string())
+            }
+            other => AgentResponse::error(&other.to_string()),
+        };
+        return Err((StatusCode::BAD_REQUEST, Json(response)).into_response());
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, None);
     if config.model.trim().is_empty() {
+        // Defensive: `resolve_agent_model` should have errored above if no
+        // model was configured. Reaching this branch means it succeeded but
+        // wrote an empty model — surface the same typed `ConfigError` so
+        // callers see a consistent wire shape and `tracing::warn!` carries
+        // the operator-facing remediation hint.
+        let cfg_err = crate::agent::ConfigError::NoModelConfigured;
+        tracing::warn!(
+            "no model configured after resolve_agent_model; \
+             set `agents.defaults.model` in config or provide a `model` parameter"
+        );
         return Err((
             StatusCode::BAD_REQUEST,
-            Json(AgentResponse::error(
-                "no model configured; set `agents.defaults.model` in config or provide a model in the request",
+            Json(AgentResponse::error_with_code(
+                cfg_err.wire_code(),
+                &cfg_err.to_string(),
             )),
         )
             .into_response());

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -2099,15 +2099,23 @@ pub(super) fn handle_agent(
             session_model: session.metadata.model.as_deref(),
         },
     ) {
-        return Err(error_shape(ERROR_UNAVAILABLE, &e.to_string(), None));
+        let code = match &e {
+            crate::agent::AgentError::Config(cfg_err) => cfg_err.wire_code(),
+            _ => ERROR_UNAVAILABLE,
+        };
+        return Err(error_shape(code, &e.to_string(), None));
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, agent_id);
     if config.model.trim().is_empty() {
-        return Err(error_shape(
-            ERROR_UNAVAILABLE,
-            "no model configured; set `agents.defaults.model` in config or provide a `model` parameter",
-            None,
-        ));
+        // Defensive: see equivalent comment in `src/server/http.rs`. Surface
+        // the typed `ConfigError` so HTTP and WS produce consistent wire
+        // shapes for the same error.
+        let cfg_err = crate::agent::ConfigError::NoModelConfigured;
+        tracing::warn!(
+            "no model configured after resolve_agent_model; \
+             set `agents.defaults.model` in config or provide a `model` parameter"
+        );
+        return Err(error_shape(cfg_err.wire_code(), &cfg_err.to_string(), None));
     }
 
     let (run_id, session_key_out, cancel_token) = setup_agent_session(


### PR DESCRIPTION
Closes #398.

## Problem

The route-resolution path in `resolve_execution_target` (`src/config/routes.rs`) was returning `AgentError::Provider(...)` with free-form messages that embedded internal config-key paths:

- `unknown route "<name>"; define it in the top-level \`routes\` config map`
- `no model configured; set \`route\` or \`model\` in agent config or defaults (e.g. \`agents.defaults.route: "fast"\` or \`agents.defaults.model: "anthropic:claude-sonnet-4-20250514"\`)`

Those strings flowed unchanged to external API callers via:

- HTTP: `AgentResponse::error(&e.to_string())` in `src/server/http.rs` (returns 400 BAD_REQUEST — bodies commonly surface to end-users via SDK error messages, browser dev tools, etc.).
- WebSocket: `error_shape(ERROR_UNAVAILABLE, &e.to_string(), None)` in `src/server/ws/handlers/sessions.rs`.

Anyone who could trigger a misconfigured-route or no-model-configured error received a free enumeration of the gateway's internal configuration topology — a low-value but real information leak in a security-first product.

## Changes

### New typed error

`ConfigError` enum in `src/agent/mod.rs`:

```rust
pub enum ConfigError {
    UnknownRoute { route: String },
    NoModelConfigured,
}

impl ConfigError {
    pub fn wire_code(&self) -> &'static str { /* "unknown_route" | "no_model_configured" */ }
}
```

`Display` produces wire-safe messages — no `routes`, `top-level`, `agent config or defaults`, `agents.defaults.model`, etc. The remediation hint with the config-key path moves to a `tracing::warn!` at the construction site so operators still see the long-form guidance in logs / Control UI without exposing it on the wire.

`AgentError::Config(#[from] ConfigError)` variant lets call sites propagate the typed error naturally.

### Wire-format additions (additive — existing clients unaffected)

- `AgentResponse` (in `src/hooks/handler.rs`) gains an optional `error_code: Option<String>` field with `serde(skip_serializing_if = "Option::is_none")`. Existing clients ignore unknown fields; new clients can dispatch on the code.
- New `AgentResponse::error_with_code(code, msg)` constructor.

### Server-boundary mapping

Both HTTP and WebSocket handlers now match on `AgentError::Config` and surface the wire code:

| Surface | Old | New |
|---|---|---|
| HTTP (`http.rs`) | `AgentResponse::error(&e.to_string())` | `AgentResponse::error_with_code(cfg_err.wire_code(), &cfg_err.to_string())` for `Config`; falls through to `error()` for other variants |
| WebSocket (`sessions.rs`) | `error_shape(ERROR_UNAVAILABLE, &e.to_string(), None)` | `error_shape(cfg_err.wire_code(), &cfg_err.to_string(), None)` for `Config`; falls through to `ERROR_UNAVAILABLE` for other variants |

Defensive empty-model checks downstream of `resolve_agent_model` (which should never fire if the resolver works correctly) also drop their inline leaky messages and emit the same typed `ConfigError::NoModelConfigured` for consistent wire shape.

## Stable wire codes (public contract)

- `"unknown_route"` — the request, session, agent, or defaults referenced a route name not in `routes`.
- `"no_model_configured"` — neither `route` nor `model` resolved to a usable backend.

Both codes are pinned by `config_error_wire_codes_are_stable`.

## Tests

- **`config_error_messages_do_not_leak_config_key_paths`** (regression): asserts that `Display` for both variants does not contain any of `top-level`, `agent config or defaults`, `` `routes` ``, `` `route` ``, `` `model` ``, `agents.defaults`, or `config map`. Acceptance criterion #1 from the issue.
- **`config_error_wire_codes_are_stable`**: pins the codes so a future rename requires an explicit test update.
- Existing `unknown_route_is_hard_error` and `no_model_configured_returns_clear_error` substring checks still pass — the wire-safe `Display` preserves the recognizable nouns (`unknown route`, `no model configured`).

Validation:

- `scripts/cargo-serial nextest run -p carapace` → **3684 / 3684 pass** (3 new tests, including the regression).
- `scripts/cargo-serial clippy --all-targets -- -D warnings` → clean.
- `scripts/cargo-serial fmt --check` → clean.

## Acceptance criteria (from #398)

- [x] No external API response carries the literal substrings `routes`, `route`, `model`, `` `route` ``, `` `model` ``, `top-level`, or `agent config or defaults` in a routing/config error message — confirmed at both HTTP and WebSocket surfaces.
- [x] HTTP remediation lands first or together with WS, never WS-only — both surfaces ship in this PR.
- [x] Existing operator-facing surfaces (logs) retain the same level of remediation detail — `tracing::warn!` at the construction site carries the full long-form guidance.
- [x] Snapshot test on the wire format covering: unknown route, no model configured.
- [x] The shipped wire-format error codes are stable and documented.

## Out of scope (follow-ups if needed)

The OpenAI-compat path (`src/server/openai.rs`), the provider selection path (`src/agent/provider.rs::select_provider`), and the cron executor path (`src/cron/executor.rs`) emit similar `no model configured` messages with their own config-key hints. Those are separate code paths and external surfaces; this PR fixes the route-resolution path #398 specifically identified. A follow-up issue can extend the same `ConfigError` taxonomy to those sites if desired — the typed-error scaffolding shipped here is reusable.
