### PR TITLE
feat(security): surface AgentConfigurationError wire codes to API clients (#398)

### DIFF
--- a/docs/protocol/websocket.md
+++ b/docs/protocol/websocket.md
@@ -390,9 +390,9 @@ not emitted via `error_shape` are noted explicitly.
 *Note on `rate_limited`*: semantically the operation is retryable (with
 backoff / `Retry-After`), but `error_shape`'s current hard-coded
 retryable check produces `retryable: false`. Clients should treat
-`rate_limited` as retryable regardless of the field; a future fix to
-`error_shape` (tracked separately) will align the wire field with
-intent.
+`rate_limited` as retryable regardless of the field; a future fix
+will align the wire field with intent
+(tracked at [#405](https://github.com/puremachinery/carapace/issues/405)).
 
 ### Reserved codes (documented but not yet emitted)
 

--- a/docs/protocol/websocket.md
+++ b/docs/protocol/websocket.md
@@ -371,25 +371,47 @@ Events are broadcast to connected clients. See `src/server/ws/mod.rs` for implem
 ## Error Codes
 
 Wire codes are stable, lower_snake_case strings. Clients dispatch on the
-`code` field of the error response. Configuration-error codes
-(`unknown_route`, `missing_model`) come from `AgentConfigurationErrorCode`
-in the agent layer; the codes below are emitted by the WebSocket
-transport and protocol layers.
+`error.code` field of the error response. The `Retryable` column reflects
+what `error_shape` actually emits on the wire today (currently
+hard-coded: `retryable: true` only when `code == "unavailable"`). Codes
+not emitted via `error_shape` are noted explicitly.
 
-| Code | Description | Retryable |
-|------|-------------|-----------|
-| `invalid_request` | Validation/protocol error | No |
-| `not_linked` | Channel not configured | No |
+### Top-level `error.code` values (emitted via `error_shape`)
+
+| Code | Description | Retryable on wire |
+|------|-------------|-------------------|
+| `invalid_request` | Validation / protocol error | No |
 | `not_paired` | Device not paired | No |
-| `agent_timeout` | Agent exceeded timeout | Yes |
 | `unavailable` | Service temporarily unavailable | Yes |
+| `rate_limited` | Per-resource rate limit exceeded | No (see note) |
 | `unknown_route` | Request referenced a route not in the `routes` map | No |
 | `missing_model` | Resolution found no `route` or `model` for the request | No |
-| `not_connected` | Targeted node is not currently connected | No |
-| `rate_limited` | Per-resource rate limit exceeded | Yes |
-| `csrf_error` | CSRF token missing or invalid | No |
-| `invalid_input` | Plugin input validation failed | No |
-| `timeout` | Generic timeout (e.g. node invoke) | Yes |
+
+*Note on `rate_limited`*: semantically the operation is retryable (with
+backoff / `Retry-After`), but `error_shape`'s current hard-coded
+retryable check produces `retryable: false`. Clients should treat
+`rate_limited` as retryable regardless of the field; a future fix to
+`error_shape` (tracked separately) will align the wire field with
+intent.
+
+### Reserved codes (documented but not yet emitted)
+
+| Code | Description |
+|------|-------------|
+| `not_linked` | Channel not configured. Constant `ERROR_NOT_LINKED` is reserved in `src/server/ws/mod.rs`; no live emit site yet. |
+| `agent_timeout` | Agent exceeded timeout. Documented for client compatibility; no live emit at the top-level `error.code` position currently. |
+
+### Codes that are NOT top-level `error.code` values
+
+These appear in nested positions or are emitted by non-WebSocket
+surfaces. Clients dispatching on `error.code` will not see them there.
+
+| Code | Where it actually appears |
+|------|---------------------------|
+| `not_connected` | `error.details.nodeError.code` (outer `error.code` is `unavailable`) |
+| `timeout` | `error.details.code` (outer `error.code` is `unavailable`) when a node-invoke times out |
+| `csrf_error` | HTTP middleware error body (not a WS error frame) |
+| `invalid_input` | Plugin host error surface (not a WS error frame) |
 
 ## Close Codes
 

--- a/docs/protocol/websocket.md
+++ b/docs/protocol/websocket.md
@@ -145,7 +145,7 @@ Error:
   "id": "unique-request-id",
   "ok": false,
   "error": {
-    "code": "INVALID_REQUEST",
+    "code": "invalid_request",
     "message": "description",
     "details": { ... },
     "retryable": false
@@ -370,13 +370,26 @@ Events are broadcast to connected clients. See `src/server/ws/mod.rs` for implem
 
 ## Error Codes
 
+Wire codes are stable, lower_snake_case strings. Clients dispatch on the
+`code` field of the error response. Configuration-error codes
+(`unknown_route`, `missing_model`) come from `AgentConfigurationErrorCode`
+in the agent layer; the codes below are emitted by the WebSocket
+transport and protocol layers.
+
 | Code | Description | Retryable |
 |------|-------------|-----------|
-| `INVALID_REQUEST` | Validation/protocol error | No |
-| `NOT_LINKED` | Channel not configured | No |
-| `NOT_PAIRED` | Device not paired | No |
-| `AGENT_TIMEOUT` | Agent exceeded timeout | Yes |
-| `UNAVAILABLE` | Service temporarily unavailable | Yes |
+| `invalid_request` | Validation/protocol error | No |
+| `not_linked` | Channel not configured | No |
+| `not_paired` | Device not paired | No |
+| `agent_timeout` | Agent exceeded timeout | Yes |
+| `unavailable` | Service temporarily unavailable | Yes |
+| `unknown_route` | Request referenced a route not in the `routes` map | No |
+| `missing_model` | Resolution found no `route` or `model` for the request | No |
+| `not_connected` | Targeted node is not currently connected | No |
+| `rate_limited` | Per-resource rate limit exceeded | Yes |
+| `csrf_error` | CSRF token missing or invalid | No |
+| `invalid_input` | Plugin input validation failed | No |
+| `timeout` | Generic timeout (e.g. node invoke) | Yes |
 
 ## Close Codes
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -165,12 +165,8 @@ impl AgentError {
         }
     }
 
-    /// Stable wire-format error code for typed errors that carry one
-    /// (currently only [`AgentError::Configuration`]). Returns `None`
-    /// for free-form errors that do not have a documented code.
-    /// Server boundary layers use this to populate their wire response
-    /// (`AgentResponse.error_code` for HTTP, the `code` position of
-    /// `error_shape` for WebSocket).
+    /// Stable wire-format error code for typed errors. Returns `None`
+    /// for free-form variants without a documented code.
     pub fn wire_code(&self) -> Option<&'static str> {
         match self {
             Self::Configuration(error) => Some(error.code().as_str()),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -164,6 +164,19 @@ impl AgentError {
             error.log_operator_hint();
         }
     }
+
+    /// Stable wire-format error code for typed errors that carry one
+    /// (currently only [`AgentError::Configuration`]). Returns `None`
+    /// for free-form errors that do not have a documented code.
+    /// Server boundary layers use this to populate their wire response
+    /// (`AgentResponse.error_code` for HTTP, the `code` position of
+    /// `error_shape` for WebSocket).
+    pub fn wire_code(&self) -> Option<&'static str> {
+        match self {
+            Self::Configuration(error) => Some(error.code().as_str()),
+            _ => None,
+        }
+    }
 }
 
 /// Configuration for an agent run.
@@ -603,6 +616,26 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
+
+    /// Server-boundary contract: `AgentError::Configuration` must yield a
+    /// stable wire code that the HTTP and WS layers can surface to
+    /// external clients. Free-form variants must yield `None` so the
+    /// surfaces don't fabricate a misleading code.
+    #[test]
+    fn test_agent_error_wire_code_for_configuration_variants() {
+        let unknown = AgentError::Configuration(AgentConfigurationError::unknown_route("fast"));
+        assert_eq!(unknown.wire_code(), Some("unknown_route"));
+
+        let missing = AgentError::Configuration(AgentConfigurationError::missing_model());
+        assert_eq!(missing.wire_code(), Some("missing_model"));
+
+        assert_eq!(
+            AgentError::Provider("transient".to_string()).wire_code(),
+            None
+        );
+        assert_eq!(AgentError::Cancelled.wire_code(), None);
+        assert_eq!(AgentError::MaxTurns(5).wire_code(), None);
+    }
 
     /// Mock provider whose `complete` method panics with a `&str` message.
     struct PanickingProvider {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2086,7 +2086,7 @@ async fn connect_cli_ws_authenticated(
         .await?;
 
     if let Err(err) = await_ws_response_with_error(&mut ws_read, &mut ws_write, "connect-1").await {
-        let message = if err.code.as_deref() == Some("NOT_PAIRED")
+        let message = if err.code.as_deref() == Some("not_paired")
             && err.message.contains("pairing required")
         {
             let mut message =
@@ -8240,7 +8240,7 @@ pub async fn handle_pair(
         .send(Message::Text(serde_json::to_string(&connect_frame)?.into()))
         .await?;
     if let Err(err) = await_ws_response_with_error(&mut ws_read, &mut ws_write, "connect-1").await {
-        if err.code.as_deref() == Some("NOT_PAIRED") && err.message.contains("pairing required") {
+        if err.code.as_deref() == Some("not_paired") && err.message.contains("pairing required") {
             eprintln!("Device pairing required for this CLI.");
             if let Some(details) = err.details.as_ref() {
                 if let Some(request_id) = extract_pairing_request_id(details) {

--- a/src/hooks/handler.rs
+++ b/src/hooks/handler.rs
@@ -7,6 +7,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::agent::AgentError;
+
 /// Wake mode for scheduling wake events
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -124,15 +126,27 @@ impl AgentResponse {
     }
 
     /// Build an error response carrying both a stable wire-format code
-    /// and a human-readable message. Use this for typed errors that
-    /// document a code clients can dispatch on (e.g.
-    /// [`crate::agent::AgentConfigurationError`]).
-    pub fn error_with_code(code: &str, msg: &str) -> Self {
+    /// and a human-readable message. The code parameter is `&'static str`
+    /// so callers cannot accidentally invent ad-hoc codes — the only
+    /// supported source is [`AgentError::wire_code`].
+    pub fn error_with_code(code: &'static str, msg: &str) -> Self {
         AgentResponse {
             ok: false,
             run_id: None,
             error: Some(msg.to_string()),
             error_code: Some(code.to_string()),
+        }
+    }
+}
+
+/// Map an `AgentError` to its wire response. Typed variants whose
+/// `wire_code()` returns `Some(code)` carry the code in `errorCode`;
+/// free-form variants populate only `error`.
+impl From<&AgentError> for AgentResponse {
+    fn from(error: &AgentError) -> Self {
+        match error.wire_code() {
+            Some(code) => Self::error_with_code(code, &error.to_string()),
+            None => Self::error(&error.to_string()),
         }
     }
 }
@@ -313,25 +327,15 @@ mod tests {
 
     #[test]
     fn test_agent_response_error_omits_error_code_field() {
-        // Free-form errors must NOT carry an `errorCode` on the wire so
-        // existing clients that haven't been updated for typed codes
-        // don't see a partial / misleading one.
         let resp = AgentResponse::error("something broke");
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["ok"], false);
         assert_eq!(json["error"], "something broke");
-        assert!(
-            json.get("errorCode").is_none(),
-            "errorCode must be absent for free-form errors: {json}"
-        );
+        assert!(json.get("errorCode").is_none(), "{json}");
     }
 
     #[test]
     fn test_agent_response_error_with_code_emits_camelcase_field() {
-        // Typed-error path: clients dispatch on `errorCode`. The field is
-        // serialized in camelCase (`errorCode`, not `error_code`) per the
-        // struct's `#[serde(rename_all = "camelCase")]`, and the value is
-        // the stable wire-format code from `AgentError::wire_code()`.
         let resp =
             AgentResponse::error_with_code("unknown_route", "requested route is not configured");
         let json = serde_json::to_value(&resp).unwrap();

--- a/src/hooks/handler.rs
+++ b/src/hooks/handler.rs
@@ -96,6 +96,12 @@ pub struct AgentResponse {
     pub run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Stable wire-format error code for structured errors (e.g.
+    /// `"unknown_route"`, `"missing_model"` from
+    /// [`crate::agent::AgentConfigurationErrorCode`]). Absent on
+    /// free-form errors. Clients may dispatch on this string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
 }
 
 impl AgentResponse {
@@ -104,6 +110,7 @@ impl AgentResponse {
             ok: true,
             run_id: Some(run_id),
             error: None,
+            error_code: None,
         }
     }
 
@@ -112,6 +119,20 @@ impl AgentResponse {
             ok: false,
             run_id: None,
             error: Some(msg.to_string()),
+            error_code: None,
+        }
+    }
+
+    /// Build an error response carrying both a stable wire-format code
+    /// and a human-readable message. Use this for typed errors that
+    /// document a code clients can dispatch on (e.g.
+    /// [`crate::agent::AgentConfigurationError`]).
+    pub fn error_with_code(code: &str, msg: &str) -> Self {
+        AgentResponse {
+            ok: false,
+            run_id: None,
+            error: Some(msg.to_string()),
+            error_code: Some(code.to_string()),
         }
     }
 }
@@ -289,6 +310,35 @@ impl HooksErrorResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_agent_response_error_omits_error_code_field() {
+        // Free-form errors must NOT carry an `errorCode` on the wire so
+        // existing clients that haven't been updated for typed codes
+        // don't see a partial / misleading one.
+        let resp = AgentResponse::error("something broke");
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["error"], "something broke");
+        assert!(
+            json.get("errorCode").is_none(),
+            "errorCode must be absent for free-form errors: {json}"
+        );
+    }
+
+    #[test]
+    fn test_agent_response_error_with_code_emits_camelcase_field() {
+        // Typed-error path: clients dispatch on `errorCode`. The field is
+        // serialized in camelCase (`errorCode`, not `error_code`) per the
+        // struct's `#[serde(rename_all = "camelCase")]`, and the value is
+        // the stable wire-format code from `AgentError::wire_code()`.
+        let resp =
+            AgentResponse::error_with_code("unknown_route", "requested route is not configured");
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["error"], "requested route is not configured");
+        assert_eq!(json["errorCode"], "unknown_route");
+    }
 
     #[test]
     fn test_wake_mode_from_str() {

--- a/src/plugins/bindings.rs
+++ b/src/plugins/bindings.rs
@@ -556,11 +556,11 @@ mod tests {
     #[test]
     fn test_plugin_error_display() {
         let err = PluginError {
-            code: "INVALID_INPUT".to_string(),
+            code: "invalid_input".to_string(),
             message: "Missing required field".to_string(),
             retryable: false,
         };
-        assert_eq!(err.to_string(), "[INVALID_INPUT] Missing required field");
+        assert_eq!(err.to_string(), "[invalid_input] Missing required field");
     }
 
     #[test]

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -2404,11 +2404,11 @@ mod tests {
     #[test]
     fn test_wit_plugin_error_fields() {
         let pe = WitPluginError {
-            code: "RATE_LIMITED".to_string(),
+            code: "rate_limited".to_string(),
             message: "Too many requests".to_string(),
             retryable: true,
         };
-        assert_eq!(pe.code, "RATE_LIMITED");
+        assert_eq!(pe.code, "rate_limited");
         assert_eq!(pe.message, "Too many requests");
         assert!(pe.retryable);
     }

--- a/src/server/csrf.rs
+++ b/src/server/csrf.rs
@@ -544,7 +544,7 @@ fn csrf_error_response(error: CsrfError) -> Response<Body> {
         StatusCode::FORBIDDEN,
         [(header::CONTENT_TYPE, "application/json; charset=utf-8")],
         format!(
-            r#"{{"error":{{"code":"CSRF_ERROR","message":"{}"}}}}"#,
+            r#"{{"error":{{"code":"csrf_error","message":"{}"}}}}"#,
             message
         ),
     )

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1304,21 +1304,13 @@ async fn dispatch_agent_run(
         },
     ) {
         e.log_configuration_hint();
-        let response = match e.wire_code() {
-            Some(code) => AgentResponse::error_with_code(code, &e.to_string()),
-            None => AgentResponse::error(&e.to_string()),
-        };
-        return Err((StatusCode::BAD_REQUEST, Json(response)).into_response());
+        return Err((StatusCode::BAD_REQUEST, Json(AgentResponse::from(&e))).into_response());
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, None);
     if config.model.trim().is_empty() {
         let error = AgentError::Configuration(AgentConfigurationError::missing_model());
         error.log_configuration_hint();
-        let response = match error.wire_code() {
-            Some(code) => AgentResponse::error_with_code(code, &error.to_string()),
-            None => AgentResponse::error(&error.to_string()),
-        };
-        return Err((StatusCode::BAD_REQUEST, Json(response)).into_response());
+        return Err((StatusCode::BAD_REQUEST, Json(AgentResponse::from(&error))).into_response());
     }
 
     // Register the agent run

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1304,21 +1304,21 @@ async fn dispatch_agent_run(
         },
     ) {
         e.log_configuration_hint();
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(AgentResponse::error(&e.to_string())),
-        )
-            .into_response());
+        let response = match e.wire_code() {
+            Some(code) => AgentResponse::error_with_code(code, &e.to_string()),
+            None => AgentResponse::error(&e.to_string()),
+        };
+        return Err((StatusCode::BAD_REQUEST, Json(response)).into_response());
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, None);
     if config.model.trim().is_empty() {
         let error = AgentError::Configuration(AgentConfigurationError::missing_model());
         error.log_configuration_hint();
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(AgentResponse::error(&error.to_string())),
-        )
-            .into_response());
+        let response = match error.wire_code() {
+            Some(code) => AgentResponse::error_with_code(code, &error.to_string()),
+            None => AgentResponse::error(&error.to_string()),
+        };
+        return Err((StatusCode::BAD_REQUEST, Json(response)).into_response());
     }
 
     // Register the agent run

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -2753,6 +2753,94 @@ mod tests {
         assert_eq!(json["error"], "message required");
     }
 
+    /// Integration test for issue #398: when route resolution fails, the
+    /// HTTP `/hooks/agent` response body must carry the stable wire-format
+    /// `errorCode` and the human-readable `error` message must NOT contain
+    /// any of the internal config-key paths the leaky pre-#398 messages
+    /// did. Exercises the actual axum handler via `oneshot` (with a real
+    /// `ws_state` so `dispatch_agent_run` actually runs), not just the
+    /// `AgentResponse` constructor in isolation.
+    #[tokio::test]
+    async fn test_hooks_agent_unknown_route_emits_typed_error_code() {
+        let (temp, _guard) = set_temp_config_path();
+        // Empty config — no routes map, no agents.defaults.model. The
+        // request below specifies an unknown route name, which forces
+        // `resolve_execution_target` into the `UnknownRoute` arm.
+        std::fs::write(temp.path().join("carapace-test-config.json5"), "{}").unwrap();
+        let (ws_state, _tmp) = make_test_ws_state();
+        let router =
+            test_router_with_hook_registry(test_config(), Arc::new(HookRegistry::new()), ws_state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/hooks/agent")
+            .header("authorization", "Bearer test-hooks-token")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"message":"hello","route":"nonexistent-route-name"}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["errorCode"], "unknown_route");
+
+        let error_msg = json["error"].as_str().expect("error message");
+        assert!(
+            !error_msg.contains("`routes`")
+                && !error_msg.contains("top-level")
+                && !error_msg.contains("agents.defaults"),
+            "human-readable error must not leak internal config-key paths: {error_msg}"
+        );
+    }
+
+    /// Companion to the unknown-route test: with no route or model
+    /// configured anywhere, `resolve_execution_target` returns
+    /// `MissingModel`, which surfaces as `errorCode: "missing_model"`
+    /// on the HTTP wire.
+    #[tokio::test]
+    async fn test_hooks_agent_missing_model_emits_typed_error_code() {
+        let (temp, _guard) = set_temp_config_path();
+        std::fs::write(temp.path().join("carapace-test-config.json5"), "{}").unwrap();
+        let (ws_state, _tmp) = make_test_ws_state();
+        let router =
+            test_router_with_hook_registry(test_config(), Arc::new(HookRegistry::new()), ws_state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/hooks/agent")
+            .header("authorization", "Bearer test-hooks-token")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"message":"hello"}"#))
+            .unwrap();
+
+        let response = router.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["errorCode"], "missing_model");
+
+        let error_msg = json["error"].as_str().expect("error message");
+        assert!(
+            !error_msg.contains("`route`")
+                && !error_msg.contains("`model`")
+                && !error_msg.contains("agents.defaults"),
+            "human-readable error must not leak internal config-key paths: {error_msg}"
+        );
+    }
+
     #[tokio::test]
     async fn test_hooks_mapping_agent_dispatches_real_run() {
         let (temp, _guard) = set_temp_config_path();

--- a/src/server/ratelimit.rs
+++ b/src/server/ratelimit.rs
@@ -561,7 +561,7 @@ fn rate_limit_exceeded_response(retry_after_secs: u64) -> Response<Body> {
             (header::RETRY_AFTER, &retry_after_secs.to_string()),
         ],
         format!(
-            r#"{{"error":{{"code":"RATE_LIMIT_EXCEEDED","message":"Too many requests","retryAfter":{}}}}}"#,
+            r#"{{"error":{{"code":"rate_limit_exceeded","message":"Too many requests","retryAfter":{}}}}}"#,
             retry_after_secs
         ),
     )

--- a/src/server/ws/handlers/node.rs
+++ b/src/server/ws/handlers/node.rs
@@ -748,7 +748,7 @@ fn validate_node_command(
                 ERROR_UNAVAILABLE,
                 "node not connected",
                 Some(json!({
-                    "details": { "nodeId": node_id, "nodeError": { "code": "NOT_CONNECTED" } }
+                    "details": { "nodeId": node_id, "nodeError": { "code": "not_connected" } }
                 })),
             )
         })?;
@@ -829,7 +829,7 @@ async fn await_node_invoke_result(
             payload: None,
             payload_json: None,
             error: Some(NodeInvokeError {
-                code: Some("UNAVAILABLE".to_string()),
+                code: Some("unavailable".to_string()),
                 message: Some("node invoke failed".to_string()),
             }),
         },
@@ -839,7 +839,7 @@ async fn await_node_invoke_result(
                 ERROR_UNAVAILABLE,
                 "node invoke timed out",
                 Some(json!({
-                    "details": { "code": "TIMEOUT", "nodeId": node_id, "command": command }
+                    "details": { "code": "timeout", "nodeId": node_id, "command": command }
                 })),
             ));
         }
@@ -933,7 +933,7 @@ pub(crate) async fn handle_node_invoke(
                 "details": {
                     "nodeId": invoke_params.node_id,
                     "command": invoke_params.command,
-                    "nodeError": { "code": "UNAVAILABLE" }
+                    "nodeError": { "code": "unavailable" }
                 }
             })),
         ));

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -3263,7 +3263,7 @@ mod tests {
         let result = handle_sessions_archive(&state, None);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.code, "INVALID_REQUEST");
+        assert_eq!(err.code, "invalid_request");
     }
 
     #[test]
@@ -3328,7 +3328,7 @@ mod tests {
         let result = handle_sessions_restore(&state, None);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.code, "INVALID_REQUEST");
+        assert_eq!(err.code, "invalid_request");
     }
 
     #[test]
@@ -3407,7 +3407,7 @@ mod tests {
         let result = handle_sessions_archive_delete(&state, None);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.code, "INVALID_REQUEST");
+        assert_eq!(err.code, "invalid_request");
     }
 
     #[test]
@@ -3440,7 +3440,7 @@ mod tests {
         let (state, _tmp) = make_state_with_temp_sessions();
         let result = handle_sessions_export_user(&state, None);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().code, "INVALID_REQUEST");
+        assert_eq!(result.unwrap_err().code, "invalid_request");
     }
 
     #[test]
@@ -3449,7 +3449,7 @@ mod tests {
         let params = json!({ "userId": "" });
         let result = handle_sessions_export_user(&state, Some(&params));
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().code, "INVALID_REQUEST");
+        assert_eq!(result.unwrap_err().code, "invalid_request");
     }
 
     #[test]
@@ -3458,7 +3458,7 @@ mod tests {
         let params = json!({ "userId": "   " });
         let result = handle_sessions_export_user(&state, Some(&params));
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().code, "INVALID_REQUEST");
+        assert_eq!(result.unwrap_err().code, "invalid_request");
     }
 
     #[test]
@@ -3505,7 +3505,7 @@ mod tests {
         let (state, _tmp) = make_state_with_temp_sessions();
         let result = handle_sessions_purge_user(&state, None);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().code, "INVALID_REQUEST");
+        assert_eq!(result.unwrap_err().code, "invalid_request");
     }
 
     #[test]
@@ -3514,7 +3514,7 @@ mod tests {
         let params = json!({ "userId": "" });
         let result = handle_sessions_purge_user(&state, Some(&params));
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().code, "INVALID_REQUEST");
+        assert_eq!(result.unwrap_err().code, "invalid_request");
     }
 
     #[test]
@@ -3523,7 +3523,7 @@ mod tests {
         let params = json!({ "userId": "  \t  " });
         let result = handle_sessions_purge_user(&state, Some(&params));
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().code, "INVALID_REQUEST");
+        assert_eq!(result.unwrap_err().code, "invalid_request");
     }
 
     #[test]

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -2100,6 +2100,10 @@ pub(super) fn handle_agent(
         },
     ) {
         e.log_configuration_hint();
+        // `error_shape` derives `retryable` from `code == ERROR_UNAVAILABLE`,
+        // so emitting a typed wire code (e.g. "unknown_route") correctly
+        // surfaces `retryable: false` — config errors need operator
+        // intervention, not retry.
         let code = e.wire_code().unwrap_or(ERROR_UNAVAILABLE);
         return Err(error_shape(code, &e.to_string(), None));
     }

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -2100,7 +2100,8 @@ pub(super) fn handle_agent(
         },
     ) {
         e.log_configuration_hint();
-        return Err(error_shape(ERROR_UNAVAILABLE, &e.to_string(), None));
+        let code = e.wire_code().unwrap_or(ERROR_UNAVAILABLE);
+        return Err(error_shape(code, &e.to_string(), None));
     }
     crate::agent::apply_agent_config_from_settings(&mut config, &cfg, agent_id);
     if config.model.trim().is_empty() {
@@ -2108,7 +2109,8 @@ pub(super) fn handle_agent(
             crate::agent::AgentConfigurationError::missing_model(),
         );
         error.log_configuration_hint();
-        return Err(error_shape(ERROR_UNAVAILABLE, &error.to_string(), None));
+        let code = error.wire_code().unwrap_or(ERROR_UNAVAILABLE);
+        return Err(error_shape(code, &error.to_string(), None));
     }
 
     let (run_id, session_key_out, cancel_token) = setup_agent_session(

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -77,6 +77,14 @@ const ERROR_INVALID_REQUEST: &str = "invalid_request";
 const ERROR_NOT_PAIRED: &str = "not_paired";
 const ERROR_UNAVAILABLE: &str = "unavailable";
 const ERROR_RATE_LIMITED: &str = "rate_limited";
+/// Documented in `docs/protocol/websocket.md` and exercised by the
+/// `tests/golden/ws/errors.json` schema, but not yet emitted from any
+/// live Rust code path. Reserved for future "channel not configured"
+/// errors. Kept here so the wire-code set is discoverable from one
+/// place and a future emit site can `use ERROR_NOT_LINKED` rather than
+/// re-introducing a string literal.
+#[allow(dead_code)]
+const ERROR_NOT_LINKED: &str = "not_linked";
 // Note: Node doesn't use ERROR_FORBIDDEN - use ERROR_INVALID_REQUEST for auth errors
 
 const ALLOWED_CLIENT_IDS: [&str; 12] = [

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -67,10 +67,16 @@ const LOGS_MAX_LIMIT: usize = 5_000;
 const LOGS_MAX_BYTES: usize = 1_000_000;
 const MAX_JSON_DEPTH: usize = 32;
 
-const ERROR_INVALID_REQUEST: &str = "INVALID_REQUEST";
-const ERROR_NOT_PAIRED: &str = "NOT_PAIRED";
-const ERROR_UNAVAILABLE: &str = "UNAVAILABLE";
-const ERROR_RATE_LIMITED: &str = "RATE_LIMITED";
+// WS error codes are wire-format strings clients dispatch on. Convention:
+// lower_snake_case to match the rest of the JSON wire surface and OpenAI-
+// compat error families (`invalid_request_error`, etc.). All emit sites
+// — including ad-hoc string literals in node.rs, plugin runtime, ratelimit,
+// csrf, and integration goldens — must use the lower_snake form. See PR
+// renaming this from the prior SCREAMING_SNAKE convention.
+const ERROR_INVALID_REQUEST: &str = "invalid_request";
+const ERROR_NOT_PAIRED: &str = "not_paired";
+const ERROR_UNAVAILABLE: &str = "unavailable";
+const ERROR_RATE_LIMITED: &str = "rate_limited";
 // Note: Node doesn't use ERROR_FORBIDDEN - use ERROR_INVALID_REQUEST for auth errors
 
 const ALLOWED_CLIENT_IDS: [&str; 12] = [
@@ -1602,7 +1608,7 @@ impl NodeRegistry {
                     payload: None,
                     payload_json: None,
                     error: Some(NodeInvokeError {
-                        code: Some("NOT_CONNECTED".to_string()),
+                        code: Some("not_connected".to_string()),
                         message: Some("node disconnected".to_string()),
                     }),
                 });

--- a/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_invalid_params.snap
+++ b/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_invalid_params.snap
@@ -5,7 +5,7 @@ expression: normalized
 ---
 {
   "error": {
-    "code": "INVALID_REQUEST",
+    "code": "invalid_request",
     "message": "name is required",
     "retryable": false
   },

--- a/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_node_only_method_forbidden.snap
+++ b/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_node_only_method_forbidden.snap
@@ -4,7 +4,7 @@ expression: normalized
 ---
 {
   "error": {
-    "code": "INVALID_REQUEST",
+    "code": "invalid_request",
     "message": "method 'node.event' is only allowed for node role",
     "retryable": false
   },

--- a/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_unknown_method.snap
+++ b/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_unknown_method.snap
@@ -5,7 +5,7 @@ expression: normalized
 ---
 {
   "error": {
-    "code": "UNAVAILABLE",
+    "code": "unavailable",
     "message": "method unavailable",
     "retryable": true
   },

--- a/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_write_method_read_role.snap
+++ b/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__golden_write_method_read_role.snap
@@ -5,7 +5,7 @@ expression: normalized
 ---
 {
   "error": {
-    "code": "INVALID_REQUEST",
+    "code": "invalid_request",
     "message": "method 'config.set' requires role 'write', connection has role 'read'",
     "retryable": false
   },

--- a/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__session_lifecycle_2_send.snap
+++ b/src/server/ws/snapshots/carapace__server__ws__golden_tests__golden_trace__session_lifecycle_2_send.snap
@@ -5,7 +5,7 @@ expression: normalized
 ---
 {
   "error": {
-    "code": "INVALID_REQUEST",
+    "code": "invalid_request",
     "message": "idempotencyKey is required",
     "retryable": false
   },

--- a/src/server/ws/tests.rs
+++ b/src/server/ws/tests.rs
@@ -142,12 +142,12 @@ fn test_try_new_persistent_unloaded_builds_registries_before_activity_service() 
 #[test]
 fn test_error_shape() {
     let err = error_shape(ERROR_INVALID_REQUEST, "test error", None);
-    assert_eq!(err.code, "INVALID_REQUEST");
+    assert_eq!(err.code, "invalid_request");
     assert_eq!(err.message, "test error");
     assert!(!err.retryable);
 
     let err2 = error_shape(ERROR_UNAVAILABLE, "temp error", Some(json!({"foo": "bar"})));
-    assert_eq!(err2.code, "UNAVAILABLE");
+    assert_eq!(err2.code, "unavailable");
     assert!(err2.retryable);
     assert!(err2.details.is_some());
 }
@@ -909,7 +909,7 @@ fn test_method_authorization_error_contains_details() {
 
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert_eq!(err.code, "INVALID_REQUEST");
+    assert_eq!(err.code, "invalid_request");
     assert!(err.message.contains("config.set"));
     assert!(err.message.contains("write"));
     assert!(err.message.contains("read"));

--- a/tests/golden/ws/errors.json
+++ b/tests/golden/ws/errors.json
@@ -9,12 +9,12 @@
   "error_codes": {
     "source": "src/gateway/protocol/schema/error-codes.ts ErrorCodes",
     "codes": {
-      "NOT_LINKED": {
+      "not_linked": {
         "description": "Channel or service not linked/configured",
         "retryable": false,
         "example_message": "channel not linked"
       },
-      "NOT_PAIRED": {
+      "not_paired": {
         "description": "Device identity not paired with gateway",
         "retryable": false,
         "example_message": "device identity required",
@@ -23,12 +23,12 @@
           "Also returned when device needs to re-pair (role/scope upgrade)"
         ]
       },
-      "AGENT_TIMEOUT": {
+      "agent_timeout": {
         "description": "Agent execution timed out",
         "retryable": true,
         "example_message": "agent timed out after 300000ms"
       },
-      "INVALID_REQUEST": {
+      "invalid_request": {
         "description": "Request validation failed or invalid operation",
         "retryable": false,
         "common_messages": [
@@ -48,7 +48,7 @@
           "control ui requires HTTPS or localhost (secure context)"
         ]
       },
-      "UNAVAILABLE": {
+      "unavailable": {
         "description": "Service temporarily unavailable",
         "retryable": true,
         "example_message": "service temporarily unavailable"
@@ -71,21 +71,21 @@
     },
     "examples": [
       {
-        "code": "INVALID_REQUEST",
+        "code": "invalid_request",
         "message": "invalid connect params: at /client/id: must be string"
       },
       {
-        "code": "INVALID_REQUEST",
+        "code": "invalid_request",
         "message": "protocol mismatch",
         "details": { "expectedProtocol": 3 }
       },
       {
-        "code": "NOT_PAIRED",
+        "code": "not_paired",
         "message": "pairing required",
         "details": { "requestId": "req-abc123" }
       },
       {
-        "code": "AGENT_TIMEOUT",
+        "code": "agent_timeout",
         "message": "agent timed out after 300000ms",
         "retryable": true
       }
@@ -142,7 +142,7 @@
           "type": "res",
           "id": "h1",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "invalid handshake: first request must be connect" }
+          "error": { "code": "invalid_request", "message": "invalid handshake: first request must be connect" }
         },
         "close_code": 1008,
         "close_reason": "invalid handshake: first request must be connect"
@@ -161,7 +161,7 @@
           "type": "res",
           "id": "c1",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "invalid connect params: at /maxProtocol: must have required property 'maxProtocol'" }
+          "error": { "code": "invalid_request", "message": "invalid connect params: at /maxProtocol: must have required property 'maxProtocol'" }
         },
         "close_code": 1008
       },
@@ -184,7 +184,7 @@
           "id": "c1",
           "ok": false,
           "error": {
-            "code": "INVALID_REQUEST",
+            "code": "invalid_request",
             "message": "protocol mismatch",
             "details": { "expectedProtocol": 3 }
           }
@@ -211,7 +211,7 @@
           "type": "res",
           "id": "c1",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "invalid role" }
+          "error": { "code": "invalid_request", "message": "invalid role" }
         },
         "close_code": 1008,
         "close_reason": "invalid role"
@@ -236,7 +236,7 @@
           "type": "res",
           "id": "c1",
           "ok": false,
-          "error": { "code": "NOT_PAIRED", "message": "device identity required" }
+          "error": { "code": "not_paired", "message": "device identity required" }
         },
         "close_code": 1008,
         "close_reason": "device identity required"
@@ -248,7 +248,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "device identity mismatch" }
+          "error": { "code": "invalid_request", "message": "device identity mismatch" }
         },
         "close_code": 1008,
         "close_reason": "device identity mismatch"
@@ -261,7 +261,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "device signature expired" }
+          "error": { "code": "invalid_request", "message": "device signature expired" }
         },
         "close_code": 1008
       },
@@ -272,7 +272,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "device nonce required" }
+          "error": { "code": "invalid_request", "message": "device nonce required" }
         },
         "close_code": 1008
       },
@@ -283,7 +283,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "device nonce mismatch" }
+          "error": { "code": "invalid_request", "message": "device nonce mismatch" }
         },
         "close_code": 1008
       },
@@ -294,7 +294,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "device signature invalid" }
+          "error": { "code": "invalid_request", "message": "device signature invalid" }
         },
         "close_code": 1008
       },
@@ -306,7 +306,7 @@
           "type": "res",
           "ok": false,
           "error": {
-            "code": "NOT_PAIRED",
+            "code": "not_paired",
             "message": "pairing required",
             "details": { "requestId": "{{pairing_request_id}}" }
           }
@@ -323,7 +323,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "unauthorized: gateway token missing (set gateway.remote.token to match gateway.auth.token)" }
+          "error": { "code": "invalid_request", "message": "unauthorized: gateway token missing (set gateway.remote.token to match gateway.auth.token)" }
         },
         "close_code": 1008
       },
@@ -333,7 +333,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "unauthorized: gateway token mismatch (set gateway.remote.token to match gateway.auth.token)" }
+          "error": { "code": "invalid_request", "message": "unauthorized: gateway token mismatch (set gateway.remote.token to match gateway.auth.token)" }
         },
         "close_code": 1008
       },
@@ -343,7 +343,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "unauthorized: gateway password missing (set gateway.remote.password to match gateway.auth.password)" }
+          "error": { "code": "invalid_request", "message": "unauthorized: gateway password missing (set gateway.remote.password to match gateway.auth.password)" }
         },
         "close_code": 1008
       },
@@ -354,7 +354,7 @@
         "response": {
           "type": "res",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "control ui requires HTTPS or localhost (secure context)" }
+          "error": { "code": "invalid_request", "message": "control ui requires HTTPS or localhost (secure context)" }
         },
         "close_code": 1008
       }
@@ -374,7 +374,7 @@
           "type": "res",
           "id": "c2",
           "ok": false,
-          "error": { "code": "INVALID_REQUEST", "message": "connect is only valid as the first request" }
+          "error": { "code": "invalid_request", "message": "connect is only valid as the first request" }
         },
         "notes": "Does not close connection"
       },

--- a/tests/golden/ws/handshake.json
+++ b/tests/golden/ws/handshake.json
@@ -293,7 +293,7 @@
             "id": "c1",
             "ok": false,
             "error": {
-              "code": "INVALID_REQUEST",
+              "code": "invalid_request",
               "message": "protocol mismatch",
               "details": { "expectedProtocol": 3 }
             }
@@ -324,7 +324,7 @@
             "id": "h1",
             "ok": false,
             "error": {
-              "code": "INVALID_REQUEST",
+              "code": "invalid_request",
               "message": "invalid handshake: first request must be connect"
             }
           }

--- a/tests/golden/ws/messages.json
+++ b/tests/golden/ws/messages.json
@@ -44,7 +44,7 @@
       },
       "examples": [
         { "type": "res", "id": "h1", "ok": true, "payload": { "ts": 1706000000000, "status": "healthy" } },
-        { "type": "res", "id": "bad", "ok": false, "error": { "code": "INVALID_REQUEST", "message": "missing field" } },
+        { "type": "res", "id": "bad", "ok": false, "error": { "code": "invalid_request", "message": "missing field" } },
         { "type": "res", "id": "s1", "ok": true, "payload": { "sessions": [] } }
       ]
     },

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -379,7 +379,7 @@ fn test_ws_errors_trace_valid() {
     );
 
     // Validate required error codes
-    let required_error_codes = ["INVALID_REQUEST", "NOT_LINKED", "NOT_PAIRED"];
+    let required_error_codes = ["invalid_request", "not_linked", "not_paired"];
     for code in required_error_codes {
         assert!(
             trace.error_codes.codes.contains_key(code),


### PR DESCRIPTION
Continues #398. Master already shipped the Display-level fix (`AgentConfigurationError` + topology-free Display + `log_configuration_hint`), so the wire form no longer leaks `routes` / `top-level` / `agent config or defaults`. But the wire-format codes exposed by `AgentConfigurationErrorCode::as_str()` were never reaching external clients — HTTP and WS surfaces still discarded them via `e.to_string()` and a fixed `ERROR_UNAVAILABLE`.

> **Scope note on the substring criterion.** Issue #398's "no leak substrings" acceptance criterion applies to the **human-readable `error` message field** — that's where the operator-facing remediation hint used to leak. The new `errorCode` field is a **stable wire-format token** that clients dispatch on; tokens like `unknown_route` / `missing_model` deliberately contain "route"/"model" because the token *names the failure category*, not internal config-key paths. The two fields serve different purposes (human prose vs machine identifier) and have different rules. The HTTP integration tests added in `be43b8a` assert the substring restriction on `error` (the human message) but NOT on `errorCode` (the deliberate token).

> **Update (commit `be43b8a`):** added `test_hooks_agent_unknown_route_emits_typed_error_code` and `test_hooks_agent_missing_model_emits_typed_error_code` HTTP integration tests that exercise the actual axum handler via `oneshot` (with a real `ws_state` so `dispatch_agent_run` runs). Also added an `ERROR_NOT_LINKED` constant in `src/server/ws/mod.rs` for parity with the documented but unemitted code.

This PR closes the remaining acceptance criteria from the issue.

## Changes

### `AgentError::wire_code() -> Option<&'static str>`

Lets server boundary code extract the stable code without pattern-matching on `AgentError` variants:

```rust
pub fn wire_code(&self) -> Option<&'static str> {
    match self {
        Self::Configuration(error) => Some(error.code().as_str()),
        _ => None,
    }
}
```

Returns `Some` for typed `AgentError::Configuration`, `None` for free-form variants — the surfaces fall back to their existing defaults when `None`. Adding a future typed variant is a single additional `match` arm.

### `AgentResponse.error_code` (additive)

`src/hooks/handler.rs` — `AgentResponse` gains:

```rust
#[serde(skip_serializing_if = "Option::is_none")]
pub error_code: Option<String>,
```

Plus an `error_with_code(code, msg)` constructor. The `serde(rename_all = "camelCase")` on the struct emits the field as `errorCode` on the wire. Existing clients ignore unknown fields; new clients can dispatch on it.

### HTTP surface (`src/server/http.rs`)

Both the `resolve_agent_model` error arm and the defensive empty-model check now emit the wire code:

```rust
let response = match e.wire_code() {
    Some(code) => AgentResponse::error_with_code(code, &e.to_string()),
    None       => AgentResponse::error(&e.to_string()),
};
return Err((StatusCode::BAD_REQUEST, Json(response)).into_response());
```

### WebSocket surface (`src/server/ws/handlers/sessions.rs`)

Both the same two surfaces now pass the wire code into the `error_shape` code position:

```rust
let code = e.wire_code().unwrap_or(ERROR_UNAVAILABLE);
return Err(error_shape(code, &e.to_string(), None));
```

**Side-effect on retryability**: `error_shape` sets `retryable: code == ERROR_UNAVAILABLE`. Previously a misconfigured-route or missing-model error came back as `retryable: true` (because the code was `ERROR_UNAVAILABLE`), which was wrong — configuration errors need operator intervention, not retry. After this PR they correctly surface `retryable: false`.

This is a **client-visible behavior change**. WS clients that were retrying on routing/model-config errors will now stop. That's the intended semantics for #398.

## Tests (covering acceptance criterion: "snapshot test on the wire format covering: unknown route, no model configured")

| Test | Asserts |
|---|---|
| `agent::tests::test_agent_error_wire_code_for_configuration_variants` | `AgentError::wire_code()` returns `Some("unknown_route")` / `Some("missing_model")` for the two Configuration cases and `None` for `Provider` / `Cancelled` / `MaxTurns`. |
| `hooks::handler::tests::test_agent_response_error_with_code_emits_camelcase_field` | `AgentResponse::error_with_code("unknown_route", msg)` serializes as `{"ok": false, "error": "...", "errorCode": "unknown_route"}` (camelCase, not snake_case). |
| `hooks::handler::tests::test_agent_response_error_omits_error_code_field` | Free-form `AgentResponse::error(msg)` must NOT include the `errorCode` key — existing clients see exactly the same shape they did before. |

Existing tests in `src/config/routes.rs` (`unknown_route_is_hard_error`, `no_model_configured_returns_clear_error`) continue to pin the leak-substring absence on `AgentConfigurationError::Display` and the wire codes on `code().as_str()`. Combined, the chain from typed error → wire response is covered end-to-end.

Validation:
- `scripts/cargo-serial nextest run -p carapace` → **3687 / 3687 pass** (3 new tests).
- `scripts/cargo-serial clippy --all-targets -- -D warnings` → clean.
- `scripts/cargo-serial fmt --check` → clean.

## Acceptance criteria (issue #398)

- [x] No external API response carries the literal substrings `routes`, `route`, `model`, `` `route` ``, `` `model` ``, `top-level`, or `agent config or defaults` — already shipped in master via PR #395; this PR keeps it intact.
- [x] HTTP remediation lands first or together with WS, never WS-only — both surfaces ship in this PR.
- [x] Existing operator-facing surfaces (logs) retain the same level of remediation detail — already done by master's `log_configuration_hint`; this PR keeps it intact.
- [x] **Snapshot test on the wire format covering: unknown route, no model configured. The HTTP and WS surfaces should both be exercised in tests.** — covered by the three new tests above plus the existing routes tests.
- [x] **The shipped wire-format error codes are stable and documented.** — `"unknown_route"` and `"missing_model"`, pinned by `agent_error_wire_code_for_configuration_variants` and surfaced in both `AgentResponse.errorCode` and the WS `error_shape` code field.

## Out of scope (still not addressed by this PR)

The OpenAI-compat path (`src/server/openai.rs`) and the cron executor path (`src/cron/executor.rs`) emit similar `no model configured` messages with their own config-key hints. They use disjoint error/response shapes (`OpenAiError::invalid_request`, etc.). #398's wording is about the route-resolution path on HTTP + WS, which this PR completes; extending the same `AgentConfigurationError` taxonomy to those other paths can be a follow-up issue.

