### PR TITLE
fix: typed retryable codes + WS handle_agent integration tests (#405, #406)

### DIFF
--- a/docs/protocol/websocket.md
+++ b/docs/protocol/websocket.md
@@ -371,28 +371,21 @@ Events are broadcast to connected clients. See `src/server/ws/mod.rs` for implem
 ## Error Codes
 
 Wire codes are stable, lower_snake_case strings. Clients dispatch on the
-`error.code` field of the error response. The `Retryable` column reflects
-what `error_shape` actually emits on the wire today (currently
-hard-coded: `retryable: true` only when `code == "unavailable"`). Codes
-not emitted via `error_shape` are noted explicitly.
+`error.code` field of the error response. The `Retryable` column matches
+what `error_shape` emits on the wire — derived from the `RETRYABLE_CODES`
+set in `src/server/ws/mod.rs`. Adding a new retryable code requires
+extending that set.
 
 ### Top-level `error.code` values (emitted via `error_shape`)
 
-| Code | Description | Retryable on wire |
-|------|-------------|-------------------|
+| Code | Description | Retryable |
+|------|-------------|-----------|
 | `invalid_request` | Validation / protocol error | No |
 | `not_paired` | Device not paired | No |
 | `unavailable` | Service temporarily unavailable | Yes |
-| `rate_limited` | Per-resource rate limit exceeded | No (see note) |
+| `rate_limited` | Per-resource rate limit exceeded | Yes |
 | `unknown_route` | Request referenced a route not in the `routes` map | No |
 | `missing_model` | Resolution found no `route` or `model` for the request | No |
-
-*Note on `rate_limited`*: semantically the operation is retryable (with
-backoff / `Retry-After`), but `error_shape`'s current hard-coded
-retryable check produces `retryable: false`. Clients should treat
-`rate_limited` as retryable regardless of the field; a future fix
-will align the wire field with intent
-(tracked at [#405](https://github.com/puremachinery/carapace/issues/405)).
 
 ### Reserved codes (documented but not yet emitted)
 

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -3168,6 +3168,48 @@ mod tests {
         }
     }
 
+    /// Integration test for issue #406: when the WS `handle_agent` path
+    /// hits a route-resolution error, the resulting `ErrorShape` must
+    /// carry the typed wire code (`unknown_route`) and `retryable: false`.
+    /// Exercises the full handler, not just the `wire_code()` helper, so a
+    /// regression that reverted the dispatch from
+    /// `e.wire_code().unwrap_or(ERROR_UNAVAILABLE)` back to a fixed
+    /// `ERROR_UNAVAILABLE` would fail this assertion.
+    #[test]
+    fn test_handle_agent_unknown_route_returns_typed_code() {
+        // Empty config — no routes, no defaults.
+        let _fixture = crate::test_support::config::StableConfigFixture::new(serde_json::json!({}));
+        let (state, _tmp) = make_state_with_temp_sessions();
+        let conn = make_conn("conn-route-test");
+        let params = json!({
+            "message": "hello",
+            "idempotencyKey": "ws-route-test-1",
+            "route": "nonexistent-route-name"
+        });
+
+        let err = handle_agent(Some(&params), Arc::new(state), &conn).unwrap_err();
+        assert_eq!(err.code, "unknown_route");
+        assert!(!err.retryable);
+    }
+
+    /// Companion to the unknown-route test for issue #406. With no route
+    /// or model anywhere, `resolve_execution_target` returns `MissingModel`
+    /// which surfaces as `error.code: "missing_model"` on the WS wire.
+    #[test]
+    fn test_handle_agent_missing_model_returns_typed_code() {
+        let _fixture = crate::test_support::config::StableConfigFixture::new(serde_json::json!({}));
+        let (state, _tmp) = make_state_with_temp_sessions();
+        let conn = make_conn("conn-model-test");
+        let params = json!({
+            "message": "hello",
+            "idempotencyKey": "ws-model-test-1"
+        });
+
+        let err = handle_agent(Some(&params), Arc::new(state), &conn).unwrap_err();
+        assert_eq!(err.code, "missing_model");
+        assert!(!err.retryable);
+    }
+
     #[test]
     fn test_handle_sessions_create_with_key() {
         let (state, _tmp) = make_state_with_temp_sessions();

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -2100,10 +2100,6 @@ pub(super) fn handle_agent(
         },
     ) {
         e.log_configuration_hint();
-        // `error_shape` derives `retryable` from `code == ERROR_UNAVAILABLE`,
-        // so emitting a typed wire code (e.g. "unknown_route") correctly
-        // surfaces `retryable: false` — config errors need operator
-        // intervention, not retry.
         let code = e.wire_code().unwrap_or(ERROR_UNAVAILABLE);
         return Err(error_shape(code, &e.to_string(), None));
     }
@@ -3168,13 +3164,9 @@ mod tests {
         }
     }
 
-    /// Integration test for issue #406: when the WS `handle_agent` path
-    /// hits a route-resolution error, the resulting `ErrorShape` must
-    /// carry the typed wire code (`unknown_route`) and `retryable: false`.
-    /// Exercises the full handler, not just the `wire_code()` helper, so a
-    /// regression that reverted the dispatch from
-    /// `e.wire_code().unwrap_or(ERROR_UNAVAILABLE)` back to a fixed
-    /// `ERROR_UNAVAILABLE` would fail this assertion.
+    /// `handle_agent` surfaces `unknown_route` with `retryable: false`
+    /// end-to-end when the request references a route name not in the
+    /// routes config.
     #[test]
     fn test_handle_agent_unknown_route_returns_typed_code() {
         // Empty config — no routes, no defaults.
@@ -3192,9 +3184,8 @@ mod tests {
         assert!(!err.retryable);
     }
 
-    /// Companion to the unknown-route test for issue #406. With no route
-    /// or model anywhere, `resolve_execution_target` returns `MissingModel`
-    /// which surfaces as `error.code: "missing_model"` on the WS wire.
+    /// `handle_agent` surfaces `missing_model` with `retryable: false`
+    /// end-to-end when no route or model resolves anywhere.
     #[test]
     fn test_handle_agent_missing_model_returns_typed_code() {
         let _fixture = crate::test_support::config::StableConfigFixture::new(serde_json::json!({}));

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -89,16 +89,19 @@ const ERROR_NOT_LINKED: &str = "not_linked";
 
 /// Wire codes whose `retryable` field is `true` in the error response.
 ///
-/// Adding a new retryable code requires extending this list — codes not
-/// listed here surface as `retryable: false` regardless of intent. Keeping
-/// the classification explicit prevents silent doc-vs-wire drift (issue
-/// #405): a previous version derived `retryable` from `code == ERROR_UNAVAILABLE`
-/// alone, which silently produced `retryable: false` for `rate_limited`
-/// despite the protocol doc claiming the opposite.
+/// Adding a new retryable code requires extending this list — unlisted
+/// codes surface as `retryable: false`. The slice is the single source
+/// of truth for retryable classification; `error_shape` consults it via
+/// `wire_code_is_retryable`. Domain-level codes from
+/// `AgentConfigurationError` (e.g. `unknown_route`, `missing_model`)
+/// are intentionally absent — config errors require operator
+/// intervention, not retry.
 ///
-/// Domain-level codes from `AgentConfigurationError` (e.g. `unknown_route`,
-/// `missing_model`) are intentionally NOT retryable — they require operator
-/// intervention.
+/// A typed-enum alternative (variants carrying retryability as a method)
+/// would compile-time-enforce the classification but require migrating
+/// every `error_shape` call site away from `&'static str`. The slice is
+/// the smaller, grep-able shape that fits the existing `const ERROR_*`
+/// convention.
 const RETRYABLE_CODES: &[&str] = &[ERROR_UNAVAILABLE, ERROR_RATE_LIMITED];
 
 /// Returns `true` if a wire code should surface `retryable: true` to clients.

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -87,6 +87,25 @@ const ERROR_RATE_LIMITED: &str = "rate_limited";
 const ERROR_NOT_LINKED: &str = "not_linked";
 // Note: Node doesn't use ERROR_FORBIDDEN - use ERROR_INVALID_REQUEST for auth errors
 
+/// Wire codes whose `retryable` field is `true` in the error response.
+///
+/// Adding a new retryable code requires extending this list — codes not
+/// listed here surface as `retryable: false` regardless of intent. Keeping
+/// the classification explicit prevents silent doc-vs-wire drift (issue
+/// #405): a previous version derived `retryable` from `code == ERROR_UNAVAILABLE`
+/// alone, which silently produced `retryable: false` for `rate_limited`
+/// despite the protocol doc claiming the opposite.
+///
+/// Domain-level codes from `AgentConfigurationError` (e.g. `unknown_route`,
+/// `missing_model`) are intentionally NOT retryable — they require operator
+/// intervention.
+const RETRYABLE_CODES: &[&str] = &[ERROR_UNAVAILABLE, ERROR_RATE_LIMITED];
+
+/// Returns `true` if a wire code should surface `retryable: true` to clients.
+fn wire_code_is_retryable(code: &str) -> bool {
+    RETRYABLE_CODES.contains(&code)
+}
+
 const ALLOWED_CLIENT_IDS: [&str; 12] = [
     "webchat-ui",
     "carapace-control-ui",
@@ -3220,7 +3239,7 @@ fn error_shape(code: &'static str, message: &str, details: Option<Value>) -> Err
     ErrorShape {
         code,
         message: message.to_string(),
-        retryable: code == ERROR_UNAVAILABLE,
+        retryable: wire_code_is_retryable(code),
         details,
     }
 }

--- a/src/server/ws/tests.rs
+++ b/src/server/ws/tests.rs
@@ -152,11 +152,7 @@ fn test_error_shape() {
     assert!(err2.details.is_some());
 }
 
-/// Regression for issue #405: `rate_limited` must surface
-/// `retryable: true` on the wire. Previously `error_shape` derived
-/// retryability from `code == ERROR_UNAVAILABLE` only, so `rate_limited`
-/// silently produced `retryable: false` despite the protocol doc
-/// claiming the opposite. The `RETRYABLE_CODES` set fixes this.
+/// `rate_limited` must surface `retryable: true` on the wire.
 #[test]
 fn test_error_shape_rate_limited_is_retryable() {
     let err = error_shape(ERROR_RATE_LIMITED, "rate limit exceeded", None);
@@ -167,10 +163,9 @@ fn test_error_shape_rate_limited_is_retryable() {
     );
 }
 
-/// Configuration-error codes (`unknown_route`, `missing_model`) are
-/// intentionally NOT retryable — they require operator intervention.
-/// Asserting both rules out a future change to `RETRYABLE_CODES` that
-/// would silently mis-classify domain codes as retryable.
+/// Configuration-error codes (`unknown_route`, `missing_model`) must
+/// surface `retryable: false`. Pinning both rules out a future change
+/// to `RETRYABLE_CODES` that mis-classifies domain codes as retryable.
 #[test]
 fn test_error_shape_config_errors_are_not_retryable() {
     let err = error_shape("unknown_route", "requested route is not configured", None);

--- a/src/server/ws/tests.rs
+++ b/src/server/ws/tests.rs
@@ -152,6 +152,36 @@ fn test_error_shape() {
     assert!(err2.details.is_some());
 }
 
+/// Regression for issue #405: `rate_limited` must surface
+/// `retryable: true` on the wire. Previously `error_shape` derived
+/// retryability from `code == ERROR_UNAVAILABLE` only, so `rate_limited`
+/// silently produced `retryable: false` despite the protocol doc
+/// claiming the opposite. The `RETRYABLE_CODES` set fixes this.
+#[test]
+fn test_error_shape_rate_limited_is_retryable() {
+    let err = error_shape(ERROR_RATE_LIMITED, "rate limit exceeded", None);
+    assert_eq!(err.code, "rate_limited");
+    assert!(
+        err.retryable,
+        "rate_limited must be retryable per RETRYABLE_CODES + #405"
+    );
+}
+
+/// Configuration-error codes (`unknown_route`, `missing_model`) are
+/// intentionally NOT retryable — they require operator intervention.
+/// Asserting both rules out a future change to `RETRYABLE_CODES` that
+/// would silently mis-classify domain codes as retryable.
+#[test]
+fn test_error_shape_config_errors_are_not_retryable() {
+    let err = error_shape("unknown_route", "requested route is not configured", None);
+    assert_eq!(err.code, "unknown_route");
+    assert!(!err.retryable);
+
+    let err2 = error_shape("missing_model", "agent model is not configured", None);
+    assert_eq!(err2.code, "missing_model");
+    assert!(!err2.retryable);
+}
+
 #[test]
 fn test_canonicalize_ws_method_name_aliases() {
     assert_eq!(canonicalize_ws_method_name("agent.run"), "agent");


### PR DESCRIPTION
Closes #405 and #406.

## Stacking note

Branched off PR #400 (`feat/config-error-wire-codes`) because #406's tests use `AgentError::wire_code()` introduced there. Once #400 merges, this PR's base will resolve to master automatically. Diff against master will show this PR's 4 files; diff against `feat/config-error-wire-codes` shows just the new work.

---

## #405: Typed retryable wire codes

`error_shape` previously derived the `retryable` field from `code == ERROR_UNAVAILABLE` alone, which silently produced `retryable: false` for `rate_limited` despite the protocol doc claiming the opposite. Same pattern would mis-classify any future retryable code added without remembering to extend the comparison.

Replaced the comparison with an explicit set in `src/server/ws/mod.rs`:

```rust
const RETRYABLE_CODES: &[&str] = &[ERROR_UNAVAILABLE, ERROR_RATE_LIMITED];

fn wire_code_is_retryable(code: &str) -> bool {
    RETRYABLE_CODES.contains(&code)
}

fn error_shape(code: &'static str, message: &str, details: Option<Value>) -> ErrorShape {
    ErrorShape {
        code,
        message: message.to_string(),
        retryable: wire_code_is_retryable(code),
        details,
    }
}
```

Adding a new retryable code now requires extending the slice — review-time enforcement, with a doc comment that names the contract and points at the issue history. This is "Option B" from #405's proposed shapes; the typed-enum "Option A" would be more invasive (touches every emit site to migrate from `&'static str`) for marginal additional safety.

**Wire-visible behavior change**: `rate_limited` now correctly carries `retryable: true`. The protocol-doc footnote calling out the prior discrepancy is removed.

## #406: WS `handle_agent` integration tests

Added two tests in `src/server/ws/handlers/sessions.rs`:

- `test_handle_agent_unknown_route_returns_typed_code` — submits an unknown route through the full `handle_agent` handler, asserts `err.code == "unknown_route"` and `!err.retryable`.
- `test_handle_agent_missing_model_returns_typed_code` — submits a request with no route/model and an empty config, asserts `err.code == "missing_model"` and `!err.retryable`.

These exercise the full WS dispatch (parse → session creation → resolve → error_shape), not just the `wire_code()` helper. A regression that reverted the WS dispatch from `e.wire_code().unwrap_or(ERROR_UNAVAILABLE)` back to a fixed `ERROR_UNAVAILABLE` would fail at least one of these tests.

## Unit-level coverage for #405's contract

Added two regression tests in `src/server/ws/tests.rs`:

- `test_error_shape_rate_limited_is_retryable` — pins that `rate_limited` surfaces `retryable: true`.
- `test_error_shape_config_errors_are_not_retryable` — pins that `unknown_route` / `missing_model` stay non-retryable, ruling out a future change to `RETRYABLE_CODES` that would silently mis-classify domain codes as retryable.

## Validation

- `scripts/cargo-serial nextest run -p carapace` → **3693 / 3693 pass** (4 new tests).
- `scripts/cargo-serial clippy --all-targets -- -D warnings` → clean.
- `scripts/cargo-serial fmt --check` → clean.

## Acceptance criteria

**#405**:
- [x] Adding a new wire error code requires explicitly classifying its retryability — extending `RETRYABLE_CODES` is the single edit point, with a doc comment that names the contract.
- [x] `rate_limited` wire response carries `retryable: true`.
- [x] No existing retryable behavior regresses — `unavailable` stays retryable; non-retryable codes stay non-retryable.
- [x] Snapshot/regression tests pinning `retryable` for at least one retryable and one non-retryable code on the wire.

**#406**:
- [x] WS `handle_agent` integration test asserts `error.code == "unknown_route"` and `error.retryable == false`.
- [x] WS `handle_agent` integration test asserts `error.code == "missing_model"` and `error.retryable == false`.
- [x] A regression that reverted the WS dispatch to a fixed `ERROR_UNAVAILABLE` would fail at least one of the new tests.
