### PR TITLE
ci: require PR base to be master

### DIFF
--- a/.github/workflows/pr-base-branch-check.yml
+++ b/.github/workflows/pr-base-branch-check.yml
@@ -1,0 +1,31 @@
+name: PR Base Branch Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check-base-branch:
+    name: Verify base is master
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-master base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ "$BASE_REF" != "master" ]]; then
+            echo "::error title=PR base must be master::This PR targets '$BASE_REF', not 'master'."
+            echo ""
+            echo "If this is a stacked PR whose dependency has merged, retarget to master:"
+            echo "  gh pr edit $PR_NUMBER --base master"
+            echo ""
+            echo "Stacked PRs that merge into a stale base produce orphaned merge commits"
+            echo "that GitHub reports as MERGED but never reach master. See the post-mortem"
+            echo "on PR #407 for context."
+            exit 1
+          fi
+          echo "Base is master — ok."


### PR DESCRIPTION
## Summary

Adds a `pr-base-branch-check` workflow that fails any PR whose `base` branch is not `master`. Single 31-line YAML; the check should be marked **required** in branch protection after merge so it can actually gate merges.

## Why

PR #407 was reported as MERGED by GitHub but its commits never reached master. The mechanism:

1. PR #400 (`base: master`, head: `feat/config-error-wire-codes`) merged to master with a merge commit (`83f4929`).
2. PR #407 (`base: feat/config-error-wire-codes`, head: `feat/retryable-codes-and-ws-tests`) had been opened as a stacked PR before #400 merged. GitHub did **not** auto-retarget #407's base after #400 landed.
3. PR #407 was then merged into the now-superseded `feat/config-error-wire-codes` branch, producing merge commit `5717df7` reachable only from the orphaned branch. GitHub reported `state: MERGED`.
4. The "Auto-delete head branches" repo setting deleted `feat/retryable-codes-and-ws-tests` after merge, hiding the orphaned state.
5. Issues #405 and #406 were closed under the (incorrect) assumption that #407's content was on master. Both have been reopened.

This workflow makes step 3 impossible: a PR with `base != master` fails CI and cannot merge.

## Behavior

- Triggers on `pull_request` (`opened`, `edited`, `reopened`, `synchronize`) — covers retargeting via `gh pr edit --base ...`.
- Reads `github.base_ref` and `github.event.pull_request.number` via `env:` (workflow-injection-safe).
- Emits a GitHub `::error::` annotation with the retarget command if the base is anything other than `master`.

## Follow-up

After merge, branch-protection rules need updating to make `Verify base is master` a required status check on master. That requires admin and is left to repo admin.

## Test plan

- [ ] Workflow syntax validates (parses on push).
- [ ] CI run on this PR shows "Verify base is master" passing (this PR's base is master).
- [ ] After merge, repo admin marks the check as required in branch-protection settings.