### PR TITLE
fix: serialize config env reads (#415)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,11 @@ for docs/website/meta-only and non-shell script-only pushes.
 - Represent all timestamps as milliseconds since the Unix epoch.
 - Config fields use camelCase in JSON/JSON5 and snake_case in Rust structs
   (use serde `rename` or `rename_all` as needed).
+- Runtime reads of values that may be supplied through `config.env` must use
+  `crate::config::read_config_env` or `read_config_env_os`, so reads share the
+  same lock as config reload writes. Raw OS/process values that must not be
+  shadowed by `config.env` must use `read_process_env` or `read_process_env_os`;
+  direct `std::env::var(_os)` calls are rejected by clippy.
 - Place unit tests in inline `#[cfg(test)] mod tests { }` blocks at the bottom
   of each source file.
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+disallowed-methods = [
+  { path = "std::env::var", reason = "use crate::config::read_config_env for config.env-injectable values, or crate::config::read_process_env for process-only values" },
+  { path = "std::env::var_os", reason = "use crate::config::read_config_env_os for config.env-injectable values, or crate::config::read_process_env_os for process-only values" },
+  { path = "std::env::set_var", reason = "use crate::config's locked config-env write path, or crate::test_support::env::ScopedEnv in tests" },
+  { path = "std::env::remove_var", reason = "use crate::config's locked config-env write path, or crate::test_support::env::ScopedEnv in tests" },
+]

--- a/src/agent/builtin_tools.rs
+++ b/src/agent/builtin_tools.rs
@@ -5,13 +5,13 @@
 //! standard tool dispatch path.
 
 use std::collections::HashMap;
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde_json::{json, Value};
 
+use crate::config::read_config_env;
 use crate::plugins::tools::{BuiltinTool, ToolInvokeResult};
 use crate::runtime_bridge::run_sync_blocking_send;
 
@@ -334,8 +334,7 @@ fn handle_media_analyze(args: Value) -> ToolInvokeResult {
 }
 
 fn resolve_openai_media_key(cfg: &Value) -> Option<String> {
-    env::var("OPENAI_API_KEY")
-        .ok()
+    read_config_env("OPENAI_API_KEY")
         .filter(|k| !k.is_empty())
         .or_else(|| {
             cfg.get("models")
@@ -356,8 +355,7 @@ fn resolve_openai_media_key(cfg: &Value) -> Option<String> {
 }
 
 fn resolve_openai_base_url(cfg: &Value) -> Option<String> {
-    env::var("OPENAI_BASE_URL")
-        .ok()
+    read_config_env("OPENAI_BASE_URL")
         .filter(|v| !v.is_empty())
         .or_else(|| {
             cfg.get("openai")
@@ -369,8 +367,7 @@ fn resolve_openai_base_url(cfg: &Value) -> Option<String> {
 }
 
 fn resolve_anthropic_media_key(cfg: &Value) -> Result<Option<String>, String> {
-    if let Some(api_key) = env::var("ANTHROPIC_API_KEY")
-        .ok()
+    if let Some(api_key) = read_config_env("ANTHROPIC_API_KEY")
         .map(|k| k.trim().to_string())
         .filter(|k| !k.is_empty())
         .or_else(|| {
@@ -399,8 +396,7 @@ fn resolve_anthropic_media_key(cfg: &Value) -> Result<Option<String>, String> {
 }
 
 fn resolve_anthropic_base_url(cfg: &Value) -> Option<String> {
-    env::var("ANTHROPIC_BASE_URL")
-        .ok()
+    read_config_env("ANTHROPIC_BASE_URL")
         .filter(|v| !v.is_empty())
         .or_else(|| {
             cfg.get("anthropic")
@@ -1157,7 +1153,7 @@ fn parse_primary(tokens: &[Token], pos: &mut usize) -> Result<f64, String> {
 
 /// Resolve the sessions base path, matching the server's convention.
 fn resolve_sessions_path() -> PathBuf {
-    if let Ok(state_dir) = std::env::var("CARAPACE_STATE_DIR") {
+    if let Some(state_dir) = crate::config::read_process_env("CARAPACE_STATE_DIR") {
         return PathBuf::from(state_dir).join("sessions");
     }
     dirs::config_dir()

--- a/src/agent/claude_cli.rs
+++ b/src/agent/claude_cli.rs
@@ -98,8 +98,7 @@ pub fn is_enabled(cfg: &serde_json::Value) -> bool {
     cfg.pointer("/claudeCli/enabled")
         .and_then(|v| v.as_bool())
         .unwrap_or(false)
-        || std::env::var("CLAUDE_CLI_ENABLED")
-            .ok()
+        || crate::config::read_config_env("CLAUDE_CLI_ENABLED")
             .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 

--- a/src/agent/factory.rs
+++ b/src/agent/factory.rs
@@ -16,6 +16,7 @@ use crate::auth::profiles::{
     profile_store_encryption_enabled_from_env, resolve_anthropic_profile_token,
     AuthProfileCredentialKind, OAuthProvider, ProfileStore,
 };
+use crate::config::read_config_env;
 
 /// Open and load the profile store, logging a warning on failure.
 ///
@@ -61,8 +62,7 @@ fn resolve_anthropic_auth_profile_id(cfg: &Value) -> Option<String> {
 }
 
 fn resolve_anthropic_api_key(cfg: &Value) -> Option<String> {
-    std::env::var("ANTHROPIC_API_KEY")
-        .ok()
+    read_config_env("ANTHROPIC_API_KEY")
         .or_else(|| {
             cfg.get("anthropic")
                 .and_then(|v| v.get("apiKey"))
@@ -396,19 +396,19 @@ struct VertexConfig {
 
 fn get_vertex_config(cfg: &Value) -> VertexConfig {
     let vertex_cfg = cfg.get("vertex");
-    let project_id = std::env::var("VERTEX_PROJECT_ID").ok().or_else(|| {
+    let project_id = read_config_env("VERTEX_PROJECT_ID").or_else(|| {
         vertex_cfg
             .and_then(|v| v.get("projectId"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
     });
-    let location = std::env::var("VERTEX_LOCATION").ok().or_else(|| {
+    let location = read_config_env("VERTEX_LOCATION").or_else(|| {
         vertex_cfg
             .and_then(|v| v.get("location"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
     });
-    let model = std::env::var("VERTEX_MODEL").ok().or_else(|| {
+    let model = read_config_env("VERTEX_MODEL").or_else(|| {
         vertex_cfg
             .and_then(|v| v.get("model"))
             .and_then(|v| v.as_str())
@@ -444,7 +444,7 @@ fn get_openai_config(cfg: &Value) -> OpenAiConfig {
     let get_optional_string = |env_keys: &[&str], cfg_key: &str| {
         env_keys
             .iter()
-            .find_map(|key| std::env::var(key).ok())
+            .find_map(|key| read_config_env(key))
             .or_else(|| {
                 openai_cfg
                     .and_then(|v| v.get(cfg_key))
@@ -477,7 +477,7 @@ fn try_build_ollama_provider(
     cfg: &Value,
 ) -> Result<Option<Arc<dyn agent::LlmProvider>>, Box<dyn std::error::Error>> {
     let ollama_providers_cfg = cfg.get("providers").and_then(|v| v.get("ollama"));
-    let ollama_base_url = std::env::var("OLLAMA_BASE_URL").ok().or_else(|| {
+    let ollama_base_url = read_config_env("OLLAMA_BASE_URL").or_else(|| {
         ollama_providers_cfg
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
@@ -548,7 +548,7 @@ pub fn build_providers(cfg: &Value) -> Result<Option<MultiProvider>, Box<dyn std
     // Anthropic
     let anthropic_api_key = resolve_anthropic_api_key(cfg);
     let anthropic_auth_profile = resolve_anthropic_auth_profile_id(cfg);
-    let anthropic_base_url = std::env::var("ANTHROPIC_BASE_URL").ok().or_else(|| {
+    let anthropic_base_url = read_config_env("ANTHROPIC_BASE_URL").or_else(|| {
         cfg.get("anthropic")
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
@@ -599,8 +599,7 @@ pub fn build_providers(cfg: &Value) -> Result<Option<MultiProvider>, Box<dyn std
     let ollama_provider = try_build_ollama_provider(cfg)?;
 
     // Gemini
-    let google_api_key = std::env::var("GOOGLE_API_KEY")
-        .ok()
+    let google_api_key = read_config_env("GOOGLE_API_KEY")
         .or_else(|| {
             cfg.get("google")
                 .and_then(|v| v.get("apiKey"))
@@ -610,7 +609,7 @@ pub fn build_providers(cfg: &Value) -> Result<Option<MultiProvider>, Box<dyn std
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
     let google_auth_profile = resolve_google_auth_profile_id(cfg);
-    let google_base_url = std::env::var("GOOGLE_API_BASE_URL").ok().or_else(|| {
+    let google_base_url = read_config_env("GOOGLE_API_BASE_URL").or_else(|| {
         cfg.get("google")
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
@@ -620,13 +619,13 @@ pub fn build_providers(cfg: &Value) -> Result<Option<MultiProvider>, Box<dyn std
         build_gemini_provider(cfg, google_api_key, google_auth_profile, google_base_url)?;
 
     // Venice
-    let venice_api_key = std::env::var("VENICE_API_KEY").ok().or_else(|| {
+    let venice_api_key = read_config_env("VENICE_API_KEY").or_else(|| {
         cfg.get("venice")
             .and_then(|v| v.get("apiKey"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
     });
-    let venice_base_url = std::env::var("VENICE_BASE_URL").ok().or_else(|| {
+    let venice_base_url = read_config_env("VENICE_BASE_URL").or_else(|| {
         cfg.get("venice")
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
@@ -648,9 +647,8 @@ pub fn build_providers(cfg: &Value) -> Result<Option<MultiProvider>, Box<dyn std
             .and_then(|v| v.as_bool())
             != Some(false)
         {
-            let region = std::env::var("AWS_REGION")
-                .ok()
-                .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+            let region = read_config_env("AWS_REGION")
+                .or_else(|| read_config_env("AWS_DEFAULT_REGION"))
                 .or_else(|| {
                     bedrock_cfg
                         .and_then(|b| b.get("region"))
@@ -658,21 +656,21 @@ pub fn build_providers(cfg: &Value) -> Result<Option<MultiProvider>, Box<dyn std
                         .map(String::from)
                 });
 
-            let access_key = std::env::var("AWS_ACCESS_KEY_ID").ok().or_else(|| {
+            let access_key = read_config_env("AWS_ACCESS_KEY_ID").or_else(|| {
                 bedrock_cfg
                     .and_then(|b| b.get("accessKeyId"))
                     .and_then(|v| v.as_str())
                     .map(String::from)
             });
 
-            let secret_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok().or_else(|| {
+            let secret_key = read_config_env("AWS_SECRET_ACCESS_KEY").or_else(|| {
                 bedrock_cfg
                     .and_then(|b| b.get("secretAccessKey"))
                     .and_then(|v| v.as_str())
                     .map(String::from)
             });
 
-            let session_token = std::env::var("AWS_SESSION_TOKEN").ok().or_else(|| {
+            let session_token = read_config_env("AWS_SESSION_TOKEN").or_else(|| {
                 bedrock_cfg
                     .and_then(|b| b.get("sessionToken"))
                     .and_then(|v| v.as_str())
@@ -782,7 +780,7 @@ pub struct ProviderFingerprint {
 pub fn fingerprint_providers(cfg: &Value) -> ProviderFingerprint {
     let anthropic_key = resolve_anthropic_api_key(cfg);
     let anthropic_auth_profile_fingerprint = resolve_anthropic_auth_profile_fingerprint(cfg);
-    let anthropic_url = std::env::var("ANTHROPIC_BASE_URL").ok().or_else(|| {
+    let anthropic_url = read_config_env("ANTHROPIC_BASE_URL").or_else(|| {
         cfg.get("anthropic")
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
@@ -798,7 +796,7 @@ pub fn fingerprint_providers(cfg: &Value) -> ProviderFingerprint {
     let codex_profile_fingerprint = resolve_openai_auth_profile_fingerprint(cfg);
 
     let ollama_cfg = cfg.get("providers").and_then(|v| v.get("ollama"));
-    let ollama_url = std::env::var("OLLAMA_BASE_URL").ok().or_else(|| {
+    let ollama_url = read_config_env("OLLAMA_BASE_URL").or_else(|| {
         ollama_cfg
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
@@ -806,8 +804,7 @@ pub fn fingerprint_providers(cfg: &Value) -> ProviderFingerprint {
     });
     let ollama_configured = ollama_url.is_some() || ollama_cfg.is_some();
 
-    let google_key = std::env::var("GOOGLE_API_KEY")
-        .ok()
+    let google_key = read_config_env("GOOGLE_API_KEY")
         .or_else(|| {
             cfg.get("google")
                 .and_then(|v| v.get("apiKey"))
@@ -816,20 +813,20 @@ pub fn fingerprint_providers(cfg: &Value) -> ProviderFingerprint {
         })
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
-    let google_url = std::env::var("GOOGLE_API_BASE_URL").ok().or_else(|| {
+    let google_url = read_config_env("GOOGLE_API_BASE_URL").or_else(|| {
         cfg.get("google")
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
     });
 
-    let venice_key = std::env::var("VENICE_API_KEY").ok().or_else(|| {
+    let venice_key = read_config_env("VENICE_API_KEY").or_else(|| {
         cfg.get("venice")
             .and_then(|v| v.get("apiKey"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
     });
-    let venice_url = std::env::var("VENICE_BASE_URL").ok().or_else(|| {
+    let venice_url = read_config_env("VENICE_BASE_URL").or_else(|| {
         cfg.get("venice")
             .and_then(|v| v.get("baseUrl"))
             .and_then(|v| v.as_str())
@@ -843,16 +840,15 @@ pub fn fingerprint_providers(cfg: &Value) -> ProviderFingerprint {
         .and_then(|b| b.get("enabled"))
         .and_then(|v| v.as_bool())
         != Some(false);
-    let bedrock_region = std::env::var("AWS_REGION")
-        .ok()
-        .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())
+    let bedrock_region = read_config_env("AWS_REGION")
+        .or_else(|| read_config_env("AWS_DEFAULT_REGION"))
         .or_else(|| {
             bedrock_cfg
                 .and_then(|b| b.get("region"))
                 .and_then(|v| v.as_str())
                 .map(String::from)
         });
-    let bedrock_access_key = std::env::var("AWS_ACCESS_KEY_ID").ok().or_else(|| {
+    let bedrock_access_key = read_config_env("AWS_ACCESS_KEY_ID").or_else(|| {
         bedrock_cfg
             .and_then(|b| b.get("accessKeyId"))
             .and_then(|v| v.as_str())

--- a/src/agent/sandbox.rs
+++ b/src/agent/sandbox.rs
@@ -225,7 +225,8 @@ fn default_ssh_tunnel_allowed_paths() -> Vec<String> {
     {
         push_unique_path(&mut paths, "/dev");
 
-        if let Some(home) = std::env::var("HOME").ok().filter(|home| !home.is_empty()) {
+        if let Some(home) = crate::config::read_process_env("HOME").filter(|home| !home.is_empty())
+        {
             push_unique_path(&mut paths, &home);
             let ssh_dir = format!("{home}/.ssh");
             push_unique_path(&mut paths, &ssh_dir);
@@ -711,13 +712,9 @@ fn windows_filtered_env(config: &ProcessSandboxConfig) -> Option<Vec<(OsString, 
         return None;
     }
 
-    let mut filtered = Vec::new();
-    for key in &config.env_filter {
-        if let Some(value) = std::env::var_os(key) {
-            filtered.push((OsString::from(key), value));
-        }
-    }
-    Some(filtered)
+    Some(crate::config::read_config_env_os_many(
+        config.env_filter.iter().map(String::as_str),
+    ))
 }
 
 #[cfg(target_os = "windows")]
@@ -1179,8 +1176,8 @@ fn resolve_windows_executable_with_env(
 
 #[cfg(target_os = "windows")]
 fn resolve_windows_executable(program: &str) -> std::io::Result<Option<PathBuf>> {
-    let path_var = std::env::var_os("PATH");
-    let path_exts = std::env::var("PATHEXT").ok();
+    let path_var = crate::config::read_process_env_os("PATH");
+    let path_exts = crate::config::read_process_env("PATHEXT");
     resolve_windows_executable_with_env(program, path_var.as_deref(), path_exts.as_deref())
 }
 
@@ -1341,7 +1338,7 @@ fn macos_seatbelt_available() -> bool {
         return true;
     }
 
-    std::env::var_os("PATH").is_some_and(|paths| {
+    crate::config::read_process_env_os("PATH").is_some_and(|paths| {
         std::env::split_paths(&paths).any(|dir| dir.join("sandbox-exec").is_file())
     })
 }
@@ -1717,10 +1714,10 @@ fn configure_sandboxed_command(cmd: &mut Command, config: Option<&ProcessSandbox
 
     if !cfg.env_filter.is_empty() {
         cmd.env_clear();
-        for var in &cfg.env_filter {
-            if let Ok(value) = std::env::var(var) {
-                cmd.env(var, value);
-            }
+        for (key, value) in
+            crate::config::read_config_env_os_many(cfg.env_filter.iter().map(String::as_str))
+        {
+            cmd.env(key, value);
         }
     }
 

--- a/src/auth/profile_runtime.rs
+++ b/src/auth/profile_runtime.rs
@@ -94,8 +94,7 @@ struct AnthropicProfileRuntimeInputs {
 
 impl AnthropicProfileRuntimeInputs {
     fn from_env() -> Result<Self, String> {
-        let password = std::env::var("CARAPACE_CONFIG_PASSWORD")
-            .ok()
+        let password = crate::config::read_process_env("CARAPACE_CONFIG_PASSWORD")
             .filter(|value| !value.trim().is_empty())
             .ok_or_else(|| {
                 "Anthropic auth profile is configured, but CARAPACE_CONFIG_PASSWORD is not set."

--- a/src/auth/profiles.rs
+++ b/src/auth/profiles.rs
@@ -1030,8 +1030,8 @@ impl ProfileStore {
     /// rest using the same password-derived keying material used for config
     /// secret sealing. Otherwise the store falls back to plaintext storage.
     pub fn from_env(state_dir: PathBuf) -> Result<Self, AuthProfileError> {
-        match std::env::var("CARAPACE_CONFIG_PASSWORD") {
-            Ok(password) if !password.trim().is_empty() => {
+        match crate::config::read_process_env("CARAPACE_CONFIG_PASSWORD") {
+            Some(password) if !password.trim().is_empty() => {
                 Self::with_encryption(state_dir, password.as_bytes())
             }
             _ => Ok(Self::new(state_dir)),
@@ -1817,8 +1817,7 @@ impl Drop for ProfileStore {
 }
 
 pub fn profile_store_encryption_enabled_from_env() -> bool {
-    std::env::var("CARAPACE_CONFIG_PASSWORD")
-        .ok()
+    crate::config::read_process_env("CARAPACE_CONFIG_PASSWORD")
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false)
 }

--- a/src/channels/telegram_inbound.rs
+++ b/src/channels/telegram_inbound.rs
@@ -104,8 +104,7 @@ pub fn resolve_webhook_secret(cfg: &Value) -> Option<String> {
         .and_then(|v| v.as_str())
         .and_then(normalize_secret)
         .or_else(|| {
-            std::env::var("TELEGRAM_WEBHOOK_SECRET")
-                .ok()
+            crate::config::read_config_env("TELEGRAM_WEBHOOK_SECRET")
                 .as_deref()
                 .and_then(normalize_secret)
         })

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1391,7 +1391,7 @@ pub(crate) struct GatewayAuth {
 }
 
 pub(crate) async fn resolve_gateway_auth() -> GatewayAuth {
-    let token_env = std::env::var("CARAPACE_GATEWAY_TOKEN").ok().and_then(|v| {
+    let token_env = config::read_config_env("CARAPACE_GATEWAY_TOKEN").and_then(|v| {
         let token = v.trim().to_string();
         if token.is_empty() {
             None
@@ -1399,16 +1399,14 @@ pub(crate) async fn resolve_gateway_auth() -> GatewayAuth {
             Some(token)
         }
     });
-    let password_env = std::env::var("CARAPACE_GATEWAY_PASSWORD")
-        .ok()
-        .and_then(|v| {
-            let password = v.trim().to_string();
-            if password.is_empty() {
-                None
-            } else {
-                Some(password)
-            }
-        });
+    let password_env = config::read_config_env("CARAPACE_GATEWAY_PASSWORD").and_then(|v| {
+        let password = v.trim().to_string();
+        if password.is_empty() {
+            None
+        } else {
+            Some(password)
+        }
+    });
 
     let mut token_cfg = None;
     let mut password_cfg = None;
@@ -1493,8 +1491,7 @@ fn strict_device_identity_mode() -> bool {
 }
 
 fn env_flag_enabled(name: &str) -> bool {
-    std::env::var(name)
-        .ok()
+    config::read_config_env(name)
         .map(|value| {
             matches!(
                 value.trim().to_lowercase().as_str(),
@@ -2853,7 +2850,7 @@ fn rollback_managed_plugin_file_transaction_blocking(
 
 #[cfg(test)]
 fn should_fail_staged_plugin_write(dest: &Path) -> bool {
-    std::env::var_os("CARAPACE_TEST_FAIL_STAGE_PLUGIN_WRITE_DEST")
+    crate::config::read_process_env_os("CARAPACE_TEST_FAIL_STAGE_PLUGIN_WRITE_DEST")
         .map(PathBuf::from)
         .as_deref()
         == Some(dest)
@@ -2915,7 +2912,7 @@ async fn write_staged_plugin_artifact(dest: &Path, bytes: &[u8]) -> std::io::Res
 
 #[cfg(test)]
 fn should_fail_staged_plugin_cleanup(dest: &Path) -> bool {
-    std::env::var_os("CARAPACE_TEST_FAIL_STAGE_PLUGIN_CLEANUP_DEST")
+    crate::config::read_process_env_os("CARAPACE_TEST_FAIL_STAGE_PLUGIN_CLEANUP_DEST")
         .map(PathBuf::from)
         .as_deref()
         == Some(dest)
@@ -2923,7 +2920,7 @@ fn should_fail_staged_plugin_cleanup(dest: &Path) -> bool {
 
 #[cfg(test)]
 fn should_fail_staged_plugin_rename_dest(dest: &Path) -> bool {
-    std::env::var_os("CARAPACE_TEST_FAIL_STAGE_PLUGIN_RENAME_DEST")
+    crate::config::read_process_env_os("CARAPACE_TEST_FAIL_STAGE_PLUGIN_RENAME_DEST")
         .map(PathBuf::from)
         .as_deref()
         == Some(dest)
@@ -2931,7 +2928,7 @@ fn should_fail_staged_plugin_rename_dest(dest: &Path) -> bool {
 
 #[cfg(test)]
 fn should_fail_restore_previous_plugin_artifact(dest: &Path) -> bool {
-    std::env::var_os("CARAPACE_TEST_FAIL_RESTORE_PLUGIN_DEST")
+    crate::config::read_process_env_os("CARAPACE_TEST_FAIL_RESTORE_PLUGIN_DEST")
         .map(PathBuf::from)
         .as_deref()
         == Some(dest)
@@ -4088,15 +4085,13 @@ enum ModelProviderRoute {
 }
 
 fn env_var_present(key: &str) -> bool {
-    std::env::var(key)
-        .ok()
+    config::read_config_env(key)
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false)
 }
 
 fn env_var_value(key: &str) -> Option<String> {
-    std::env::var(key)
-        .ok()
+    config::read_config_env(key)
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
 }
@@ -4727,7 +4722,7 @@ fn prompt_optional_value_from_env(
     value_label: &str,
     hide_sensitive_input: bool,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    let env_value = std::env::var(env_var).ok().filter(|v| !v.trim().is_empty());
+    let env_value = config::read_config_env(env_var).filter(|v| !v.trim().is_empty());
     if let Some(value) = env_value {
         let use_env = prompt_yes_no(&format!("Use {label} from ${env_var}?"), true)?;
         if use_env {
@@ -5553,15 +5548,13 @@ fn resolve_env_placeholder(value: &str) -> Option<String> {
         warn_unsupported_verify_placeholder_key(key);
         return None;
     }
-    std::env::var(key)
-        .ok()
+    config::read_config_env(key)
         .map(|env_value| env_value.trim().to_string())
         .filter(|normalized| !normalized.is_empty())
 }
 
 fn resolve_channel_bot_token(cfg: &Value, channel_key: &str, env_var: &str) -> Option<String> {
-    std::env::var(env_var)
-        .ok()
+    config::read_config_env(env_var)
         .map(|value| value.trim().to_string())
         .filter(|normalized| !normalized.is_empty())
         .or_else(|| resolve_channel_bot_token_from_config(cfg, channel_key))
@@ -5579,8 +5572,7 @@ fn channel_outcome_configured(cfg: &Value, channel_key: &str) -> bool {
 }
 
 fn resolve_hooks_token(cfg: &Value) -> Option<String> {
-    std::env::var("CARAPACE_HOOKS_TOKEN")
-        .ok()
+    config::read_config_env("CARAPACE_HOOKS_TOKEN")
         .map(|value| value.trim().to_string())
         .filter(|normalized| !normalized.is_empty())
         .or_else(|| {
@@ -8156,7 +8148,7 @@ pub async fn handle_pair(
     // Resolve the device name.
     let device_name = match name {
         Some(n) => n.to_string(),
-        None => std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string()),
+        None => config::read_process_env("HOSTNAME").unwrap_or_else(|| "unknown".to_string()),
     };
 
     let ws_url = ws_url_from_http(&parsed_url)?;
@@ -13321,7 +13313,9 @@ mod tests {
         let name = Some("my-device");
         let device_name = match name {
             Some(n) => n.to_string(),
-            None => std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string()),
+            None => {
+                crate::config::read_process_env("HOSTNAME").unwrap_or_else(|| "unknown".to_string())
+            }
         };
         assert_eq!(device_name, "my-device");
     }
@@ -13331,7 +13325,9 @@ mod tests {
         let name: Option<&str> = None;
         let device_name = match name {
             Some(n) => n.to_string(),
-            None => std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string()),
+            None => {
+                crate::config::read_process_env("HOSTNAME").unwrap_or_else(|| "unknown".to_string())
+            }
         };
         // Should be either the hostname or "unknown", both are acceptable.
         assert!(

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -17,7 +17,6 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::env;
 use tracing::debug;
 
 // ---------------------------------------------------------------------------
@@ -499,11 +498,11 @@ impl Default for VertexDefaults {
 }
 
 fn default_vertex_project_id() -> Option<String> {
-    env::var("VERTEX_PROJECT_ID").ok()
+    super::read_config_env("VERTEX_PROJECT_ID")
 }
 
 fn default_vertex_location() -> String {
-    env::var("VERTEX_LOCATION").unwrap_or_else(|_| "us-central1".to_string())
+    super::read_config_env("VERTEX_LOCATION").unwrap_or_else(|| "us-central1".to_string())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,7 +12,7 @@ pub mod watcher;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 use regex::Regex;
 use serde_json::Value;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsString;
@@ -135,6 +135,8 @@ static CONFIG_ENV_STATE: LazyLock<Mutex<InjectedConfigEnvState>> =
 
 thread_local! {
     static CONFIG_ENV_STATE_LOCK_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static CONFIG_ENV_STATE_ACTIVE_SNAPSHOT: RefCell<Option<HashMap<String, String>>> =
+        const { RefCell::new(None) };
 }
 
 struct ConfigEnvStateGuard {
@@ -143,6 +145,7 @@ struct ConfigEnvStateGuard {
 
 impl ConfigEnvStateGuard {
     fn new(inner: MutexGuard<'static, InjectedConfigEnvState>) -> Self {
+        refresh_config_env_state_active_snapshot(&inner);
         CONFIG_ENV_STATE_LOCK_DEPTH.with(|depth| {
             depth.set(depth.get() + 1);
         });
@@ -174,6 +177,9 @@ impl Drop for ConfigEnvStateGuard {
         unsafe {
             ManuallyDrop::drop(&mut self.inner);
         }
+        CONFIG_ENV_STATE_ACTIVE_SNAPSHOT.with(|snapshot| {
+            *snapshot.borrow_mut() = None;
+        });
         CONFIG_ENV_STATE_LOCK_DEPTH.with(|depth| {
             depth.set(depth.get().saturating_sub(1));
         });
@@ -189,6 +195,41 @@ fn try_lock_config_env_state() -> Result<ConfigEnvStateGuard, ConfigError> {
         return Err(ConfigError::ReentrantConfigEnvAccess);
     }
     Ok(ConfigEnvStateGuard::new(CONFIG_ENV_STATE.lock()))
+}
+
+fn refresh_config_env_state_active_snapshot(state: &InjectedConfigEnvState) {
+    CONFIG_ENV_STATE_ACTIVE_SNAPSHOT.with(|snapshot| {
+        *snapshot.borrow_mut() = Some(state.active_values.clone());
+    });
+}
+
+fn read_reentrant_config_env_os(key: &str) -> Option<OsString> {
+    let config_value = CONFIG_ENV_STATE_ACTIVE_SNAPSHOT.with(|snapshot| {
+        snapshot
+            .borrow()
+            .as_ref()
+            .and_then(|active_values| active_values.get(key).map(OsString::from))
+    });
+    config_value.or_else(|| read_process_env_os(key))
+}
+
+fn read_reentrant_config_env_os_many<'a, I>(keys: I) -> Vec<(OsString, OsString)>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    CONFIG_ENV_STATE_ACTIVE_SNAPSHOT.with(|snapshot| {
+        let snapshot = snapshot.borrow();
+        let active_values = snapshot.as_ref();
+        keys.into_iter()
+            .filter_map(|key| {
+                let value = active_values
+                    .and_then(|values| values.get(key))
+                    .map(OsString::from)
+                    .or_else(|| read_process_env_os(key))?;
+                Some((OsString::from(key), value))
+            })
+            .collect()
+    })
 }
 
 fn lock_config_env_state_for_internal_state() -> ConfigEnvStateGuard {
@@ -259,8 +300,11 @@ pub(crate) fn read_config_env_os(key: &str) -> Option<OsString> {
     let state = match try_lock_config_env_state() {
         Ok(state) => state,
         Err(ConfigError::ReentrantConfigEnvAccess) => {
-            tracing::warn!(key, "reentrant config env read using process-env fallback");
-            return read_process_env_os(key);
+            tracing::warn!(
+                key,
+                "reentrant config env read using active snapshot fallback"
+            );
+            return read_reentrant_config_env_os(key);
         }
         Err(err) => unreachable!("unexpected config env lock error: {err}"),
     };
@@ -279,13 +323,8 @@ where
     let state = match try_lock_config_env_state() {
         Ok(state) => state,
         Err(ConfigError::ReentrantConfigEnvAccess) => {
-            tracing::warn!("reentrant batched config env read using process-env fallback");
-            return keys
-                .into_iter()
-                .filter_map(|key| {
-                    read_process_env_os(key).map(|value| (OsString::from(key), value))
-                })
-                .collect();
+            tracing::warn!("reentrant batched config env read using active snapshot fallback");
+            return read_reentrant_config_env_os_many(keys);
         }
         Err(err) => unreachable!("unexpected config env lock error: {err}"),
     };
@@ -763,10 +802,6 @@ fn resolve_external_env_var(
     resolve_process_env_var(key)
 }
 
-#[allow(
-    clippy::disallowed_methods,
-    reason = "central locked config-env writer; callers must hold CONFIG_ENV_STATE"
-)]
 fn apply_config_env_vars(next: &HashMap<String, String>, state: &mut InjectedConfigEnvState) {
     let next_keys: HashSet<String> = next.keys().cloned().collect();
 
@@ -775,11 +810,7 @@ fn apply_config_env_vars(next: &HashMap<String, String>, state: &mut InjectedCon
             continue;
         }
 
-        match state.previous_values.remove(&key).flatten() {
-            Some(previous) => env::set_var(&key, previous),
-            None => env::remove_var(&key),
-        }
-        state.active_values.remove(&key);
+        restore_previous_config_env_value(&key, state);
     }
 
     for (key, value) in next {
@@ -790,24 +821,12 @@ fn apply_config_env_vars(next: &HashMap<String, String>, state: &mut InjectedCon
         {
             continue;
         }
-        if !state.active_values.contains_key(key) {
-            state
-                .previous_values
-                .insert(key.clone(), read_process_env_os(key));
-        }
-        // Config env entries are validated by collect_config_env_entry before
-        // reaching this writer, so std::env::set_var should not reject these
-        // keys or values. Keep active_values as the in-memory source of truth
-        // before mutating process env under the same lock.
-        state.active_values.insert(key.clone(), value.clone());
-        env::set_var(key, value);
+        set_config_env_value(key, value, state);
     }
+
+    refresh_config_env_state_active_snapshot(state);
 }
 
-#[allow(
-    clippy::disallowed_methods,
-    reason = "central locked config-env restore path; callers must hold CONFIG_ENV_STATE"
-)]
 fn restore_config_env_state(
     previous: &InjectedConfigEnvState,
     current: &mut InjectedConfigEnvState,
@@ -817,17 +836,64 @@ fn restore_config_env_state(
             continue;
         }
 
-        match current.previous_values.remove(&key).flatten() {
-            Some(value) => env::set_var(&key, value),
-            None => env::remove_var(&key),
-        }
+        restore_previous_config_env_value(&key, current);
     }
 
     for (key, value) in &previous.active_values {
-        env::set_var(key, value);
+        set_process_env_value(key, value);
     }
 
     *current = previous.clone();
+    refresh_config_env_state_active_snapshot(current);
+}
+
+fn set_config_env_value(key: &str, value: &str, state: &mut InjectedConfigEnvState) {
+    let previous = (!state.active_values.contains_key(key)).then(|| read_process_env_os(key));
+
+    // Config env entries are validated by collect_config_env_entry before
+    // reaching this writer, so std::env::set_var should not reject these keys
+    // or values. Mutate process env first so the same-thread reentrant fallback
+    // never observes active_values ahead of process env.
+    set_process_env_value(key, value);
+
+    if let Some(previous) = previous {
+        state.previous_values.insert(key.to_string(), previous);
+    }
+    state
+        .active_values
+        .insert(key.to_string(), value.to_string());
+}
+
+fn restore_previous_config_env_value(key: &str, state: &mut InjectedConfigEnvState) {
+    match state.previous_values.get(key).cloned().flatten() {
+        Some(value) => set_process_env_value(key, value),
+        None => remove_process_env_value(key),
+    }
+    state.previous_values.remove(key);
+    state.active_values.remove(key);
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "central serialized config-env process writer; callers must hold CONFIG_ENV_STATE"
+)]
+fn set_process_env_value<K, V>(key: K, value: V)
+where
+    K: AsRef<std::ffi::OsStr>,
+    V: AsRef<std::ffi::OsStr>,
+{
+    env::set_var(key, value);
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "central serialized config-env process remover; callers must hold CONFIG_ENV_STATE"
+)]
+fn remove_process_env_value<K>(key: K)
+where
+    K: AsRef<std::ffi::OsStr>,
+{
+    env::remove_var(key);
 }
 
 /// Parse JSON5 content
@@ -1325,7 +1391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_config_env_readers_reject_reentrant_lock_without_panic() {
+    fn test_config_env_readers_use_active_snapshot_when_reentrant() {
         let mut env_guard = ScopedEnv::new();
         let _env_state_guard = ScopedEnvStateForTest::new();
         env_guard.unset("TEST_REENTRANT_CONFIG_ENV_READ");
@@ -1333,6 +1399,9 @@ mod tests {
             "TEST_REENTRANT_CONFIG_ENV_READ".to_string(),
             "config-value".to_string(),
         )]));
+        // Prove the reentrant path is backed by the active config-env snapshot,
+        // not by the raw process environment side effect.
+        env_guard.unset("TEST_REENTRANT_CONFIG_ENV_READ");
 
         let _state = lock_config_env_state_for_internal_state();
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,13 +9,16 @@ pub mod schema;
 pub mod secrets;
 pub mod watcher;
 
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{Mutex, MutexGuard, RwLock};
 use regex::Regex;
 use serde_json::Value;
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsString;
 use std::fs;
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
@@ -99,6 +102,12 @@ pub enum ConfigError {
 
     #[error("Validation error at {path}: {message}")]
     ValidationError { path: String, message: String },
+
+    #[error("config env state is already locked on this thread")]
+    ReentrantConfigEnvAccess,
+
+    #[error("runtime env substitution attempted while config env state is locked")]
+    ReentrantConfigEnvSubstitution,
 }
 
 /// Cached configuration entry
@@ -124,26 +133,88 @@ pub(crate) struct InjectedConfigEnvState {
 static CONFIG_ENV_STATE: LazyLock<Mutex<InjectedConfigEnvState>> =
     LazyLock::new(|| Mutex::new(InjectedConfigEnvState::default()));
 
+thread_local! {
+    static CONFIG_ENV_STATE_LOCK_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+struct ConfigEnvStateGuard {
+    inner: ManuallyDrop<MutexGuard<'static, InjectedConfigEnvState>>,
+}
+
+impl ConfigEnvStateGuard {
+    fn new(inner: MutexGuard<'static, InjectedConfigEnvState>) -> Self {
+        CONFIG_ENV_STATE_LOCK_DEPTH.with(|depth| {
+            depth.set(depth.get() + 1);
+        });
+        Self {
+            inner: ManuallyDrop::new(inner),
+        }
+    }
+}
+
+impl Deref for ConfigEnvStateGuard {
+    type Target = InjectedConfigEnvState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for ConfigEnvStateGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl Drop for ConfigEnvStateGuard {
+    fn drop(&mut self) {
+        // Release the mutex explicitly before marking the thread-local depth as
+        // clear, so the logical guard state never under-reports the physical
+        // mutex hold.
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
+        CONFIG_ENV_STATE_LOCK_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+        });
+    }
+}
+
+fn config_env_state_locked_on_current_thread() -> bool {
+    CONFIG_ENV_STATE_LOCK_DEPTH.with(|depth| depth.get() > 0)
+}
+
+fn try_lock_config_env_state() -> Result<ConfigEnvStateGuard, ConfigError> {
+    if config_env_state_locked_on_current_thread() {
+        return Err(ConfigError::ReentrantConfigEnvAccess);
+    }
+    Ok(ConfigEnvStateGuard::new(CONFIG_ENV_STATE.lock()))
+}
+
+fn lock_config_env_state_for_internal_state() -> ConfigEnvStateGuard {
+    try_lock_config_env_state().expect("CONFIG_ENV_STATE is not reentrant")
+}
+
 /// Snapshot of the currently-injected config env state, opaque to callers.
 pub(crate) fn snapshot_env_state() -> InjectedConfigEnvState {
-    CONFIG_ENV_STATE.lock().clone()
+    lock_config_env_state_for_internal_state().clone()
 }
 
 /// Restore process env to the state captured by [`snapshot_env_state`].
 pub(crate) fn restore_env_state(snapshot: &InjectedConfigEnvState) {
-    let mut current = CONFIG_ENV_STATE.lock();
+    let mut current = lock_config_env_state_for_internal_state();
     restore_config_env_state(snapshot, &mut current);
 }
 
 #[cfg(test)]
 pub(crate) fn apply_config_env_for_test(vars: HashMap<String, String>) {
-    let mut state = CONFIG_ENV_STATE.lock();
+    let mut state = lock_config_env_state_for_internal_state();
     apply_config_env_vars(&vars, &mut state);
 }
 
 #[cfg(test)]
 fn reset_config_env_state() {
-    let mut state = CONFIG_ENV_STATE.lock();
+    let mut state = lock_config_env_state_for_internal_state();
     let empty = InjectedConfigEnvState::default();
     restore_config_env_state(&empty, &mut state);
 }
@@ -171,15 +242,108 @@ impl Drop for ScopedEnvStateForTest {
     }
 }
 
+/// Read an environment variable that may be supplied by `config.env`.
+///
+/// Config reloads mutate process env under `CONFIG_ENV_STATE`; runtime reads of
+/// config-injectable keys must use the same lock so they cannot race
+/// `set_var`/`remove_var`.
+pub fn read_config_env(key: &str) -> Option<String> {
+    os_string_to_string(key, read_config_env_os(key)?, "config env")
+}
+
+/// Read an OS environment variable that may be supplied by `config.env`.
+///
+/// Use this for runtime forwarding of environment values where non-Unicode
+/// values must be preserved.
+pub(crate) fn read_config_env_os(key: &str) -> Option<OsString> {
+    let state = match try_lock_config_env_state() {
+        Ok(state) => state,
+        Err(ConfigError::ReentrantConfigEnvAccess) => {
+            tracing::warn!(key, "reentrant config env read using process-env fallback");
+            return read_process_env_os(key);
+        }
+        Err(err) => unreachable!("unexpected config env lock error: {err}"),
+    };
+    state
+        .active_values
+        .get(key)
+        .map(OsString::from)
+        .or_else(|| read_process_env_os(key))
+}
+
+/// Read several config-injectable environment variables as one consistent snapshot.
+pub(crate) fn read_config_env_os_many<'a, I>(keys: I) -> Vec<(OsString, OsString)>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let state = match try_lock_config_env_state() {
+        Ok(state) => state,
+        Err(ConfigError::ReentrantConfigEnvAccess) => {
+            tracing::warn!("reentrant batched config env read using process-env fallback");
+            return keys
+                .into_iter()
+                .filter_map(|key| {
+                    read_process_env_os(key).map(|value| (OsString::from(key), value))
+                })
+                .collect();
+        }
+        Err(err) => unreachable!("unexpected config env lock error: {err}"),
+    };
+    keys.into_iter()
+        .filter_map(|key| {
+            let value = state
+                .active_values
+                .get(key)
+                .map(OsString::from)
+                .or_else(|| read_process_env_os(key))?;
+            Some((OsString::from(key), value))
+        })
+        .collect()
+}
+
+/// Read a process-only environment variable.
+///
+/// Use this for loader-control, build metadata, OS/system values, and import
+/// probes that must not be shadowed by `config.env`.
+pub fn read_process_env(key: &str) -> Option<String> {
+    os_string_to_string(key, read_process_env_os(key)?, "process env")
+}
+
+/// Read a process-only OS environment variable.
+///
+/// This intentionally bypasses `CONFIG_ENV_STATE`; do not use it for values
+/// that users are allowed to inject through `config.env`.
+#[allow(
+    clippy::disallowed_methods,
+    reason = "central raw process-env wrapper; callers must choose this explicitly"
+)]
+pub fn read_process_env_os(key: &str) -> Option<OsString> {
+    env::var_os(key)
+}
+
+fn os_string_to_string(key: &str, value: OsString, source: &str) -> Option<String> {
+    match value.into_string() {
+        Ok(value) => Some(value),
+        Err(_) => {
+            tracing::warn!(
+                env_var = %key,
+                source = %source,
+                "environment variable value is not valid UTF-8; treating it as unset"
+            );
+            None
+        }
+    }
+}
+
 /// Get the config file path.
 /// Priority: CARAPACE_CONFIG_PATH > CARAPACE_STATE_DIR/carapace.json5 > ~/.config/carapace/carapace.json5
 /// Falls back to .json extension if the .json5 file doesn't exist.
 pub fn get_config_path() -> PathBuf {
-    if let Ok(path) = env::var("CARAPACE_CONFIG_PATH") {
+    if let Some(path) = read_process_env("CARAPACE_CONFIG_PATH") {
         return PathBuf::from(path);
     }
 
-    if let Ok(state_dir) = env::var("CARAPACE_STATE_DIR") {
+    if let Some(state_dir) = read_process_env("CARAPACE_STATE_DIR") {
         let dir = PathBuf::from(state_dir);
         let json5 = dir.join("carapace.json5");
         if json5.exists() {
@@ -201,12 +365,11 @@ pub fn get_config_path() -> PathBuf {
 /// Get the cache TTL duration
 fn get_cache_ttl() -> Option<Duration> {
     // Check if caching is disabled
-    if env::var("CARAPACE_DISABLE_CONFIG_CACHE").is_ok() {
+    if read_process_env("CARAPACE_DISABLE_CONFIG_CACHE").is_some() {
         return None;
     }
 
-    let ms = env::var("CARAPACE_CONFIG_CACHE_MS")
-        .ok()
+    let ms = read_process_env("CARAPACE_CONFIG_CACHE_MS")
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(DEFAULT_CACHE_TTL_MS);
 
@@ -214,7 +377,7 @@ fn get_cache_ttl() -> Option<Duration> {
 }
 
 pub(crate) fn config_password() -> Option<Zeroizing<Vec<u8>>> {
-    let password = env::var(CONFIG_PASSWORD_ENV).ok()?;
+    let password = read_process_env(CONFIG_PASSWORD_ENV)?;
     if password.is_empty() {
         return None;
     }
@@ -385,7 +548,7 @@ pub(crate) fn load_config_pair_uncached(path: &Path) -> Result<(Value, Value), C
 fn load_raw_config_uncached(path: &Path) -> Result<Value, ConfigError> {
     // Return empty object if file doesn't exist.
     if !path.exists() {
-        let mut env_state = CONFIG_ENV_STATE.lock();
+        let mut env_state = try_lock_config_env_state()?;
         let empty_env_state = InjectedConfigEnvState::default();
         restore_config_env_state(&empty_env_state, &mut env_state);
         return Ok(Value::Object(serde_json::Map::new()));
@@ -410,7 +573,7 @@ fn load_raw_config_uncached(path: &Path) -> Result<Value, ConfigError> {
     // This intentionally mutates process env because later config/runtime
     // lookups rely on these values, but the mutation is serialized and rolled
     // back if substitution fails.
-    let mut env_state = CONFIG_ENV_STATE.lock();
+    let mut env_state = try_lock_config_env_state()?;
     let resolved_env = resolve_config_env_vars(&value, &env_state)?;
     let previous_env_state = env_state.clone();
     apply_config_env_vars(&resolved_env, &mut env_state);
@@ -597,11 +760,13 @@ fn resolve_external_env_var(
         });
     }
 
-    env::var(key).map_err(|_| ConfigError::MissingEnvVar {
-        var: key.to_string(),
-    })
+    resolve_process_env_var(key)
 }
 
+#[allow(
+    clippy::disallowed_methods,
+    reason = "central locked config-env writer; callers must hold CONFIG_ENV_STATE"
+)]
 fn apply_config_env_vars(next: &HashMap<String, String>, state: &mut InjectedConfigEnvState) {
     let next_keys: HashSet<String> = next.keys().cloned().collect();
 
@@ -626,13 +791,23 @@ fn apply_config_env_vars(next: &HashMap<String, String>, state: &mut InjectedCon
             continue;
         }
         if !state.active_values.contains_key(key) {
-            state.previous_values.insert(key.clone(), env::var_os(key));
+            state
+                .previous_values
+                .insert(key.clone(), read_process_env_os(key));
         }
-        env::set_var(key, value);
+        // Config env entries are validated by collect_config_env_entry before
+        // reaching this writer, so std::env::set_var should not reject these
+        // keys or values. Keep active_values as the in-memory source of truth
+        // before mutating process env under the same lock.
         state.active_values.insert(key.clone(), value.clone());
+        env::set_var(key, value);
     }
 }
 
+#[allow(
+    clippy::disallowed_methods,
+    reason = "central locked config-env restore path; callers must hold CONFIG_ENV_STATE"
+)]
 fn restore_config_env_state(
     previous: &InjectedConfigEnvState,
     current: &mut InjectedConfigEnvState,
@@ -814,7 +989,9 @@ fn deep_merge(base: &mut Value, overlay: Value) {
 fn substitute_env_vars(value: &mut Value) -> Result<(), ConfigError> {
     match value {
         Value::String(s) => {
-            *s = substitute_env_in_string(s)?;
+            // The config loader calls this while holding CONFIG_ENV_STATE after
+            // installing config env values, so avoid re-locking here.
+            *s = substitute_env_in_string_with(s, resolve_process_env_var)?;
         }
         Value::Object(obj) => {
             for (_, v) in obj.iter_mut() {
@@ -831,12 +1008,27 @@ fn substitute_env_vars(value: &mut Value) -> Result<(), ConfigError> {
     Ok(())
 }
 
-/// Substitute environment variables in a single string
+/// Substitute environment variables in a single runtime string.
+///
+/// This resolves through [`read_config_env`] and therefore acquires
+/// `CONFIG_ENV_STATE`. Loader paths that already hold that lock must use
+/// `substitute_env_in_string_with(..., resolve_process_env_var)` instead.
 pub(crate) fn substitute_env_in_string(s: &str) -> Result<String, ConfigError> {
-    substitute_env_in_string_with(s, |var_name| {
-        env::var(var_name).map_err(|_| ConfigError::MissingEnvVar {
-            var: var_name.to_string(),
-        })
+    if config_env_state_locked_on_current_thread() {
+        return Err(ConfigError::ReentrantConfigEnvSubstitution);
+    }
+    substitute_env_in_string_with(s, resolve_runtime_env_var)
+}
+
+fn resolve_process_env_var(var_name: &str) -> Result<String, ConfigError> {
+    read_process_env(var_name).ok_or_else(|| ConfigError::MissingEnvVar {
+        var: var_name.to_string(),
+    })
+}
+
+fn resolve_runtime_env_var(var_name: &str) -> Result<String, ConfigError> {
+    read_config_env(var_name).ok_or_else(|| ConfigError::MissingEnvVar {
+        var: var_name.to_string(),
     })
 }
 
@@ -1101,6 +1293,64 @@ mod tests {
 
         let result = substitute_env_in_string("Bearer ${TEST_API_KEY}").unwrap();
         assert_eq!(result, "Bearer sk-secret");
+    }
+
+    #[test]
+    fn test_env_var_substitution_reads_active_config_env_state() {
+        let mut env_guard = ScopedEnv::new();
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        env_guard.set("TEST_CONFIG_SUBSTITUTE_ENV", "external-value");
+        apply_config_env_for_test(HashMap::from([(
+            "TEST_CONFIG_SUBSTITUTE_ENV".to_string(),
+            "config-value".to_string(),
+        )]));
+
+        let result = substitute_env_in_string("${TEST_CONFIG_SUBSTITUTE_ENV}").unwrap();
+
+        assert_eq!(result, "config-value");
+        env_guard.unset("TEST_CONFIG_SUBSTITUTE_ENV");
+    }
+
+    #[test]
+    fn test_runtime_env_substitution_rejects_reentrant_config_env_lock() {
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        let _state = lock_config_env_state_for_internal_state();
+
+        let result = substitute_env_in_string("${TEST_CONFIG_SUBSTITUTE_ENV}");
+
+        assert!(matches!(
+            result,
+            Err(ConfigError::ReentrantConfigEnvSubstitution)
+        ));
+    }
+
+    #[test]
+    fn test_config_env_readers_reject_reentrant_lock_without_panic() {
+        let mut env_guard = ScopedEnv::new();
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        env_guard.unset("TEST_REENTRANT_CONFIG_ENV_READ");
+        apply_config_env_for_test(HashMap::from([(
+            "TEST_REENTRANT_CONFIG_ENV_READ".to_string(),
+            "config-value".to_string(),
+        )]));
+
+        let _state = lock_config_env_state_for_internal_state();
+
+        assert_eq!(
+            read_config_env("TEST_REENTRANT_CONFIG_ENV_READ").as_deref(),
+            Some("config-value")
+        );
+        assert_eq!(
+            read_config_env_os("TEST_REENTRANT_CONFIG_ENV_READ").as_deref(),
+            Some(std::ffi::OsStr::new("config-value"))
+        );
+        assert_eq!(
+            read_config_env_os_many(["TEST_REENTRANT_CONFIG_ENV_READ"]),
+            vec![(
+                OsString::from("TEST_REENTRANT_CONFIG_ENV_READ"),
+                OsString::from("config-value")
+            )]
+        );
     }
 
     #[test]
@@ -1563,38 +1813,36 @@ mod tests {
     fn test_snapshot_then_restore_env_state_reverts_config_injected_var() {
         // Test-unique key so we don't fight other env-touching tests.
         const TEST_KEY: &str = "CARAPACE_TEST_ENV_RESTORE_VAR";
-        reset_config_env_state_for_test();
-        std::env::remove_var(TEST_KEY);
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        let mut env_guard = ScopedEnv::new();
+        env_guard.unset(TEST_KEY);
 
         {
-            let mut state = CONFIG_ENV_STATE.lock();
+            let mut state = lock_config_env_state_for_internal_state();
             apply_config_env_vars(
                 &HashMap::from([(TEST_KEY.to_string(), "initial".to_string())]),
                 &mut state,
             );
         }
-        assert_eq!(std::env::var(TEST_KEY).ok(), Some("initial".to_string()));
+        assert_eq!(read_process_env(TEST_KEY), Some("initial".to_string()));
 
         let snapshot = snapshot_env_state();
 
         {
-            let mut state = CONFIG_ENV_STATE.lock();
+            let mut state = lock_config_env_state_for_internal_state();
             apply_config_env_vars(
                 &HashMap::from([(TEST_KEY.to_string(), "bad".to_string())]),
                 &mut state,
             );
         }
-        assert_eq!(std::env::var(TEST_KEY).ok(), Some("bad".to_string()));
+        assert_eq!(read_process_env(TEST_KEY), Some("bad".to_string()));
 
         restore_env_state(&snapshot);
         assert_eq!(
-            std::env::var(TEST_KEY).ok(),
+            read_process_env(TEST_KEY),
             Some("initial".to_string()),
             "restore_env_state must put process env back to the snapshot value"
         );
-
-        reset_config_env_state_for_test();
-        std::env::remove_var(TEST_KEY);
     }
 
     #[test]
@@ -1772,11 +2020,11 @@ mod tests {
         assert_eq!(config["gateway"]["auth"]["token"], "sometoken");
         assert_eq!(config["vertex"]["projectId"], "someproject");
         assert_eq!(
-            env::var("TEST_INCLUDED_GATEWAY_TOKEN").unwrap(),
+            read_process_env("TEST_INCLUDED_GATEWAY_TOKEN").unwrap(),
             "sometoken"
         );
         assert_eq!(
-            env::var("TEST_INCLUDED_VERTEX_PROJECT_ID").unwrap(),
+            read_process_env("TEST_INCLUDED_VERTEX_PROJECT_ID").unwrap(),
             "someproject"
         );
 
@@ -1822,7 +2070,10 @@ mod tests {
         let config = load_config_uncached(&main_path).unwrap();
 
         assert_eq!(config["gateway"]["auth"]["token"], "nested-token");
-        assert_eq!(env::var("TEST_NESTED_ENV_INCLUDE").unwrap(), "nested-token");
+        assert_eq!(
+            read_process_env("TEST_NESTED_ENV_INCLUDE").unwrap(),
+            "nested-token"
+        );
 
         env_guard.unset("TEST_NESTED_ENV_INCLUDE");
         reset_config_env_state_for_test();
@@ -1916,14 +2167,102 @@ mod tests {
         assert_eq!(config["openai"]["apiKey"], "sk-test-from-env-block");
         assert_eq!(config["meta"]["lastVersion"], "enabled");
         assert_eq!(
-            env::var("TEST_API_KEY_FROM_ENV_BLOCK").unwrap(),
+            read_process_env("TEST_API_KEY_FROM_ENV_BLOCK").unwrap(),
             "sk-test-from-env-block"
         );
-        assert_eq!(env::var("TEST_OTHER_FLAG").unwrap(), "enabled");
+        assert_eq!(read_process_env("TEST_OTHER_FLAG").unwrap(), "enabled");
 
         env_guard.unset("TEST_API_KEY_FROM_ENV_BLOCK");
         env_guard.unset("TEST_OTHER_FLAG");
         reset_config_env_state_for_test();
+    }
+
+    #[test]
+    fn test_read_config_env_serializes_active_and_external_values() {
+        let mut env_guard = ScopedEnv::new();
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        env_guard.set("TEST_SERIALIZED_CONFIG_ENV", "external-value");
+
+        assert_eq!(
+            read_config_env("TEST_SERIALIZED_CONFIG_ENV").as_deref(),
+            Some("external-value")
+        );
+
+        let dir = TempDir::new().unwrap();
+        let main_path = create_temp_config(
+            &dir,
+            "config.json5",
+            r#"{
+                "env": {
+                    "vars": {
+                        "TEST_SERIALIZED_CONFIG_ENV": "config-value"
+                    }
+                }
+            }"#,
+        );
+
+        load_config_uncached(&main_path).unwrap();
+        assert_eq!(
+            read_config_env("TEST_SERIALIZED_CONFIG_ENV").as_deref(),
+            Some("config-value")
+        );
+
+        reset_config_env_state_for_test();
+        assert_eq!(
+            read_config_env("TEST_SERIALIZED_CONFIG_ENV").as_deref(),
+            Some("external-value")
+        );
+
+        env_guard.unset("TEST_SERIALIZED_CONFIG_ENV");
+    }
+
+    #[test]
+    fn test_read_config_env_os_many_returns_consistent_snapshot() {
+        let mut env_guard = ScopedEnv::new();
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        env_guard.set("TEST_CONFIG_ENV_MANY_EXTERNAL", "external-value");
+        env_guard.set("TEST_CONFIG_ENV_MANY_SHADOWED", "external-shadow");
+        env_guard.unset("TEST_CONFIG_ENV_MANY_MISSING");
+        apply_config_env_for_test(HashMap::from([(
+            "TEST_CONFIG_ENV_MANY_SHADOWED".to_string(),
+            "config-shadow".to_string(),
+        )]));
+
+        let values = read_config_env_os_many([
+            "TEST_CONFIG_ENV_MANY_SHADOWED",
+            "TEST_CONFIG_ENV_MANY_EXTERNAL",
+            "TEST_CONFIG_ENV_MANY_MISSING",
+        ]);
+
+        assert_eq!(
+            values,
+            vec![
+                (
+                    OsString::from("TEST_CONFIG_ENV_MANY_SHADOWED"),
+                    OsString::from("config-shadow"),
+                ),
+                (
+                    OsString::from("TEST_CONFIG_ENV_MANY_EXTERNAL"),
+                    OsString::from("external-value"),
+                ),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_read_config_env_rejects_non_utf8_process_value() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let mut env_guard = ScopedEnv::new();
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        env_guard.set(
+            "TEST_NON_UTF8_CONFIG_ENV",
+            OsString::from_vec(vec![b'o', 0xff]),
+        );
+
+        assert_eq!(read_config_env("TEST_NON_UTF8_CONFIG_ENV"), None);
+        assert!(read_config_env_os("TEST_NON_UTF8_CONFIG_ENV").is_some());
     }
 
     #[test]
@@ -1956,7 +2295,7 @@ mod tests {
 
         assert_eq!(config["gateway"]["auth"]["token"], "base-token-suffix");
         assert_eq!(
-            env::var("TEST_COMPOSED_TOKEN").unwrap(),
+            read_process_env("TEST_COMPOSED_TOKEN").unwrap(),
             "base-token-suffix"
         );
 
@@ -1998,11 +2337,11 @@ mod tests {
 
         let first = load_config_uncached(&first_path).unwrap();
         assert_eq!(first["meta"]["lastVersion"], "from-config");
-        assert_eq!(env::var("TEST_RELOAD_ENV").unwrap(), "from-config");
+        assert_eq!(read_process_env("TEST_RELOAD_ENV").unwrap(), "from-config");
 
         let second = load_config_uncached(&second_path).unwrap();
         assert_eq!(second["meta"]["lastVersion"], "preexisting");
-        assert_eq!(env::var("TEST_RELOAD_ENV").unwrap(), "preexisting");
+        assert_eq!(read_process_env("TEST_RELOAD_ENV").unwrap(), "preexisting");
 
         env_guard.unset("TEST_RELOAD_ENV");
         reset_config_env_state_for_test();
@@ -2037,7 +2376,7 @@ mod tests {
             Err(ConfigError::MissingEnvVar { var }) if var == "TEST_MISSING_AFTER_INJECTION"
         ));
         assert_eq!(
-            env::var("TEST_FAILED_SUBSTITUTION_ENV").unwrap(),
+            read_process_env("TEST_FAILED_SUBSTITUTION_ENV").unwrap(),
             "preexisting"
         );
 
@@ -2085,7 +2424,7 @@ mod tests {
         let first = load_config_uncached(&working_path).unwrap();
         assert_eq!(first["meta"]["lastVersion"], "from-first-load");
         assert_eq!(
-            env::var("TEST_RELOAD_ROLLBACK_ENV").unwrap(),
+            read_process_env("TEST_RELOAD_ROLLBACK_ENV").unwrap(),
             "from-first-load"
         );
 
@@ -2095,7 +2434,7 @@ mod tests {
             Err(ConfigError::MissingEnvVar { var }) if var == "TEST_RELOAD_ROLLBACK_MISSING"
         ));
         assert_eq!(
-            env::var("TEST_RELOAD_ROLLBACK_ENV").unwrap(),
+            read_process_env("TEST_RELOAD_ROLLBACK_ENV").unwrap(),
             "from-first-load"
         );
 
@@ -2139,7 +2478,10 @@ mod tests {
 
         let first = load_config_uncached(&first_path).unwrap();
         assert_eq!(first["meta"]["lastVersion"], "first-token");
-        assert_eq!(env::var("TEST_STALE_CONFIG_ENV").unwrap(), "first-token");
+        assert_eq!(
+            read_process_env("TEST_STALE_CONFIG_ENV").unwrap(),
+            "first-token"
+        );
 
         let second = load_config_uncached(&second_path);
         assert!(matches!(
@@ -2200,12 +2542,15 @@ mod tests {
 
         let working = load_config_uncached(&working_path).unwrap();
         assert_eq!(working["meta"]["lastVersion"], "from-config");
-        assert_eq!(env::var("TEST_MISSING_CONFIG_ENV").unwrap(), "from-config");
+        assert_eq!(
+            read_process_env("TEST_MISSING_CONFIG_ENV").unwrap(),
+            "from-config"
+        );
 
         let missing_path = dir.path().join("deleted.json5");
         let missing = load_config_uncached(&missing_path).unwrap();
         assert!(missing.is_object());
-        assert!(env::var("TEST_MISSING_CONFIG_ENV").is_err());
+        assert!(read_process_env("TEST_MISSING_CONFIG_ENV").is_none());
 
         reset_config_env_state_for_test();
     }

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -358,10 +358,10 @@ mod hostname {
         }
 
         // Fallback to environment variables
-        if let Some(name) = std::env::var_os("HOSTNAME") {
+        if let Some(name) = crate::config::read_process_env_os("HOSTNAME") {
             return Ok(name);
         }
-        if let Some(name) = std::env::var_os("COMPUTERNAME") {
+        if let Some(name) = crate::config::read_process_env_os("COMPUTERNAME") {
             return Ok(name);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::disallowed_methods)]
+
 //! carapace gateway library
 //!
 //! This library provides the core functionality for the carapace gateway,

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -139,10 +139,10 @@ pub enum LoggingError {
 /// Checks CARAPACE_LOG first, then RUST_LOG, falling back to the default level.
 fn build_env_filter(default_level: Level) -> Result<EnvFilter, LoggingError> {
     // Check CARAPACE_LOG first, then RUST_LOG
-    if let Ok(filter) = std::env::var("CARAPACE_LOG") {
+    if let Some(filter) = crate::config::read_process_env("CARAPACE_LOG") {
         return Ok(EnvFilter::try_new(filter)?);
     }
-    if let Ok(filter) = std::env::var("RUST_LOG") {
+    if let Some(filter) = crate::config::read_process_env("RUST_LOG") {
         return Ok(EnvFilter::try_new(filter)?);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::disallowed_methods)]
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -208,7 +210,7 @@ async fn run_server() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Initialize logging based on the CARAPACE_DEV environment variable.
 fn init_logging_from_env() -> Result<(), Box<dyn std::error::Error>> {
-    let dev_mode = std::env::var("CARAPACE_DEV")
+    let dev_mode = config::read_process_env("CARAPACE_DEV")
         .map(|v| !v.is_empty() && v != "0" && v.to_lowercase() != "false")
         .unwrap_or(false);
     let log_config = if dev_mode {
@@ -311,13 +313,13 @@ fn resolve_signal_config(cfg: &Value) -> Option<SignalConfig> {
         .and_then(|s| s.get("baseUrl"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("SIGNAL_CLI_URL").ok())?;
+        .or_else(|| config::read_config_env("SIGNAL_CLI_URL"))?;
 
     let phone_number = signal_cfg
         .and_then(|s| s.get("phoneNumber"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("SIGNAL_PHONE_NUMBER").ok())?;
+        .or_else(|| config::read_config_env("SIGNAL_PHONE_NUMBER"))?;
 
     Some(SignalConfig {
         base_url,
@@ -343,13 +345,13 @@ fn resolve_telegram_config(cfg: &Value) -> Option<TelegramConfig> {
         .and_then(|s| s.get("botToken"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("TELEGRAM_BOT_TOKEN").ok())?;
+        .or_else(|| config::read_config_env("TELEGRAM_BOT_TOKEN"))?;
 
     let base_url = telegram_cfg
         .and_then(|s| s.get("baseUrl"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("TELEGRAM_BASE_URL").ok())
+        .or_else(|| config::read_config_env("TELEGRAM_BASE_URL"))
         .unwrap_or_else(|| channels::telegram::TELEGRAM_DEFAULT_API_BASE_URL.to_string());
 
     Some(TelegramConfig {
@@ -376,30 +378,26 @@ fn resolve_discord_config(cfg: &Value) -> Option<DiscordConfig> {
         .and_then(|s| s.get("botToken"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("DISCORD_BOT_TOKEN").ok())?;
+        .or_else(|| config::read_config_env("DISCORD_BOT_TOKEN"))?;
 
     let base_url = discord_cfg
         .and_then(|s| s.get("baseUrl"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("DISCORD_BASE_URL").ok())
+        .or_else(|| config::read_config_env("DISCORD_BASE_URL"))
         .unwrap_or_else(|| channels::discord::DISCORD_DEFAULT_API_BASE_URL.to_string());
 
     let gateway_url = discord_cfg
         .and_then(|s| s.get("gatewayUrl"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("DISCORD_GATEWAY_URL").ok())
+        .or_else(|| config::read_config_env("DISCORD_GATEWAY_URL"))
         .unwrap_or_else(|| channels::discord_gateway::DEFAULT_DISCORD_GATEWAY_URL.to_string());
 
     let gateway_intents = discord_cfg
         .and_then(|s| s.get("gatewayIntents"))
         .and_then(|v| v.as_u64())
-        .or_else(|| {
-            std::env::var("DISCORD_GATEWAY_INTENTS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-        })
+        .or_else(|| config::read_config_env("DISCORD_GATEWAY_INTENTS").and_then(|v| v.parse().ok()))
         .unwrap_or(37377);
 
     let gateway_enabled = discord_cfg
@@ -434,13 +432,13 @@ fn resolve_slack_config(cfg: &Value) -> Option<SlackConfig> {
         .and_then(|s| s.get("botToken"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("SLACK_BOT_TOKEN").ok())?;
+        .or_else(|| config::read_config_env("SLACK_BOT_TOKEN"))?;
 
     let base_url = slack_cfg
         .and_then(|s| s.get("baseUrl"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("SLACK_BASE_URL").ok())
+        .or_else(|| config::read_config_env("SLACK_BASE_URL"))
         .unwrap_or_else(|| "https://slack.com/api".to_string());
 
     Some(SlackConfig {

--- a/src/migration/nemoclaw.rs
+++ b/src/migration/nemoclaw.rs
@@ -72,7 +72,7 @@ fn extract_inference_config(config: &Value, plan: &mut ImportPlan) {
     // NemoClaw stores the env var name, not the credential itself.
     // Resolve the actual value from the environment.
     let credential_value = if !credential_env.is_empty() {
-        std::env::var(credential_env).ok().filter(|v| !v.is_empty())
+        crate::config::read_process_env(credential_env).filter(|v| !v.is_empty())
     } else {
         None
     };

--- a/src/migration/openclaw.rs
+++ b/src/migration/openclaw.rs
@@ -23,7 +23,7 @@ pub struct OpenClawDiscovery {
 /// Scan standard locations for an OpenClaw installation.
 pub fn discover() -> Option<OpenClawDiscovery> {
     // Check env override first.
-    if let Ok(path) = std::env::var("OPENCLAW_CONFIG_PATH") {
+    if let Some(path) = crate::config::read_process_env("OPENCLAW_CONFIG_PATH") {
         let config_path = PathBuf::from(path);
         if config_path.is_file() {
             let state_dir = config_path.parent().unwrap_or(Path::new(".")).to_path_buf();
@@ -31,7 +31,7 @@ pub fn discover() -> Option<OpenClawDiscovery> {
         }
     }
 
-    if let Ok(dir) = std::env::var("OPENCLAW_STATE_DIR") {
+    if let Some(dir) = crate::config::read_process_env("OPENCLAW_STATE_DIR") {
         let state_dir = PathBuf::from(dir);
         if let Some(config_path) = find_config_in_dir(&state_dir) {
             return Some(build_discovery(state_dir, config_path));

--- a/src/migration/opencode.rs
+++ b/src/migration/opencode.rs
@@ -23,7 +23,7 @@ pub fn discover() -> Option<OpenCodeDiscovery> {
     }
 
     // XDG config.
-    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+    if let Some(xdg) = crate::config::read_process_env_os("XDG_CONFIG_HOME") {
         let path = Path::new(&xdg).join("opencode").join(".opencode.json");
         if path.is_file() {
             return Some(OpenCodeDiscovery { config_path: path });

--- a/src/onboarding/anthropic.rs
+++ b/src/onboarding/anthropic.rs
@@ -57,8 +57,7 @@ pub fn persist_cli_anthropic_setup_token(
 
 pub fn anthropic_setup_token_api_key_conflict(config: &Value) -> AnthropicSetupTokenApiKeyConflict {
     AnthropicSetupTokenApiKeyConflict {
-        env_api_key_present: std::env::var("ANTHROPIC_API_KEY")
-            .ok()
+        env_api_key_present: crate::config::read_config_env("ANTHROPIC_API_KEY")
             .map(|value| !value.trim().is_empty())
             .unwrap_or(false),
         config_api_key_present: config

--- a/src/onboarding/bedrock.rs
+++ b/src/onboarding/bedrock.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::time::Duration;
 
 use crate::agent::bedrock::{sign_aws_v4_request, AwsCredentials};
@@ -57,7 +56,7 @@ pub struct BedrockCredentialSources {
 pub fn detect_credential_sources() -> BedrockCredentialSources {
     let mut sources = BedrockCredentialSources::default();
 
-    if let Ok(v) = env::var("AWS_REGION") {
+    if let Some(v) = crate::config::read_config_env("AWS_REGION") {
         if !v.is_empty() {
             sources.region = Some(CredentialSource {
                 value: v,
@@ -66,7 +65,7 @@ pub fn detect_credential_sources() -> BedrockCredentialSources {
         }
     }
     if sources.region.is_none() {
-        if let Ok(v) = env::var("AWS_DEFAULT_REGION") {
+        if let Some(v) = crate::config::read_config_env("AWS_DEFAULT_REGION") {
             if !v.is_empty() {
                 sources.region = Some(CredentialSource {
                     value: v,
@@ -76,7 +75,7 @@ pub fn detect_credential_sources() -> BedrockCredentialSources {
         }
     }
 
-    if let Ok(v) = env::var("AWS_ACCESS_KEY_ID") {
+    if let Some(v) = crate::config::read_config_env("AWS_ACCESS_KEY_ID") {
         if !v.is_empty() {
             sources.access_key = Some(CredentialSource {
                 value: v,
@@ -85,7 +84,7 @@ pub fn detect_credential_sources() -> BedrockCredentialSources {
         }
     }
 
-    if let Ok(v) = env::var("AWS_SECRET_ACCESS_KEY") {
+    if let Some(v) = crate::config::read_config_env("AWS_SECRET_ACCESS_KEY") {
         if !v.is_empty() {
             sources.secret_key = Some(CredentialSource {
                 value: v,
@@ -94,7 +93,7 @@ pub fn detect_credential_sources() -> BedrockCredentialSources {
         }
     }
 
-    if let Ok(v) = env::var("AWS_SESSION_TOKEN") {
+    if let Some(v) = crate::config::read_config_env("AWS_SESSION_TOKEN") {
         if !v.is_empty() {
             sources.session_token = Some(CredentialSource {
                 value: v,

--- a/src/onboarding/codex.rs
+++ b/src/onboarding/codex.rs
@@ -76,7 +76,7 @@ pub fn resolve_openai_oauth_provider_config(
     let stored_provider_config = load_stored_openai_provider_config(cfg, state_dir);
 
     let client_id = client_id_override
-        .or_else(|| std::env::var(CODEX_SPEC.client_id_env).ok())
+        .or_else(|| crate::config::read_config_env(CODEX_SPEC.client_id_env))
         .or_else(|| configured_openai_oauth_client_id(cfg))
         .or_else(|| {
             stored_provider_config
@@ -85,7 +85,7 @@ pub fn resolve_openai_oauth_provider_config(
         })
         .unwrap_or_default();
     let client_secret = client_secret_override
-        .or_else(|| std::env::var(CODEX_SPEC.client_secret_env).ok())
+        .or_else(|| crate::config::read_config_env(CODEX_SPEC.client_secret_env))
         .or_else(|| {
             stored_provider_config
                 .as_ref()

--- a/src/onboarding/gemini.rs
+++ b/src/onboarding/gemini.rs
@@ -82,7 +82,7 @@ pub fn resolve_google_oauth_provider_config(
     let stored_provider_config = load_stored_google_provider_config(cfg, state_dir);
 
     let client_id = client_id_override
-        .or_else(|| std::env::var(GEMINI_SPEC.client_id_env).ok())
+        .or_else(|| crate::config::read_config_env(GEMINI_SPEC.client_id_env))
         .or_else(|| configured_google_oauth_client_id(cfg))
         .or_else(|| {
             stored_provider_config
@@ -91,7 +91,7 @@ pub fn resolve_google_oauth_provider_config(
         })
         .unwrap_or_default();
     let client_secret = client_secret_override
-        .or_else(|| std::env::var(GEMINI_SPEC.client_secret_env).ok())
+        .or_else(|| crate::config::read_config_env(GEMINI_SPEC.client_secret_env))
         .or_else(|| {
             stored_provider_config
                 .as_ref()

--- a/src/onboarding/setup.rs
+++ b/src/onboarding/setup.rs
@@ -1375,15 +1375,13 @@ fn load_profile_summary(
 }
 
 fn profile_store_password_present() -> bool {
-    std::env::var("CARAPACE_CONFIG_PASSWORD")
-        .ok()
+    crate::config::read_process_env("CARAPACE_CONFIG_PASSWORD")
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false)
 }
 
 fn env_var_present(key: &str) -> bool {
-    std::env::var(key)
-        .ok()
+    crate::config::read_config_env(key)
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false)
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 pub(crate) fn resolve_state_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("CARAPACE_STATE_DIR") {
+    if let Some(dir) = crate::config::read_process_env("CARAPACE_STATE_DIR") {
         return PathBuf::from(dir);
     }
     dirs::config_dir()

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -196,10 +196,9 @@ pub fn build_http_config(cfg: &Value) -> Result<HttpConfig, String> {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let gateway_token = std::env::var("CARAPACE_GATEWAY_TOKEN").ok().or(cfg_token);
-    let gateway_password = std::env::var("CARAPACE_GATEWAY_PASSWORD")
-        .ok()
-        .or(cfg_password);
+    let gateway_token = crate::config::read_config_env("CARAPACE_GATEWAY_TOKEN").or(cfg_token);
+    let gateway_password =
+        crate::config::read_config_env("CARAPACE_GATEWAY_PASSWORD").or(cfg_password);
     let auth_mode = auth_obj
         .and_then(|a| a.get("mode"))
         .and_then(|v| v.as_str())
@@ -233,8 +232,7 @@ pub fn build_http_config(cfg: &Value) -> Result<HttpConfig, String> {
         }
     };
 
-    let sender_scope_secret = std::env::var("CARAPACE_SERVER_SECRET")
-        .ok()
+    let sender_scope_secret = crate::config::read_config_env("CARAPACE_SERVER_SECRET")
         .filter(|value| !value.is_empty())
         .or_else(|| gateway_token.clone().filter(|value| !value.is_empty()))
         .or_else(|| gateway_password.clone().filter(|value| !value.is_empty()))
@@ -1038,7 +1036,7 @@ fn resolve_slack_signing_secret(cfg: &Value) -> Option<String> {
         .and_then(|s| s.get("signingSecret"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("SLACK_SIGNING_SECRET").ok())
+        .or_else(|| crate::config::read_config_env("SLACK_SIGNING_SECRET"))
 }
 
 // ============================================================================

--- a/src/server/plugin_bootstrap.rs
+++ b/src/server/plugin_bootstrap.rs
@@ -323,8 +323,9 @@ fn resolve_managed_plugin_path(
 
 fn initialize_plugin_engine() -> Result<Arc<PluginEngine>, LoaderError> {
     #[cfg(test)]
-    if let Some(message) = std::env::var_os(TEST_FORCE_PLUGIN_ENGINE_INIT_FAILURE_ENV)
-        .filter(|value| !value.is_empty())
+    if let Some(message) =
+        crate::config::read_process_env_os(TEST_FORCE_PLUGIN_ENGINE_INIT_FAILURE_ENV)
+            .filter(|value| !value.is_empty())
     {
         return Err(LoaderError::EngineError(
             message.to_string_lossy().into_owned(),
@@ -340,8 +341,9 @@ fn initialize_plugin_loader(
     plugin_engine: Arc<PluginEngine>,
 ) -> Result<Arc<PluginLoader>, LoaderError> {
     #[cfg(test)]
-    if let Some(message) = std::env::var_os(TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV)
-        .filter(|value| !value.is_empty())
+    if let Some(message) =
+        crate::config::read_process_env_os(TEST_FORCE_PLUGIN_LOADER_INIT_FAILURE_ENV)
+            .filter(|value| !value.is_empty())
     {
         return Err(LoaderError::EngineError(
             message.to_string_lossy().into_owned(),

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -689,7 +689,7 @@ fn revert_to_last_good(state: &ReloadState) {
         );
     }
     config::restore_env_state(&state.last_good_env);
-    if std::env::var("CARAPACE_DISABLE_CONFIG_CACHE").is_ok() {
+    if crate::config::read_process_env("CARAPACE_DISABLE_CONFIG_CACHE").is_some() {
         warn!(
             "Hot-reload rollback ran with CARAPACE_DISABLE_CONFIG_CACHE=1; \
              on-disk config still reflects the rejected save. Subscribers \
@@ -2116,6 +2116,11 @@ mod tests {
 
     const TEST_PROVIDER_KEY: &str = "ANTHROPIC_API_KEY";
 
+    fn install_reloaded_config_without_provider_env(env: &mut ScopedEnv) {
+        crate::config::apply_config_env_for_test(HashMap::new());
+        env.unset(TEST_PROVIDER_KEY);
+    }
+
     #[test]
     fn handle_provider_reload_reverts_when_new_config_has_no_provider() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
@@ -2127,8 +2132,7 @@ mod tests {
             .map(|(r, n)| (r.clone(), n.clone()))
             .expect("fixture installs last_good_cache");
 
-        crate::config::apply_config_env_for_test(HashMap::new());
-        env.unset(TEST_PROVIDER_KEY);
+        install_reloaded_config_without_provider_env(&mut env);
         let new_raw = json!({ "marker": "raw-new", "agents": { "defaults": { "route": "fast" } } });
         let new_normalized =
             json!({ "marker": "normalized-new", "agents": { "defaults": { "route": "fast" } } });
@@ -2149,7 +2153,7 @@ mod tests {
         assert!(Arc::ptr_eq(normalized_after_state, &prior_normalized));
         assert_eq!(state.current_fingerprint, prior_fingerprint);
         assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
+            crate::config::read_process_env(TEST_PROVIDER_KEY),
             Some("test-initial-key".to_string()),
             "rollback must restore the env-injected provider var"
         );
@@ -2183,7 +2187,7 @@ mod tests {
         // not the initial one — pins last_good_env advancement on swap.
         crate::config::restore_env_state(&state.last_good_env);
         assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
+            crate::config::read_process_env(TEST_PROVIDER_KEY),
             Some("test-rotated-key".to_string()),
         );
     }
@@ -2226,7 +2230,7 @@ mod tests {
         // the probe.
         crate::config::restore_env_state(&state.last_good_env);
         assert_eq!(
-            std::env::var(PROBE_VAR).ok(),
+            crate::config::read_process_env(PROBE_VAR),
             Some("probe-value".to_string())
         );
         // Explicit cleanup is unnecessary: ScopedEnvStateForTest's Drop
@@ -2311,8 +2315,7 @@ mod tests {
         let counter_before = *rx.borrow_and_update();
 
         // Watcher's first tick: bad config installed in cache.
-        crate::config::apply_config_env_for_test(HashMap::new());
-        env.unset(TEST_PROVIDER_KEY);
+        install_reloaded_config_without_provider_env(&mut env);
         let bad_raw = json!({ "marker": "bad-raw" });
         let bad_normalized = json!({ "marker": "bad-normalized" });
         crate::config::update_cache(bad_raw, bad_normalized);
@@ -2360,7 +2363,7 @@ mod tests {
         // `CARAPACE_CONFIG_PASSWORD` is unset (the default in test envs).
         // The `/nonexistent` path itself is never read — the guard fires
         // before the profile-store lookup.
-        env.unset(TEST_PROVIDER_KEY);
+        install_reloaded_config_without_provider_env(&mut env);
         env.unset("CARAPACE_CONFIG_PASSWORD");
         let new_raw = json!({
             "anthropic": { "authProfile": "/nonexistent/path/that/does/not/resolve" }
@@ -2388,7 +2391,7 @@ mod tests {
         assert_eq!(*normalized_after, *prior_normalized);
         assert_eq!(state.current_fingerprint, prior_fingerprint);
         assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
+            crate::config::read_process_env(TEST_PROVIDER_KEY),
             Some("test-initial-key".to_string()),
             "rollback must restore the env-injected provider var on the Err arm too"
         );
@@ -2456,7 +2459,7 @@ mod tests {
         assert!(Arc::ptr_eq(cache_raw, &prior_raw));
         assert!(Arc::ptr_eq(cache_normalized, &prior_normalized));
         assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
+            crate::config::read_process_env(TEST_PROVIDER_KEY),
             Some("test-initial-key".to_string()),
             "rollback must restore env on the load-failure arm too"
         );
@@ -2502,7 +2505,7 @@ mod tests {
 
         // Env restoration works regardless of cache mode.
         assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
+            crate::config::read_process_env(TEST_PROVIDER_KEY),
             Some("test-initial-key".to_string()),
             "env restoration must work in disabled-cache mode"
         );
@@ -2566,7 +2569,7 @@ mod tests {
         let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
         assert_eq!(*raw_after, bad_raw);
         assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
+            crate::config::read_process_env(TEST_PROVIDER_KEY),
             Some("test-initial-key".to_string()),
             "degraded path must still restore env"
         );

--- a/src/server/ws/handlers/tts.rs
+++ b/src/server/ws/handlers/tts.rs
@@ -169,7 +169,7 @@ fn resolve_openai_api_key() -> Option<String> {
     }
 
     // Fall back to environment variable
-    env::var("OPENAI_API_KEY").ok().filter(|k| !k.is_empty())
+    config::read_config_env("OPENAI_API_KEY").filter(|k| !k.is_empty())
 }
 
 /// Validate and normalise the requested audio format.
@@ -498,6 +498,8 @@ pub(super) async fn handle_tts_speak(params: Option<&Value>) -> Result<Value, Er
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ScopedEnvStateForTest;
+    use crate::test_support::env::ScopedEnv;
     use std::sync::Mutex;
 
     /// Mutex to serialize tests that modify global state
@@ -592,7 +594,9 @@ mod tests {
         handle_tts_set_provider(Some(&params)).unwrap();
 
         // Ensure no OPENAI_API_KEY is set for this test
-        env::remove_var("OPENAI_API_KEY");
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        let mut env_guard = ScopedEnv::new();
+        env_guard.unset("OPENAI_API_KEY");
 
         let params = json!({ "text": "Hello from OpenAI" });
         let result = handle_tts_convert(Some(&params)).await;
@@ -803,7 +807,9 @@ mod tests {
         handle_tts_enable().unwrap();
         let p = json!({ "provider": "openai" });
         handle_tts_set_provider(Some(&p)).unwrap();
-        env::remove_var("OPENAI_API_KEY");
+        let _env_state_guard = ScopedEnvStateForTest::new();
+        let mut env_guard = ScopedEnv::new();
+        env_guard.unset("OPENAI_API_KEY");
 
         let params = json!({ "text": "Test speech" });
         let result = handle_tts_speak(Some(&params)).await;

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
-use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1238,7 +1237,7 @@ pub async fn build_ws_state_owned_from_value(cfg: &Value) -> Result<WsServerStat
     let encryption_config = sessions::resolve_session_encryption_config(cfg);
     let fallback_integrity_secret = resolve_session_integrity_secret(
         &state.config.auth.resolved,
-        std::env::var("CARAPACE_SERVER_SECRET").ok(),
+        config::read_config_env("CARAPACE_SERVER_SECRET"),
     );
     let encryption_password_present = crate::config::config_password().is_some();
     let session_store = sessions::configured_store_with_path(
@@ -1375,8 +1374,8 @@ async fn resolve_gateway_auth_config(
         .and_then(|v| v.as_str())
         .unwrap_or("off");
 
-    let env_token = env::var("CARAPACE_GATEWAY_TOKEN").ok();
-    let env_password = env::var("CARAPACE_GATEWAY_PASSWORD").ok();
+    let env_token = config::read_config_env("CARAPACE_GATEWAY_TOKEN");
+    let env_password = config::read_config_env("CARAPACE_GATEWAY_PASSWORD");
 
     let state_dir = resolve_state_dir();
     let mut creds = credentials::read_gateway_auth(state_dir).await?;
@@ -3196,17 +3195,17 @@ fn now_ms() -> u64 {
 }
 
 fn server_version() -> String {
-    std::env::var("CARAPACE_VERSION")
-        .or_else(|_| std::env::var("npm_package_version"))
-        .unwrap_or_else(|_| "dev".to_string())
+    config::read_process_env("CARAPACE_VERSION")
+        .or_else(|| config::read_process_env("npm_package_version"))
+        .unwrap_or_else(|| "dev".to_string())
 }
 
 fn server_commit() -> Option<String> {
-    std::env::var("GIT_COMMIT").ok()
+    config::read_process_env("GIT_COMMIT")
 }
 
 fn server_hostname() -> String {
-    std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string())
+    config::read_process_env("HOSTNAME").unwrap_or_else(|| "unknown".to_string())
 }
 
 enum InboundText {

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -64,20 +64,17 @@ pub(crate) fn resolve_session_integrity_secret_from_value(
     cfg: &serde_json::Value,
     fallback_secret: Option<(String, &'static str)>,
 ) -> Option<(String, &'static str)> {
-    if let Some(secret) = std::env::var("CARAPACE_SERVER_SECRET")
-        .ok()
-        .filter(|value| !value.is_empty())
+    if let Some(secret) =
+        crate::config::read_config_env("CARAPACE_SERVER_SECRET").filter(|value| !value.is_empty())
     {
         return Some((secret, "CARAPACE_SERVER_SECRET"));
     }
-    if let Some(secret) = std::env::var("CARAPACE_GATEWAY_TOKEN")
-        .ok()
-        .filter(|value| !value.is_empty())
+    if let Some(secret) =
+        crate::config::read_config_env("CARAPACE_GATEWAY_TOKEN").filter(|value| !value.is_empty())
     {
         return Some((secret, "CARAPACE_GATEWAY_TOKEN"));
     }
-    if let Some(secret) = std::env::var("CARAPACE_GATEWAY_PASSWORD")
-        .ok()
+    if let Some(secret) = crate::config::read_config_env("CARAPACE_GATEWAY_PASSWORD")
         .filter(|value| !value.is_empty())
     {
         return Some((secret, "CARAPACE_GATEWAY_PASSWORD"));

--- a/src/test_support/env.rs
+++ b/src/test_support/env.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::disallowed_methods,
+    reason = "ScopedEnv is the designated raw process-env mutation harness for tests"
+)]
+
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Default path for usage data storage
 fn default_usage_path() -> PathBuf {
-    if let Ok(dir) = std::env::var("CARAPACE_STATE_DIR") {
+    if let Some(dir) = crate::config::read_process_env("CARAPACE_STATE_DIR") {
         return PathBuf::from(dir).join("usage.json");
     }
     dirs::config_dir()


### PR DESCRIPTION
## Summary

- add `config::read_config_env` / `read_config_env_os` so runtime reads of `config.env`-injectable values share `CONFIG_ENV_STATE` locking
- migrate provider, channel, gateway auth, setup/onboarding, sandbox forwarding, and TTS env reads away from direct `std::env::var`
- document the policy in `CONTRIBUTING.md`

Fixes #415.

## Validation

- `scripts/cargo-serial nextest run -p carapace --filter-expr 'test(config_env) | test(provider) | test(fingerprint) | test(setup) | test(gateway_auth) | test(channel_bot_token) | test(hooks_token)'`
- `scripts/cargo-serial clippy --all-targets -- -D warnings`
