### PR TITLE
fix: bridge owns cache write so failed reloads produce zero ticks (closes #418, #422)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -974,7 +974,7 @@ pub fn reload_config() -> Result<(Value, Vec<ValidationIssue>), ConfigError> {
 /// Result of a cache-less config load: the raw and normalized halves plus
 /// any validation issues. Both halves come from the same load generation —
 /// the caller decides whether (and when) to install via [`update_cache_arc`].
-pub struct PendingConfig {
+pub(crate) struct PendingConfig {
     pub raw: Arc<Value>,
     pub normalized: Arc<Value>,
     pub issues: Vec<ValidationIssue>,
@@ -992,7 +992,7 @@ pub struct PendingConfig {
 /// for provider validation; on a rejected reload the bridge can simply drop
 /// the returned `PendingConfig` and `CONFIG_CACHE` stays at the last
 /// committed value.
-pub fn load_pending_config() -> Result<PendingConfig, ConfigError> {
+pub(crate) fn load_pending_config() -> Result<PendingConfig, ConfigError> {
     let path = get_config_path();
     let cached = load_cached_config_uncached(&path)?;
     let issues = validate_config(&cached.value);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -319,16 +319,6 @@ pub(crate) fn load_raw_config_shared() -> Result<Arc<Value>, ConfigError> {
     with_cached_config(|cached| Arc::clone(&cached.raw_value))
 }
 
-/// Load a consistent `(raw, normalized)` pair from the same cache
-/// generation. On the cache-hit path this is a single `CONFIG_CACHE` read
-/// lock; on the cache-miss path both halves come from the same
-/// `CachedConfig` produced by `load_cached_config_uncached`. The hot-reload
-/// bridge relies on raw and normalized describing the same underlying
-/// snapshot, never two different generations.
-pub(crate) fn load_both_config_shared() -> Result<(Arc<Value>, Arc<Value>), ConfigError> {
-    with_cached_config(|cached| (Arc::clone(&cached.raw_value), Arc::clone(&cached.value)))
-}
-
 /// Run `project` against the current cached config, refreshing from disk
 /// if the cache is empty / TTL-expired / cache-disabled. Centralizes the
 /// TTL guard + cache-miss + `maybe_store_cached_config` path so policy
@@ -941,27 +931,19 @@ pub(crate) fn update_cache_for_test_with_age(raw_value: Value, value: Value, age
 
 /// Subscribe to in-process config-change notifications.
 ///
-/// Subscribers wake on any cache update via [`update_cache`] /
+/// Subscribers wake on cache updates via [`update_cache`] /
 /// [`update_cache_arc`] and should re-read the cache via
 /// [`load_config_shared`] / [`load_raw_config_shared`] on each tick.
 ///
-/// # Idempotency contract
-/// On a hot-reload that the watcher commits but the bridge subsequently
-/// rolls back (no LLM provider in the new config, or `build_providers`
-/// failed), this channel fires twice in quick succession: once with the
-/// rejected cache value and once with the rolled-back value. The
-/// `tokio::sync::watch` coalesces missed wakeups to the latest value, so
-/// a subscriber that wasn't already in `changed().await` sees only the
-/// rolled-back state. A subscriber whose `changed().await` was already
-/// pending when the first tick arrived **will** observe the rejected
-/// state once before the rollback tick wakes it again.
+/// The hot-reload bridge installs the cache only on validated reloads, so
+/// each tick corresponds to a successfully-validated config snapshot:
+/// rejected reloads (no provider, build failure, parse error) produce zero
+/// ticks. Subscribers can therefore re-read the cache without needing to
+/// tolerate a transient bad-state read.
 ///
-/// **Subscribers must therefore be idempotent and tolerant of a one-tick
-/// transient bad-state read** — typically by re-reading the cache on each
-/// tick rather than caching values across ticks, and by avoiding
-/// non-idempotent side effects (network calls, file writes, etc.) keyed
-/// off a single tick. The structural fix that removes this requirement
-/// is tracked in puremachinery/carapace#418.
+/// The disk-fallback path in `with_cached_config` (cache-miss / TTL-expired
+/// reads of the config file) writes silently — it does not broadcast — so
+/// subscribers see only validated reload events.
 pub fn subscribe_config_changes() -> tokio::sync::watch::Receiver<u64> {
     CONFIG_CHANGE_TX.subscribe()
 }
@@ -971,19 +953,54 @@ fn broadcast_config_change() {
     let _ = CONFIG_CHANGE_TX.send(next);
 }
 
-/// Reload the config from disk, validate it, and update the cache atomically.
+/// Reload the config from disk, validate it, and install it in `CONFIG_CACHE`.
 ///
 /// Returns the new config on success or a `ConfigError` if the file cannot be
 /// read or parsed. Validation warnings are returned alongside the config; only
 /// hard parse/read errors cause an `Err`.
+///
+/// Prefer [`load_pending_config`] when the caller wants to validate the
+/// reloaded payload (e.g. against provider invariants in the hot-reload
+/// bridge) **before** committing it. `reload_config` always commits, so any
+/// validation it skips happens too late to suppress the resulting cache
+/// broadcast.
 pub fn reload_config() -> Result<(Value, Vec<ValidationIssue>), ConfigError> {
+    let pending = load_pending_config()?;
+    let new_config = pending.normalized.as_ref().clone();
+    update_cache_arc(pending.raw, pending.normalized);
+    Ok((new_config, pending.issues))
+}
+
+/// Result of a cache-less config load: the raw and normalized halves plus
+/// any validation issues. Both halves come from the same load generation —
+/// the caller decides whether (and when) to install via [`update_cache_arc`].
+pub struct PendingConfig {
+    pub raw: Arc<Value>,
+    pub normalized: Arc<Value>,
+    pub issues: Vec<ValidationIssue>,
+}
+
+/// Read the config from disk without touching `CONFIG_CACHE`.
+///
+/// Includes are resolved and env vars are substituted as part of the load
+/// (the substitution requires injecting config-provided env vars into the
+/// process, so this side-effect happens here regardless of whether the
+/// caller commits the result). Subscribers of [`subscribe_config_changes`]
+/// are NOT notified — only [`update_cache`] / [`update_cache_arc`] broadcast.
+///
+/// Used by the hot-reload bridge to obtain the new `(raw, normalized)` pair
+/// for provider validation; on a rejected reload the bridge can simply drop
+/// the returned `PendingConfig` and `CONFIG_CACHE` stays at the last
+/// committed value.
+pub fn load_pending_config() -> Result<PendingConfig, ConfigError> {
     let path = get_config_path();
     let cached = load_cached_config_uncached(&path)?;
-    let new_config = cached.value.as_ref().clone();
-    let issues = validate_config(&new_config);
-    // Update the cache with the freshly loaded config
-    update_cache(cached.raw_value.as_ref().clone(), new_config.clone());
-    Ok((new_config, issues))
+    let issues = validate_config(&cached.value);
+    Ok(PendingConfig {
+        raw: cached.raw_value,
+        normalized: cached.value,
+        issues,
+    })
 }
 
 /// Validation error with path context

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1240,16 +1240,25 @@ pub(crate) struct PendingConfig {
 
 /// Read the config from disk without touching `CONFIG_CACHE`.
 ///
-/// Includes are resolved and env vars are substituted as part of the load
-/// (the substitution requires injecting config-provided env vars into the
-/// process, so this side-effect happens here regardless of whether the
-/// caller commits the result). Subscribers of [`subscribe_config_changes`]
-/// are NOT notified — only [`update_cache`] / [`update_cache_arc`] broadcast.
+/// **SIDE EFFECT — process env mutation.** The loader injects config-provided
+/// env vars (`gateway.env.vars`) into the running process so `${VAR}`
+/// substitution can resolve them. The injection happens **before** the
+/// caller has a chance to validate the result (e.g. against provider
+/// invariants). Callers that may reject the load (the hot-reload bridge,
+/// SIGHUP) MUST snapshot env state before calling this and then either
+///   - commit by accepting the load (env stays mutated, cache gets the new
+///     payload via [`update_cache_arc`]), or
+///   - reject by calling `restore_env_state` / `revert_pending_env` to
+///     undo the env mutation alongside *not* writing the cache.
 ///
-/// Used by the hot-reload bridge to obtain the new `(raw, normalized)` pair
-/// for provider validation; on a rejected reload the bridge can simply drop
-/// the returned `PendingConfig` and `CONFIG_CACHE` stays at the last
-/// committed value.
+/// Until the caller resolves that fork, concurrent tasks observing process
+/// env see the not-yet-validated values. The bridge yields at the
+/// `spawn_blocking` `.await` inside `handle_provider_reload`, so other
+/// tasks scheduled on the runtime can read the partially-mutated env in
+/// that window.
+///
+/// Subscribers of [`subscribe_config_changes`] are NOT notified by this
+/// call — only [`update_cache`] / [`update_cache_arc`] broadcast.
 pub(crate) fn load_pending_config() -> Result<PendingConfig, ConfigError> {
     let path = get_config_path();
     let cached = load_cached_config_uncached(&path)?;

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -220,6 +220,11 @@ pub(crate) fn mode_label(mode: &ReloadMode) -> &'static str {
     }
 }
 
+/// **SIDE EFFECT — env mutation, see [`super::load_pending_config`].**
+/// Callers must snapshot env before invoking and either commit by writing
+/// the resulting `payload` to the cache, or revert env via
+/// `restore_env_state` on rejection.
+///
 /// Wrap the result of [`super::load_pending_config`] into a typed
 /// `ConfigEvent`, preserving the raw + normalized Arcs in the success
 /// variant so the bridge can install them later without re-reading anything.

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -11,6 +11,7 @@
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::Value;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::task;
@@ -49,9 +50,14 @@ impl ReloadMode {
 }
 
 /// Result of a config reload attempt.
+///
+/// On success, `payload` carries the validated `(raw, normalized)` Arcs. The
+/// hot-reload bridge consumes them directly rather than re-reading from
+/// `CONFIG_CACHE`, so a rejected reload never has to roll the cache back
+/// (the cache is only written by the bridge after validation).
 #[derive(Debug, Clone)]
 pub struct ReloadResult {
-    /// Whether the reload succeeded.
+    /// Whether the reload succeeded (parse + schema-level validation).
     pub success: bool,
     /// The reload mode that was applied.
     pub mode: String,
@@ -59,6 +65,17 @@ pub struct ReloadResult {
     pub warnings: Vec<String>,
     /// Error message if the reload failed.
     pub error: Option<String>,
+    /// On success, the loaded `(raw, normalized)` payload. `None` on failure.
+    pub payload: Option<ReloadPayload>,
+}
+
+/// The validated raw + normalized config pair carried with a successful
+/// `ReloadResult`. `Arc` so cloning the broadcast event is a cheap refcount
+/// bump.
+#[derive(Debug, Clone)]
+pub struct ReloadPayload {
+    pub raw: Arc<Value>,
+    pub normalized: Arc<Value>,
 }
 
 /// Notification sent when config changes are detected and applied.
@@ -172,17 +189,21 @@ fn mode_label(mode: &ReloadMode) -> &'static str {
     }
 }
 
-/// Validate the reloaded configuration, apply it, and build a `ReloadResult`.
+/// Wrap the result of [`super::load_pending_config`] into a `ReloadResult`,
+/// preserving the raw + normalized Arcs in the success payload so the bridge
+/// can install them later without re-reading anything.
 ///
-/// Called by `perform_reload` after `super::reload_config()` returns.
+/// Called by `perform_reload` / `perform_reload_async`. The cache is **not**
+/// touched here — the bridge owns the install on its `Apply` arm.
 fn process_config_reload_event(
     mode: &ReloadMode,
-    outcome: Result<(serde_json::Value, Vec<super::ValidationIssue>), super::ConfigError>,
+    outcome: Result<super::PendingConfig, super::ConfigError>,
 ) -> ReloadResult {
     let mode_str = mode_label(mode);
     match outcome {
-        Ok((_config, issues)) => {
-            let warnings: Vec<String> = issues
+        Ok(pending) => {
+            let warnings: Vec<String> = pending
+                .issues
                 .iter()
                 .map(|i| format!("{}: {}", i.path, i.message))
                 .collect();
@@ -204,6 +225,10 @@ fn process_config_reload_event(
                 mode: mode_str.to_string(),
                 warnings,
                 error: None,
+                payload: Some(ReloadPayload {
+                    raw: pending.raw,
+                    normalized: pending.normalized,
+                }),
             }
         }
         Err(e) => {
@@ -218,25 +243,27 @@ fn process_config_reload_event(
                 mode: mode_str.to_string(),
                 warnings: Vec::new(),
                 error: Some(error_msg),
+                payload: None,
             }
         }
     }
 }
 
-/// Perform a config reload (parse, validate, update cache).
+/// Perform a config reload (parse, validate, return payload — does **not**
+/// install the cache; the bridge owns that step).
 ///
-/// This is the core reload logic shared by the file watcher, SIGHUP handler,
-/// and the `config.reload` WS method.
+/// Shared by the file watcher, the SIGHUP handler, and the `config.reload`
+/// WS method.
 pub fn perform_reload(mode: &ReloadMode) -> ReloadResult {
     info!("Config reload triggered (mode={:?})", mode);
-    let outcome = super::reload_config();
+    let outcome = super::load_pending_config();
     process_config_reload_event(mode, outcome)
 }
 
 /// Perform a config reload on a blocking thread to avoid stalling async tasks.
 pub async fn perform_reload_async(mode: &ReloadMode) -> ReloadResult {
     info!("Config reload triggered (mode={:?})", mode);
-    let outcome = task::spawn_blocking(super::reload_config).await;
+    let outcome = task::spawn_blocking(super::load_pending_config).await;
     match outcome {
         Ok(result) => process_config_reload_event(mode, result),
         Err(err) => {
@@ -247,6 +274,7 @@ pub async fn perform_reload_async(mode: &ReloadMode) -> ReloadResult {
                 mode: mode_label(mode).to_string(),
                 warnings: Vec::new(),
                 error: Some(error_msg),
+                payload: None,
             }
         }
     }
@@ -577,6 +605,7 @@ mod tests {
             mode: "hot".to_string(),
             warnings: Vec::new(),
             error: None,
+            payload: None,
         };
         watcher
             .event_sender()

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -599,13 +599,17 @@ mod tests {
         let watcher = ConfigWatcher::from_config(&config);
         let mut rx = watcher.subscribe();
 
-        // Manually send an event
+        // Manually send an event. `success: true` requires `payload: Some`;
+        // a minimal one is fine since the test only verifies fan-out.
         let result = ReloadResult {
             success: true,
             mode: "hot".to_string(),
             warnings: Vec::new(),
             error: None,
-            payload: None,
+            payload: Some(ReloadPayload {
+                raw: Arc::new(serde_json::json!({})),
+                normalized: Arc::new(serde_json::json!({})),
+            }),
         };
         watcher
             .event_sender()

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -191,7 +191,28 @@ impl ConfigWatcher {
 }
 
 /// Convert a `ReloadMode` to its string label.
-fn mode_label(mode: &ReloadMode) -> &'static str {
+/// Resolve the reload mode for a manual reload (SIGHUP, WS `config.reload`).
+/// Reads `gateway.reload.mode` from `CONFIG_CACHE` via `Arc` projection (no
+/// deep clone) and falls back to `Hot` when the operator hasn't configured
+/// reloads — manual reloads always do at least a hot reload.
+pub(crate) fn manual_reload_mode() -> ReloadMode {
+    let configured = super::load_config_shared()
+        .ok()
+        .and_then(|cfg| {
+            cfg.get("gateway")
+                .and_then(|g| g.get("reload"))
+                .and_then(|r| r.get("mode"))
+                .and_then(|m| m.as_str())
+                .map(ReloadMode::parse_mode)
+        })
+        .unwrap_or(ReloadMode::Hot);
+    match configured {
+        ReloadMode::Off => ReloadMode::Hot,
+        other => other,
+    }
+}
+
+pub(crate) fn mode_label(mode: &ReloadMode) -> &'static str {
     match mode {
         ReloadMode::Hot => "hot",
         ReloadMode::Hybrid => "hybrid",

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -49,42 +49,52 @@ impl ReloadMode {
     }
 }
 
-/// Result of a config reload attempt.
-///
-/// On success, `payload` carries the validated `(raw, normalized)` Arcs. The
-/// hot-reload bridge consumes them directly rather than re-reading from
-/// `CONFIG_CACHE`, so a rejected reload never has to roll the cache back
-/// (the cache is only written by the bridge after validation).
-#[derive(Debug, Clone)]
-pub struct ReloadResult {
-    /// Whether the reload succeeded (parse + schema-level validation).
-    pub success: bool,
-    /// The reload mode that was applied.
-    pub mode: String,
-    /// Validation warnings (non-fatal).
-    pub warnings: Vec<String>,
-    /// Error message if the reload failed.
-    pub error: Option<String>,
-    /// On success, the loaded `(raw, normalized)` payload. `None` on failure.
-    pub payload: Option<ReloadPayload>,
-}
-
 /// The validated raw + normalized config pair carried with a successful
-/// `ReloadResult`. `Arc` so cloning the broadcast event is a cheap refcount
-/// bump.
+/// reload. `Arc` so cloning the broadcast event is a cheap refcount bump.
 #[derive(Debug, Clone)]
 pub struct ReloadPayload {
     pub raw: Arc<Value>,
     pub normalized: Arc<Value>,
 }
 
+/// Outcome of a successful config reload.
+///
+/// `payload` is **not** `Option` — successful reloads always carry the
+/// validated `(raw, normalized)` Arcs. The hot-reload bridge consumes them
+/// directly rather than re-reading from `CONFIG_CACHE`, so a rejected reload
+/// never has to roll the cache back (the cache is only written by the bridge
+/// after validation).
+#[derive(Debug, Clone)]
+pub struct SuccessfulReload {
+    /// The reload mode that was applied.
+    pub mode: String,
+    /// Validation warnings (non-fatal).
+    pub warnings: Vec<String>,
+    /// Validated `(raw, normalized)` payload from the loader.
+    pub payload: ReloadPayload,
+}
+
+/// Outcome of a failed config reload.
+#[derive(Debug, Clone)]
+pub struct FailedReload {
+    /// The reload mode that was attempted.
+    pub mode: String,
+    /// Error message describing why the reload failed.
+    pub error: String,
+}
+
 /// Notification sent when config changes are detected and applied.
+///
+/// The two variants are typed differently: `Reloaded` always carries a
+/// payload (invariant guaranteed by the type), `ReloadFailed` always carries
+/// an error. Consumers do not need runtime guards for missing-payload-on-
+/// success or missing-error-on-failure states — those are unrepresentable.
 #[derive(Debug, Clone)]
 pub enum ConfigEvent {
     /// Config was successfully reloaded.
-    Reloaded(ReloadResult),
+    Reloaded(SuccessfulReload),
     /// Config reload failed (invalid config, parse error, etc.).
-    ReloadFailed(ReloadResult),
+    ReloadFailed(FailedReload),
 }
 
 /// Config watcher that monitors the config file and reloads on changes.
@@ -189,16 +199,16 @@ fn mode_label(mode: &ReloadMode) -> &'static str {
     }
 }
 
-/// Wrap the result of [`super::load_pending_config`] into a `ReloadResult`,
-/// preserving the raw + normalized Arcs in the success payload so the bridge
-/// can install them later without re-reading anything.
+/// Wrap the result of [`super::load_pending_config`] into a typed
+/// `ConfigEvent`, preserving the raw + normalized Arcs in the success
+/// variant so the bridge can install them later without re-reading anything.
 ///
 /// Called by `perform_reload` / `perform_reload_async`. The cache is **not**
 /// touched here — the bridge owns the install on its `Apply` arm.
 fn process_config_reload_event(
     mode: &ReloadMode,
     outcome: Result<super::PendingConfig, super::ConfigError>,
-) -> ReloadResult {
+) -> ConfigEvent {
     let mode_str = mode_label(mode);
     match outcome {
         Ok(pending) => {
@@ -220,16 +230,14 @@ fn process_config_reload_event(
                 warnings.len()
             );
 
-            ReloadResult {
-                success: true,
+            ConfigEvent::Reloaded(SuccessfulReload {
                 mode: mode_str.to_string(),
                 warnings,
-                error: None,
-                payload: Some(ReloadPayload {
+                payload: ReloadPayload {
                     raw: pending.raw,
                     normalized: pending.normalized,
-                }),
-            }
+                },
+            })
         }
         Err(e) => {
             let error_msg = e.to_string();
@@ -238,30 +246,28 @@ fn process_config_reload_event(
                 error_msg
             );
 
-            ReloadResult {
-                success: false,
+            ConfigEvent::ReloadFailed(FailedReload {
                 mode: mode_str.to_string(),
-                warnings: Vec::new(),
-                error: Some(error_msg),
-                payload: None,
-            }
+                error: error_msg,
+            })
         }
     }
 }
 
-/// Perform a config reload (parse, validate, return payload — does **not**
+/// Perform a config reload (parse, validate, return event — does **not**
 /// install the cache; the bridge owns that step).
 ///
 /// Shared by the file watcher, the SIGHUP handler, and the `config.reload`
-/// WS method.
-pub fn perform_reload(mode: &ReloadMode) -> ReloadResult {
+/// WS method. The returned `ConfigEvent` is the right variant for the
+/// outcome — callers can broadcast it directly without a `success` check.
+pub fn perform_reload(mode: &ReloadMode) -> ConfigEvent {
     info!("Config reload triggered (mode={:?})", mode);
     let outcome = super::load_pending_config();
     process_config_reload_event(mode, outcome)
 }
 
 /// Perform a config reload on a blocking thread to avoid stalling async tasks.
-pub async fn perform_reload_async(mode: &ReloadMode) -> ReloadResult {
+pub async fn perform_reload_async(mode: &ReloadMode) -> ConfigEvent {
     info!("Config reload triggered (mode={:?})", mode);
     let outcome = task::spawn_blocking(super::load_pending_config).await;
     match outcome {
@@ -269,13 +275,10 @@ pub async fn perform_reload_async(mode: &ReloadMode) -> ReloadResult {
         Err(err) => {
             let error_msg = format!("Config reload task failed: {err}");
             error!("{error_msg}");
-            ReloadResult {
-                success: false,
+            ConfigEvent::ReloadFailed(FailedReload {
                 mode: mode_label(mode).to_string(),
-                warnings: Vec::new(),
-                error: Some(error_msg),
-                payload: None,
-            }
+                error: error_msg,
+            })
         }
     }
 }
@@ -367,12 +370,7 @@ async fn execute_reload_and_broadcast(
     mode: &ReloadMode,
     event_tx: &tokio::sync::broadcast::Sender<ConfigEvent>,
 ) {
-    let result = perform_reload_async(mode).await;
-    let event = if result.success {
-        ConfigEvent::Reloaded(result)
-    } else {
-        ConfigEvent::ReloadFailed(result)
-    };
+    let event = perform_reload_async(mode).await;
     // Broadcast to subscribers (ignore send errors if no receivers)
     let _ = event_tx.send(event);
 }
@@ -534,11 +532,17 @@ mod tests {
 
         // When no config file exists, reload should succeed with defaults
         // (load_config_uncached returns defaults for missing files)
-        let result = perform_reload(&ReloadMode::Hot);
+        let event = perform_reload(&ReloadMode::Hot);
         // This should succeed since load_config_uncached returns defaults
         // for non-existent files
-        assert!(result.success);
-        assert_eq!(result.mode, "hot");
+        match event {
+            ConfigEvent::Reloaded(success) => {
+                assert_eq!(success.mode, "hot");
+            }
+            ConfigEvent::ReloadFailed(failure) => {
+                panic!("expected Reloaded, got ReloadFailed: {}", failure.error);
+            }
+        }
 
         crate::config::clear_cache();
     }
@@ -599,28 +603,26 @@ mod tests {
         let watcher = ConfigWatcher::from_config(&config);
         let mut rx = watcher.subscribe();
 
-        // Manually send an event. `success: true` requires `payload: Some`;
-        // a minimal one is fine since the test only verifies fan-out.
-        let result = ReloadResult {
-            success: true,
+        // Manually send a `Reloaded` event. The struct invariant guarantees
+        // a payload is present; a minimal one is fine since the test only
+        // verifies fan-out.
+        let success = SuccessfulReload {
             mode: "hot".to_string(),
             warnings: Vec::new(),
-            error: None,
-            payload: Some(ReloadPayload {
+            payload: ReloadPayload {
                 raw: Arc::new(serde_json::json!({})),
                 normalized: Arc::new(serde_json::json!({})),
-            }),
+            },
         };
         watcher
             .event_sender()
-            .send(ConfigEvent::Reloaded(result))
+            .send(ConfigEvent::Reloaded(success))
             .unwrap();
 
         // Should receive it
         let event = rx.recv().await.unwrap();
         match event {
             ConfigEvent::Reloaded(r) => {
-                assert!(r.success);
                 assert_eq!(r.mode, "hot");
             }
             _ => panic!("Expected Reloaded event"),
@@ -642,9 +644,15 @@ mod tests {
 
         // Set the env var to point to our test config
         env_guard.set("CARAPACE_CONFIG_PATH", config_path.as_os_str());
-        let result = perform_reload(&ReloadMode::Hot);
-        assert!(result.success);
-        assert_eq!(result.mode, "hot");
+        let event = perform_reload(&ReloadMode::Hot);
+        match event {
+            ConfigEvent::Reloaded(success) => {
+                assert_eq!(success.mode, "hot");
+            }
+            ConfigEvent::ReloadFailed(failure) => {
+                panic!("expected Reloaded, got ReloadFailed: {}", failure.error);
+            }
+        }
     }
 
     #[tokio::test]
@@ -661,9 +669,15 @@ mod tests {
         }
 
         env_guard.set("CARAPACE_CONFIG_PATH", config_path.as_os_str());
-        let result = perform_reload(&ReloadMode::Hybrid);
-        assert!(!result.success);
-        assert_eq!(result.mode, "hybrid");
-        assert!(result.error.is_some());
+        let event = perform_reload(&ReloadMode::Hybrid);
+        match event {
+            ConfigEvent::ReloadFailed(failure) => {
+                assert_eq!(failure.mode, "hybrid");
+                assert!(!failure.error.is_empty());
+            }
+            ConfigEvent::Reloaded(_) => {
+                panic!("expected ReloadFailed for invalid config, got Reloaded");
+            }
+        }
     }
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -668,12 +668,9 @@ fn handle_provider_reload(
 /// cause provider thrashing if replayed.
 fn drain_pending_events(rx: &mut tokio::sync::broadcast::Receiver<config::watcher::ConfigEvent>) {
     use tokio::sync::broadcast::error::TryRecvError;
-    loop {
-        match rx.try_recv() {
-            Ok(_) | Err(TryRecvError::Lagged(_)) => continue,
-            Err(TryRecvError::Empty) | Err(TryRecvError::Closed) => break,
-        }
-    }
+    // Discard buffered events (Ok) and any further lag notifications until
+    // we hit Empty or Closed. Empty body — the discard *is* the work.
+    while let Ok(_) | Err(TryRecvError::Lagged(_)) = rx.try_recv() {}
 }
 
 /// Handle a synchronous reload command from the WS `config.reload` admin

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -603,7 +603,7 @@ pub(crate) enum ReloadCommandResult {
 /// Disabled-cache caveat: with `CARAPACE_DISABLE_CONFIG_CACHE=1`, direct
 /// disk readers continue to read the operator's bad save until the file is
 /// repaired — the warn-log in `revert_pending_env` announces this.
-fn handle_provider_reload(
+async fn handle_provider_reload(
     ws_state: &Arc<WsServerState>,
     state: &mut ReloadState,
     raw: Arc<Value>,
@@ -617,16 +617,22 @@ fn handle_provider_reload(
     }
 
     info!("LLM provider configuration changed, rebuilding providers");
-    match crate::agent::factory::build_providers(&normalized) {
-        Ok(Some(mp)) => {
-            ws_state.set_llm_provider(Some(Arc::new(mp)));
-            info!("LLM providers hot-swapped successfully");
-            config::update_cache_arc(raw, normalized);
-            state.last_good_env = config::snapshot_env_state();
-            state.current_fingerprint = new_fingerprint;
-            ReloadOutcome::Apply
-        }
-        Ok(None) => {
+    // `build_providers` does blocking I/O (auth-profile-store load, key
+    // material decryption when CARAPACE_CONFIG_PASSWORD is set, HTTP-client
+    // construction). Run it on the blocking pool so the bridge's tokio
+    // worker stays free; the unchanged-fingerprint fast path above stays
+    // sync and pays no spawn-blocking cost for no-op reloads.
+    // `build_providers` returns `Box<dyn std::error::Error>`, which is not
+    // `Send`; stringify the error inside the blocking closure so the
+    // spawn_blocking output type is Send.
+    let normalized_for_build = Arc::clone(&normalized);
+    let build_result = tokio::task::spawn_blocking(move || {
+        crate::agent::factory::build_providers(&normalized_for_build).map_err(|e| e.to_string())
+    })
+    .await;
+    let mp = match build_result {
+        Ok(Ok(Some(mp))) => mp,
+        Ok(Ok(None)) => {
             warn!(
                 "Reloaded config has no LLM provider; rejecting reload to keep the \
                  previous provider active. Restore a provider config to apply \
@@ -636,17 +642,31 @@ fn handle_provider_reload(
             // same config retriggers build_providers, letting a transient
             // build error recover on the next attempt.
             revert_pending_env(state);
-            ReloadOutcome::Reverted
+            return ReloadOutcome::Reverted;
         }
-        Err(e) => {
+        Ok(Err(message)) => {
             warn!(
                 "Failed to rebuild LLM providers: {} (rejecting reload to keep previous provider)",
+                message
+            );
+            revert_pending_env(state);
+            return ReloadOutcome::Reverted;
+        }
+        Err(e) => {
+            error!(
+                "build_providers blocking task panicked: {} (rejecting reload)",
                 e
             );
             revert_pending_env(state);
-            ReloadOutcome::Reverted
+            return ReloadOutcome::Reverted;
         }
-    }
+    };
+    ws_state.set_llm_provider(Some(Arc::new(mp)));
+    info!("LLM providers hot-swapped successfully");
+    config::update_cache_arc(raw, normalized);
+    state.last_good_env = config::snapshot_env_state();
+    state.current_fingerprint = new_fingerprint;
+    ReloadOutcome::Apply
 }
 
 /// Discard everything currently buffered in the bridge's broadcast receiver.
@@ -682,7 +702,8 @@ async fn dispatch_bridge_reload(
                 state,
                 success.payload.raw,
                 success.payload.normalized,
-            );
+            )
+            .await;
             match outcome {
                 ReloadOutcome::Apply => ReloadCommandResult::Applied {
                     warnings: success.warnings,
@@ -749,7 +770,8 @@ fn spawn_config_watcher_bridge(
                                 &mut reload_state,
                                 success.payload.raw,
                                 success.payload.normalized,
-                            );
+                            )
+                            .await;
                             match outcome {
                                 ReloadOutcome::Apply => {
                                     crate::server::ws::broadcast_config_changed(
@@ -2180,8 +2202,8 @@ mod tests {
         env.unset(TEST_PROVIDER_KEY);
     }
 
-    #[test]
-    fn handle_provider_reload_reverts_when_new_config_has_no_provider() {
+    #[tokio::test]
+    async fn handle_provider_reload_reverts_when_new_config_has_no_provider() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
         let prior_fingerprint = state.current_fingerprint.clone();
@@ -2198,7 +2220,8 @@ mod tests {
             &mut state,
             Arc::new(new_raw),
             Arc::new(new_normalized),
-        );
+        )
+        .await;
 
         assert_eq!(outcome, ReloadOutcome::Reverted);
         // Cache must be untouched — the bridge never installed the bad
@@ -2215,8 +2238,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn handle_provider_reload_swaps_provider_and_applies_on_valid_change() {
+    #[tokio::test]
+    async fn handle_provider_reload_swaps_provider_and_applies_on_valid_change() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
 
@@ -2233,7 +2256,8 @@ mod tests {
             &mut state,
             Arc::new(new_raw.clone()),
             Arc::new(new_normalized.clone()),
-        );
+        )
+        .await;
 
         assert_eq!(outcome, ReloadOutcome::Apply);
         assert!(ws_state.llm_provider().is_some());
@@ -2251,8 +2275,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn handle_provider_reload_captures_new_last_good_when_provider_unchanged() {
+    #[tokio::test]
+    async fn handle_provider_reload_captures_new_last_good_when_provider_unchanged() {
         let (_cache, _env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
         let prior_fingerprint = state.current_fingerprint.clone();
@@ -2276,7 +2300,8 @@ mod tests {
             &mut state,
             Arc::new(new_raw.clone()),
             Arc::new(new_normalized.clone()),
-        );
+        )
+        .await;
 
         assert_eq!(outcome, ReloadOutcome::Apply);
         assert_eq!(state.current_fingerprint, prior_fingerprint);
@@ -2306,8 +2331,9 @@ mod tests {
     /// `CONFIG_CACHE`. A regression that skips `update_cache_arc` on this
     /// path would leave the cache empty, breaking every downstream reader
     /// until a later successful reload arrived.
-    #[test]
-    fn handle_provider_reload_installs_cache_and_provider_on_first_valid_swap_from_clean_state() {
+    #[tokio::test]
+    async fn handle_provider_reload_installs_cache_and_provider_on_first_valid_swap_from_clean_state(
+    ) {
         use crate::config::ScopedEnvStateForTest;
         use crate::test_support::config::ScopedConfigCache;
 
@@ -2341,7 +2367,8 @@ mod tests {
             &mut state,
             Arc::new(new_raw.clone()),
             Arc::new(new_normalized.clone()),
-        );
+        )
+        .await;
 
         assert_eq!(outcome, ReloadOutcome::Apply);
         assert!(
@@ -2413,8 +2440,8 @@ mod tests {
     /// `Reverted` it never calls `update_cache_arc`. The cache stays at
     /// whatever the previous validated reload installed — there is no
     /// transient bad-state observable to subscribers.
-    #[test]
-    fn rejected_reload_fires_zero_change_ticks_and_keeps_cache_unchanged() {
+    #[tokio::test]
+    async fn rejected_reload_fires_zero_change_ticks_and_keeps_cache_unchanged() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
         let initial_raw = json!({ "marker": "raw-initial" });
@@ -2434,7 +2461,8 @@ mod tests {
             &mut state,
             Arc::new(bad_raw),
             Arc::new(bad_normalized),
-        );
+        )
+        .await;
 
         assert_eq!(outcome, ReloadOutcome::Reverted);
         let counter_after = *rx.borrow_and_update();
@@ -2453,8 +2481,8 @@ mod tests {
 
     /// `Err(_)` arm of `build_providers` must roll back the same way
     /// `Ok(None)` does — guards against the two arms diverging.
-    #[test]
-    fn handle_provider_reload_reverts_when_build_providers_errors() {
+    #[tokio::test]
+    async fn handle_provider_reload_reverts_when_build_providers_errors() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
         let initial_raw = json!({ "marker": "raw-initial" });
@@ -2489,7 +2517,8 @@ mod tests {
             &mut state,
             Arc::new(new_raw),
             Arc::new(new_normalized),
-        );
+        )
+        .await;
 
         assert_eq!(outcome, ReloadOutcome::Reverted);
         // Bridge wrote nothing on the Err arm: cache stays at fixture state.

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -597,8 +597,10 @@ pub(crate) struct ReloadCommand {
 /// Bridge-side result of processing a [`ReloadCommand`].
 #[derive(Debug)]
 pub(crate) enum ReloadCommandResult {
-    /// New config validated and installed; WS broadcast fired.
-    Applied,
+    /// New config validated and installed; WS broadcast fired. Carries any
+    /// non-fatal validation warnings collected during the load so the WS
+    /// handler can forward them to the requesting client.
+    Applied { warnings: Vec<String> },
     /// Reload rejected on provider validation (no provider, build failure).
     /// Cache and env have been kept at / restored to last good.
     Reverted,
@@ -690,11 +692,18 @@ async fn handle_reload_command(
         Ok(Err(e)) => return ReloadCommandResult::LoadError(e.to_string()),
         Err(e) => return ReloadCommandResult::LoadError(format!("reload task join: {e}")),
     };
+    // Capture validation warnings before the move into handle_provider_reload
+    // so the WS handler can surface them to the requesting client.
+    let warnings: Vec<String> = pending
+        .issues
+        .iter()
+        .map(|i| format!("{}: {}", i.path, i.message))
+        .collect();
     let outcome = handle_provider_reload(ws_state, state, pending.raw, pending.normalized);
     match outcome {
         ReloadOutcome::Apply => {
             crate::server::ws::broadcast_config_changed(ws_state, mode);
-            ReloadCommandResult::Applied
+            ReloadCommandResult::Applied { warnings }
         }
         ReloadOutcome::Reverted => ReloadCommandResult::Reverted,
     }
@@ -842,6 +851,13 @@ fn spawn_config_watcher_bridge(
                 }
             }
         }
+        // Bridge is exiting; clear the command sender so any caller
+        // checking `state.reload_command_tx().is_some()` as a liveness
+        // signal sees the bridge as gone, not just unresponsive. Sends
+        // through the cloned tx in WS handlers will return Err once the
+        // receiver drops below, but clearing the slot keeps the visible
+        // state consistent.
+        ws_state_for_config.set_reload_command_tx(None);
     });
 }
 
@@ -2370,6 +2386,57 @@ mod tests {
         assert_eq!(*normalized_after, new_normalized);
         let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
         assert_eq!(*raw_after, new_raw);
+    }
+
+    /// `drain_pending_events` must empty the broadcast receiver so the next
+    /// `recv()` blocks on a fresh event rather than replaying buffered
+    /// (stale) ones. Critical for the lag-recovery branch — without the
+    /// drain, `tokio::sync::broadcast::Receiver` advances its cursor to the
+    /// oldest still-buffered message after a `Lagged`, which would replay
+    /// E3..En in order and could thrash the live provider through stale
+    /// intermediate fingerprints.
+    #[tokio::test]
+    async fn drain_pending_events_empties_buffer_so_next_recv_blocks_on_fresh() {
+        use config::watcher::{ConfigEvent, FailedReload};
+
+        let (event_tx, mut rx) = tokio::sync::broadcast::channel::<ConfigEvent>(4);
+        // Fill past capacity to force a Lagged on next recv.
+        for i in 0..6 {
+            event_tx
+                .send(ConfigEvent::ReloadFailed(FailedReload {
+                    mode: format!("test-{i}"),
+                    error: "synthetic".into(),
+                }))
+                .expect("send into broadcast");
+        }
+        // Confirm the receiver lags as expected.
+        match rx.try_recv() {
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => {}
+            other => panic!("expected Lagged before drain, got {other:?}"),
+        }
+
+        drain_pending_events(&mut rx);
+
+        // Receiver must report Empty now — drain consumed every buffered event.
+        match rx.try_recv() {
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {}
+            other => panic!("expected Empty after drain, got {other:?}"),
+        }
+
+        // A fresh send is observable on the next try_recv (i.e. drain didn't
+        // consume from a closed channel or otherwise break the receiver).
+        event_tx
+            .send(ConfigEvent::ReloadFailed(FailedReload {
+                mode: "post-drain".into(),
+                error: "synthetic".into(),
+            }))
+            .expect("send post-drain");
+        match rx.try_recv() {
+            Ok(ConfigEvent::ReloadFailed(failure)) => {
+                assert_eq!(failure.mode, "post-drain");
+            }
+            other => panic!("expected fresh event after drain, got {other:?}"),
+        }
     }
 
     /// A rejected reload fires zero ticks on `CONFIG_CHANGE_TX`: the bridge

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -323,13 +323,17 @@ impl ServerHandle {
 }
 
 /// Spawn the SIGHUP handler that triggers config reload on Unix systems.
+///
+/// The handler loads the payload via `perform_reload_async` and forwards
+/// it as a `ConfigEvent`; the hot-reload bridge owns the cache install and
+/// the WS broadcast on validation success, so SIGHUP no longer touches the
+/// cache or the WS broadcast directly.
 #[cfg(unix)]
 fn spawn_sighup_handler(
-    ws_state: &Arc<WsServerState>,
+    _ws_state: &Arc<WsServerState>,
     config_watcher: &config::watcher::ConfigWatcher,
     shutdown_rx: &watch::Receiver<bool>,
 ) {
-    let ws_state_for_sighup = ws_state.clone();
     let config_event_tx = config_watcher.event_sender();
     let mut sighup_shutdown_rx = shutdown_rx.clone();
     tokio::spawn(async move {
@@ -357,20 +361,17 @@ fn spawn_sighup_handler(
                         config::watcher::ReloadMode::Off => config::watcher::ReloadMode::Hot,
                         other => other,
                     };
+                    // `perform_reload_async` loads the payload but does not
+                    // install it; the bridge owns cache install + WS broadcast
+                    // after provider validation, so SIGHUP just routes the
+                    // event and lets the bridge do the rest.
                     let result = config::watcher::perform_reload_async(&mode).await;
-                    if result.success {
-                        crate::server::ws::broadcast_config_changed(
-                            &ws_state_for_sighup,
-                            &result.mode,
-                        );
-                        let _ = config_event_tx.send(
-                            config::watcher::ConfigEvent::Reloaded(result),
-                        );
+                    let event = if result.success {
+                        config::watcher::ConfigEvent::Reloaded(result)
                     } else {
-                        let _ = config_event_tx.send(
-                            config::watcher::ConfigEvent::ReloadFailed(result),
-                        );
-                    }
+                        config::watcher::ConfigEvent::ReloadFailed(result)
+                    };
+                    let _ = config_event_tx.send(event);
                 }
                 _ = sighup_shutdown_rx.changed() => {
                     if *sighup_shutdown_rx.borrow() {
@@ -555,143 +556,97 @@ fn spawn_activity_feature_support_warnings(
     });
 }
 
-/// One atomic last-good snapshot the bridge restores on a failed reload.
-///
-/// `last_good_cache` is `Option` because the cache pair must be installed
-/// as a unit; if either half couldn't be captured at bridge startup, the
-/// rollback skips the cache and only restores env to avoid writing a
-/// misleading placeholder.
+/// State carried across reload events for env-rollback and fingerprint
+/// comparison. The cache itself is no longer tracked here: the bridge owns
+/// the cache write, so by construction `CONFIG_CACHE` always reflects the
+/// last validated reload — there is no bad-state value for the cache to
+/// roll back to.
 struct ReloadState {
-    last_good_cache: Option<(Arc<Value>, Arc<Value>)>,
+    /// Snapshot of `CONFIG_ENV_STATE` taken before the loader injected the
+    /// pending reload's env vars (the loader necessarily injects to support
+    /// `${VAR}` substitution). Restored on `Reverted` to undo a rejected
+    /// reload's env mutations.
     last_good_env: config::InjectedConfigEnvState,
+    /// Fingerprint of the currently-installed provider. Used to short-circuit
+    /// `build_providers` when the new config doesn't change the provider
+    /// shape.
     current_fingerprint: crate::agent::factory::ProviderFingerprint,
-}
-
-impl ReloadState {
-    /// Capture a new last-good snapshot — cache pair, env state, and
-    /// (optionally) the fingerprint that produced this configuration.
-    /// Pass `Some(fp)` on a provider swap, `None` when the provider is
-    /// unchanged.
-    fn advance_last_good(
-        &mut self,
-        raw: Arc<Value>,
-        normalized: Arc<Value>,
-        fingerprint: Option<crate::agent::factory::ProviderFingerprint>,
-    ) {
-        self.last_good_cache = Some((raw, normalized));
-        self.last_good_env = config::snapshot_env_state();
-        if let Some(fp) = fingerprint {
-            self.current_fingerprint = fp;
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReloadOutcome {
-    /// New config validated (provider unchanged or hot-swapped). Broadcast to
+    /// New config validated and installed in the cache. Broadcast to
     /// downstream subscribers.
     Apply,
-    /// Cache rolled back to the previous known-good state, or the new config
-    /// could not be loaded. Suppress the downstream broadcast.
+    /// Reload rejected; cache was never written, env restored to last good.
+    /// Suppress the downstream broadcast.
     Reverted,
 }
 
-/// Validate the freshly-reloaded config against provider invariants and
-/// either install the new provider, capture the new last-good snapshot, or
-/// roll back to the previous one.
+/// Validate the freshly-loaded `(raw, normalized)` payload against provider
+/// invariants. On `Apply`, the bridge installs the payload in `CONFIG_CACHE`
+/// (single broadcast) and updates `state` with the new env snapshot and
+/// fingerprint. On `Reverted`, the cache is left untouched (it still holds
+/// the previously-validated config) and env is restored to `last_good_env`.
 ///
-/// `Reverted` means the cache and env have been restored to last-good and
-/// the WS broadcast should be suppressed.
-fn handle_provider_reload(ws_state: &Arc<WsServerState>, state: &mut ReloadState) -> ReloadOutcome {
-    let (new_raw_arc, new_cfg_arc) = match config::load_both_config_shared() {
-        Ok(pair) => pair,
-        Err(e) => {
-            warn!(
-                "Failed to load reloaded config: {} (rolling back to last-known-good)",
-                e
-            );
-            revert_to_last_good(state);
-            return ReloadOutcome::Reverted;
-        }
-    };
-
-    let new_fingerprint = crate::agent::factory::fingerprint_providers(&new_cfg_arc);
+/// Disabled-cache caveat: with `CARAPACE_DISABLE_CONFIG_CACHE=1`, direct
+/// disk readers via `load_*_config_shared` continue to read the operator's
+/// bad save until the file is repaired. The warn-log in the `Reverted`
+/// branch announces this to operators.
+fn handle_provider_reload(
+    ws_state: &Arc<WsServerState>,
+    state: &mut ReloadState,
+    raw: Arc<Value>,
+    normalized: Arc<Value>,
+) -> ReloadOutcome {
+    let new_fingerprint = crate::agent::factory::fingerprint_providers(&normalized);
     if new_fingerprint == state.current_fingerprint {
-        state.advance_last_good(new_raw_arc, new_cfg_arc, None);
+        config::update_cache_arc(raw, normalized);
+        state.last_good_env = config::snapshot_env_state();
         return ReloadOutcome::Apply;
     }
 
     info!("LLM provider configuration changed, rebuilding providers");
-    match crate::agent::factory::build_providers(&new_cfg_arc) {
+    match crate::agent::factory::build_providers(&normalized) {
         Ok(Some(mp)) => {
             ws_state.set_llm_provider(Some(Arc::new(mp)));
             info!("LLM providers hot-swapped successfully");
-            state.advance_last_good(new_raw_arc, new_cfg_arc, Some(new_fingerprint));
+            config::update_cache_arc(raw, normalized);
+            state.last_good_env = config::snapshot_env_state();
+            state.current_fingerprint = new_fingerprint;
             ReloadOutcome::Apply
         }
         Ok(None) => {
             warn!(
-                "Reloaded config has no LLM provider; reverting all reloaded changes \
-                 to keep the previous provider active. Restore a provider config to \
-                 apply further changes."
+                "Reloaded config has no LLM provider; rejecting reload to keep the \
+                 previous provider active. Restore a provider config to apply \
+                 further changes."
             );
             // current_fingerprint intentionally unchanged: a re-save of the
             // same config retriggers build_providers, letting a transient
             // build error recover on the next attempt.
-            revert_to_last_good(state);
+            revert_pending_env(state);
             ReloadOutcome::Reverted
         }
         Err(e) => {
             warn!(
-                "Failed to rebuild LLM providers: {} (reverting reload to keep previous provider)",
+                "Failed to rebuild LLM providers: {} (rejecting reload to keep previous provider)",
                 e
             );
-            revert_to_last_good(state);
+            revert_pending_env(state);
             ReloadOutcome::Reverted
         }
     }
 }
 
-/// Restore the cache and process env to the last-known-good snapshot.
-///
-/// Disabled-cache caveat: when `CARAPACE_DISABLE_CONFIG_CACHE` is set,
-/// `load_config_shared` / `load_raw_config_shared` skip `CONFIG_CACHE` and
-/// re-read from disk. Subscribers of `subscribe_config_changes` that
-/// re-read on each notification will still observe the operator's bad
-/// save until the file itself is repaired — rollback only protects the
-/// in-memory cache, the WS broadcast (suppressed via `Reverted`), the
-/// live `WsServerState` provider, and `CONFIG_ENV_STATE`. We log a
-/// warning in this case so the operator knows manual repair is required.
-fn revert_to_last_good(state: &ReloadState) {
-    if let Some((raw, normalized)) = state.last_good_cache.as_ref() {
-        // `update_cache_arc` increments `CONFIG_CHANGE_TX` (a
-        // `tokio::sync::watch` channel) a second time on this reload — the
-        // watcher's bad-config install fired the first. Watch coalescing
-        // means a subscriber that wasn't already in `changed().await` when
-        // N+1 fired will observe only the rolled-back N+2 state. A
-        // subscriber on another worker thread whose `changed().await` was
-        // already pending when N+1 fired (e.g. `signal_receive`'s policy
-        // reload, `spawn_activity_feature_support_warnings`) can briefly
-        // observe the bad cache before the N+2 tick wakes it again — it
-        // self-corrects on N+2 because all current subscribers re-read
-        // `CONFIG_CACHE` on each tick. Subscribers must therefore be
-        // idempotent and tolerant of transient bad-state reads; the
-        // transient is bounded to one bad+good pair per failed reload.
-        // Tracked structural fix in #418: move cache-write ownership from
-        // the watcher to the bridge so failed reloads produce zero ticks
-        // and successful reloads produce exactly one, eliminating the
-        // transient bad-state window entirely.
-        config::update_cache_arc(Arc::clone(raw), Arc::clone(normalized));
-    } else {
-        warn!(
-            "No last-known-good config snapshot captured at bridge startup; \
-             skipping cache rollback (env restoration still applied)."
-        );
-    }
+/// Undo the pending reload's env mutations and warn the operator if direct
+/// disk readers are still exposed (cache-disabled mode). The cache itself
+/// has nothing to undo: the bridge only writes on `Apply`.
+fn revert_pending_env(state: &ReloadState) {
     config::restore_env_state(&state.last_good_env);
     if std::env::var("CARAPACE_DISABLE_CONFIG_CACHE").is_ok() {
         warn!(
-            "Hot-reload rollback ran with CARAPACE_DISABLE_CONFIG_CACHE=1; \
+            "Hot-reload rejected with CARAPACE_DISABLE_CONFIG_CACHE=1; \
              on-disk config still reflects the rejected save. Subscribers \
              that re-read from disk on each change notification will see \
              the bad config until the file is repaired."
@@ -710,25 +665,11 @@ fn spawn_config_watcher_bridge(
     let mut config_rx = config_watcher.subscribe();
     let ws_state_for_config = ws_state.clone();
     let mut config_shutdown_rx = shutdown_rx.clone();
-    // `raw_config` is the normalized startup config (despite the name); used
-    // only as a fingerprint fallback if the cache load below fails.
-    let initial_cache = match config::load_both_config_shared() {
-        Ok(pair) => Some(pair),
-        Err(e) => {
-            warn!(
-                "Failed to capture initial config snapshot for hot-reload bridge: {} \
-                 (cache rollback unavailable until next successful reload)",
-                e
-            );
-            None
-        }
-    };
-    let current_fingerprint = match initial_cache.as_ref() {
-        Some((_, normalized)) => crate::agent::factory::fingerprint_providers(normalized),
-        None => crate::agent::factory::fingerprint_providers(raw_config),
-    };
+    // `raw_config` is the normalized startup config (despite the name) — the
+    // server is already running with it, so use it as the fingerprint
+    // baseline. The cache itself is whatever the startup-time load installed.
+    let current_fingerprint = crate::agent::factory::fingerprint_providers(raw_config);
     let mut reload_state = ReloadState {
-        last_good_cache: initial_cache,
         last_good_env: config::snapshot_env_state(),
         current_fingerprint,
     };
@@ -738,7 +679,19 @@ fn spawn_config_watcher_bridge(
                 event = config_rx.recv() => {
                     match event {
                         Ok(config::watcher::ConfigEvent::Reloaded(result)) => {
-                            match handle_provider_reload(&ws_state_for_config, &mut reload_state) {
+                            let Some(payload) = result.payload else {
+                                warn!(
+                                    "Config reload event missing payload; skipping bridge install"
+                                );
+                                continue;
+                            };
+                            let outcome = handle_provider_reload(
+                                &ws_state_for_config,
+                                &mut reload_state,
+                                payload.raw,
+                                payload.normalized,
+                            );
+                            match outcome {
                                 ReloadOutcome::Apply => {
                                     crate::server::ws::broadcast_config_changed(
                                         &ws_state_for_config,
@@ -746,8 +699,10 @@ fn spawn_config_watcher_bridge(
                                     );
                                 }
                                 ReloadOutcome::Reverted => {
-                                    // Cache rolled back; suppress the WS broadcast so
-                                    // clients don't observe a transient invalid state.
+                                    // Reload rejected before the cache was
+                                    // touched; suppress the WS broadcast so
+                                    // clients don't observe a transient
+                                    // invalid state.
                                 }
                             }
                         }
@@ -2107,7 +2062,6 @@ mod tests {
 
         let ws_state = Arc::new(WsServerState::new(WsServerConfig::default()));
         let reload_state = ReloadState {
-            last_good_cache: Some((Arc::new(initial_raw), Arc::new(initial_normalized.clone()))),
             last_good_env: crate::config::snapshot_env_state(),
             current_fingerprint: crate::agent::factory::fingerprint_providers(&initial_normalized),
         };
@@ -2121,32 +2075,29 @@ mod tests {
         let (_cache, mut env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
         let prior_fingerprint = state.current_fingerprint.clone();
-        let (prior_raw, prior_normalized) = state
-            .last_good_cache
-            .as_ref()
-            .map(|(r, n)| (r.clone(), n.clone()))
-            .expect("fixture installs last_good_cache");
+        let initial_raw = json!({ "marker": "raw-initial" });
+        let initial_normalized = json!({ "marker": "normalized-initial" });
 
         crate::config::apply_config_env_for_test(HashMap::new());
         env.unset(TEST_PROVIDER_KEY);
         let new_raw = json!({ "marker": "raw-new", "agents": { "defaults": { "route": "fast" } } });
         let new_normalized =
             json!({ "marker": "normalized-new", "agents": { "defaults": { "route": "fast" } } });
-        crate::config::update_cache(new_raw, new_normalized);
 
-        let outcome = handle_provider_reload(&ws_state, &mut state);
+        let outcome = handle_provider_reload(
+            &ws_state,
+            &mut state,
+            Arc::new(new_raw),
+            Arc::new(new_normalized),
+        );
 
         assert_eq!(outcome, ReloadOutcome::Reverted);
+        // Cache must be untouched — the bridge never installed the bad
+        // payload, so the fixture's initial `(raw, normalized)` still wins.
         let normalized_after = crate::config::load_config_shared().expect("normalized populated");
-        assert_eq!(*normalized_after, *prior_normalized);
+        assert_eq!(*normalized_after, initial_normalized);
         let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
-        assert_eq!(*raw_after, *prior_raw);
-        let (raw_after_state, normalized_after_state) = state
-            .last_good_cache
-            .as_ref()
-            .expect("last_good_cache preserved");
-        assert!(Arc::ptr_eq(raw_after_state, &prior_raw));
-        assert!(Arc::ptr_eq(normalized_after_state, &prior_normalized));
+        assert_eq!(*raw_after, initial_raw);
         assert_eq!(state.current_fingerprint, prior_fingerprint);
         assert_eq!(
             std::env::var(TEST_PROVIDER_KEY).ok(),
@@ -2167,18 +2118,21 @@ mod tests {
         env.set(TEST_PROVIDER_KEY, "test-rotated-key");
         let new_raw = json!({ "marker": "raw-rotated" });
         let new_normalized = json!({ "marker": "normalized-rotated" });
-        crate::config::update_cache(new_raw.clone(), new_normalized.clone());
 
-        let outcome = handle_provider_reload(&ws_state, &mut state);
+        let outcome = handle_provider_reload(
+            &ws_state,
+            &mut state,
+            Arc::new(new_raw.clone()),
+            Arc::new(new_normalized.clone()),
+        );
 
         assert_eq!(outcome, ReloadOutcome::Apply);
         assert!(ws_state.llm_provider().is_some());
-        let (raw_after, normalized_after) = state
-            .last_good_cache
-            .as_ref()
-            .expect("last_good_cache populated");
-        assert_eq!(**raw_after, new_raw);
-        assert_eq!(**normalized_after, new_normalized);
+        // The bridge writes the new payload into CONFIG_CACHE on Apply.
+        let normalized_after = crate::config::load_config_shared().expect("normalized populated");
+        assert_eq!(*normalized_after, new_normalized);
+        let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
+        assert_eq!(*raw_after, new_raw);
         // Re-applying the captured snapshot must restore the rotated value,
         // not the initial one — pins last_good_env advancement on swap.
         crate::config::restore_env_state(&state.last_good_env);
@@ -2207,23 +2161,26 @@ mod tests {
         ]));
         let new_raw = json!({ "marker": "raw-edited" });
         let new_normalized = json!({ "marker": "normalized-edited" });
-        crate::config::update_cache(new_raw.clone(), new_normalized.clone());
 
-        let outcome = handle_provider_reload(&ws_state, &mut state);
+        let outcome = handle_provider_reload(
+            &ws_state,
+            &mut state,
+            Arc::new(new_raw.clone()),
+            Arc::new(new_normalized.clone()),
+        );
 
         assert_eq!(outcome, ReloadOutcome::Apply);
         assert_eq!(state.current_fingerprint, prior_fingerprint);
-        let (raw_after, normalized_after) = state
-            .last_good_cache
-            .as_ref()
-            .expect("last_good_cache populated");
-        assert_eq!(**raw_after, new_raw);
-        assert_eq!(**normalized_after, new_normalized);
+        // Bridge writes the new payload into CONFIG_CACHE on Apply, even
+        // when the provider fingerprint is unchanged.
+        let normalized_after = crate::config::load_config_shared().expect("normalized populated");
+        assert_eq!(*normalized_after, new_normalized);
+        let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
+        assert_eq!(*raw_after, new_raw);
         // Restoring the captured snapshot must keep the probe set — pins
         // last_good_env advancement on the unchanged-provider arm. Without
-        // advance_last_good's snapshot_env_state call, last_good_env would
-        // still be the fixture's pre-probe state and restore would unset
-        // the probe.
+        // the snapshot_env_state call, last_good_env would still be the
+        // fixture's pre-probe state and restore would unset the probe.
         crate::config::restore_env_state(&state.last_good_env);
         assert_eq!(
             std::env::var(PROBE_VAR).ok(),
@@ -2234,14 +2191,14 @@ mod tests {
         // process env via restore_config_env_state.
     }
 
-    /// When the bridge starts in degraded mode (`last_good_cache: None`,
-    /// because the initial cache load failed), the very next valid provider
-    /// reload must promote `last_good_cache` from `None` to `Some(...)`. A
-    /// regression that skips `advance_last_good` on this path would leave
-    /// the bridge permanently in degraded mode — every later rollback would
-    /// silently skip cache restoration.
+    /// When the bridge starts from a clean state (cache empty after a
+    /// startup-time initial-load failure), the first valid provider reload
+    /// must install the provider AND write the new payload into
+    /// `CONFIG_CACHE`. A regression that skips `update_cache_arc` on this
+    /// path would leave the cache empty, breaking every downstream reader
+    /// until a later successful reload arrived.
     #[test]
-    fn handle_provider_reload_promotes_last_good_cache_from_none_on_valid_swap() {
+    fn handle_provider_reload_installs_cache_and_provider_on_first_valid_swap_from_clean_state() {
         use crate::config::ScopedEnvStateForTest;
         use crate::test_support::config::ScopedConfigCache;
 
@@ -2254,14 +2211,13 @@ mod tests {
         let mut env = crate::test_support::env::provider_env_cleared();
 
         let mut state = ReloadState {
-            last_good_cache: None,
             last_good_env: crate::config::snapshot_env_state(),
             current_fingerprint: crate::agent::factory::fingerprint_providers(&json!({})),
         };
 
         // Now install the API key — fingerprint mismatch on the next reload
-        // will drive build_providers and force advance_last_good's
-        // promotion of last_good_cache from None to Some.
+        // will drive build_providers and the Apply arm's update_cache_arc
+        // write.
         env.set(TEST_PROVIDER_KEY, "test-degraded-key");
         crate::config::apply_config_env_for_test(HashMap::from([(
             TEST_PROVIDER_KEY.to_string(),
@@ -2269,77 +2225,74 @@ mod tests {
         )]));
         let new_raw = json!({ "marker": "raw-from-degraded" });
         let new_normalized = json!({ "marker": "normalized-from-degraded" });
-        crate::config::update_cache(new_raw.clone(), new_normalized.clone());
         let ws_state = Arc::new(WsServerState::new(WsServerConfig::default()));
 
-        let outcome = handle_provider_reload(&ws_state, &mut state);
+        let outcome = handle_provider_reload(
+            &ws_state,
+            &mut state,
+            Arc::new(new_raw.clone()),
+            Arc::new(new_normalized.clone()),
+        );
 
         assert_eq!(outcome, ReloadOutcome::Apply);
         assert!(
             ws_state.llm_provider().is_some(),
-            "valid provider swap from degraded mode must install the provider"
+            "valid provider swap from clean state must install the provider"
         );
-        // last_good_cache must promote None → Some so future rollbacks can
-        // restore the cache, not just env.
-        let (raw_after, normalized_after) = state
-            .last_good_cache
-            .as_ref()
-            .expect("last_good_cache must be promoted from None on valid swap");
-        assert_eq!(**raw_after, new_raw);
-        assert_eq!(**normalized_after, new_normalized);
+        // Bridge must populate CONFIG_CACHE so downstream readers see the
+        // freshly-installed config (not the empty cache the test started
+        // with).
+        let normalized_after = crate::config::load_config_shared().expect("normalized populated");
+        assert_eq!(*normalized_after, new_normalized);
+        let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
+        assert_eq!(*raw_after, new_raw);
     }
 
-    /// Pins the documented `subscribe_config_changes` idempotency contract
-    /// (see `subscribe_config_changes`'s doc comment): a no-provider reload
-    /// fires `CONFIG_CHANGE_TX` exactly twice (watcher's bad install + the
-    /// rollback's good install), and the cache after the rollback holds the
-    /// good values. Future change to either tick count or the post-rollback
-    /// cache state should fail this test loudly. Structural fix in #418
-    /// would replace this assertion with "exactly zero ticks on a rejected
-    /// reload"; until that lands, this test documents today's contract.
+    /// After #418's structural fix, a rejected reload fires zero ticks on
+    /// `CONFIG_CHANGE_TX`: the bridge owns the cache write, so when
+    /// `handle_provider_reload` returns `Reverted` it never calls
+    /// `update_cache_arc` at all. The cache stays at whatever the previous
+    /// validated reload installed — there is no transient bad-state
+    /// observable to subscribers. Replaces the pre-#418 "exactly two ticks,
+    /// cache ends at good" contract.
     #[test]
-    fn rolled_back_reload_fires_two_change_ticks_and_ends_at_good_cache() {
+    fn rejected_reload_fires_zero_change_ticks_and_keeps_cache_unchanged() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
-        let (good_raw, good_normalized) = state
-            .last_good_cache
-            .as_ref()
-            .map(|(r, n)| (r.clone(), n.clone()))
-            .expect("fixture installs last_good_cache");
+        let initial_raw = json!({ "marker": "raw-initial" });
+        let initial_normalized = json!({ "marker": "normalized-initial" });
 
         let mut rx = crate::config::subscribe_config_changes();
         let counter_before = *rx.borrow_and_update();
 
-        // Watcher's first tick: bad config installed in cache.
+        // Bridge sees a no-provider reload payload directly from the
+        // watcher; no pre-call `update_cache` simulates a bad install
+        // (that's what #418 eliminates).
         crate::config::apply_config_env_for_test(HashMap::new());
         env.unset(TEST_PROVIDER_KEY);
         let bad_raw = json!({ "marker": "bad-raw" });
         let bad_normalized = json!({ "marker": "bad-normalized" });
-        crate::config::update_cache(bad_raw, bad_normalized);
-        let counter_after_bad_install = *rx.borrow_and_update();
-        assert!(
-            counter_after_bad_install > counter_before,
-            "watcher's bad-config install must tick the watch channel"
-        );
 
-        // Bridge runs and rejects the reload — fires the second tick on
-        // the rollback's update_cache_arc call.
-        let outcome = handle_provider_reload(&ws_state, &mut state);
+        let outcome = handle_provider_reload(
+            &ws_state,
+            &mut state,
+            Arc::new(bad_raw),
+            Arc::new(bad_normalized),
+        );
 
         assert_eq!(outcome, ReloadOutcome::Reverted);
-        let counter_after_rollback = *rx.borrow_and_update();
+        let counter_after = *rx.borrow_and_update();
         assert_eq!(
-            counter_after_rollback,
-            counter_after_bad_install + 1,
-            "rollback must fire exactly one additional tick (total = 2 across the rejected reload)"
+            counter_after, counter_before,
+            "rejected reload must fire zero ticks — the bridge writes nothing on Reverted"
         );
 
-        // Final cache state holds the good values — what coalescing
-        // subscribers (changed().await after both ticks) ultimately see.
+        // Cache still holds the fixture's initial values: the bridge never
+        // installed the bad payload.
         let normalized_after = crate::config::load_config_shared().expect("cache populated");
-        assert_eq!(*normalized_after, *good_normalized);
+        assert_eq!(*normalized_after, initial_normalized);
         let raw_after = crate::config::load_raw_config_shared().expect("cache populated");
-        assert_eq!(*raw_after, *good_raw);
+        assert_eq!(*raw_after, initial_raw);
     }
 
     /// `Err(_)` arm of `build_providers` must roll back the same way
@@ -2348,11 +2301,8 @@ mod tests {
     fn handle_provider_reload_reverts_when_build_providers_errors() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
             make_reload_state_with_anthropic_provider();
-        let (prior_raw, prior_normalized) = state
-            .last_good_cache
-            .as_ref()
-            .map(|(r, n)| (r.clone(), n.clone()))
-            .expect("fixture installs last_good_cache");
+        let initial_raw = json!({ "marker": "raw-initial" });
+        let initial_normalized = json!({ "marker": "normalized-initial" });
         let prior_fingerprint = state.current_fingerprint.clone();
 
         // The encryption-guard inside `build_anthropic_provider` returns
@@ -2377,15 +2327,20 @@ mod tests {
             crate::agent::factory::build_providers(&new_normalized).is_err(),
             "test config must reach the Err arm of build_providers"
         );
-        crate::config::update_cache(new_raw, new_normalized);
 
-        let outcome = handle_provider_reload(&ws_state, &mut state);
+        let outcome = handle_provider_reload(
+            &ws_state,
+            &mut state,
+            Arc::new(new_raw),
+            Arc::new(new_normalized),
+        );
 
         assert_eq!(outcome, ReloadOutcome::Reverted);
+        // Bridge wrote nothing on the Err arm: cache stays at fixture state.
         let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
-        assert_eq!(*raw_after, *prior_raw);
+        assert_eq!(*raw_after, initial_raw);
         let normalized_after = crate::config::load_config_shared().expect("normalized populated");
-        assert_eq!(*normalized_after, *prior_normalized);
+        assert_eq!(*normalized_after, initial_normalized);
         assert_eq!(state.current_fingerprint, prior_fingerprint);
         assert_eq!(
             std::env::var(TEST_PROVIDER_KEY).ok(),
@@ -2394,81 +2349,20 @@ mod tests {
         );
     }
 
-    /// When `load_both_config_shared` itself fails (unparseable on-disk
-    /// config), `handle_provider_reload` must still call `revert_to_last_good`
-    /// and return `Reverted`. Verified by reading back the post-rollback cache
-    /// (which proves `update_cache_arc` ran) and asserting env restoration
-    /// (which proves `restore_env_state` ran).
-    #[test]
-    fn handle_provider_reload_reverts_when_initial_load_fails() {
-        use crate::config::ScopedEnvStateForTest;
-        use crate::test_support::config::ScopedConfigCache;
+    // The pre-#418 `handle_provider_reload_reverts_when_initial_load_fails`
+    // test is gone: the bridge no longer reads from the cache (it gets the
+    // payload directly from the watcher event), so the "initial-load fails"
+    // arm is gone. The watcher's load-failure path now produces a
+    // `ConfigEvent::ReloadFailed` event which the bridge ignores — that
+    // path is exercised by the watcher's own tests.
 
-        let _cache_guard = ScopedConfigCache::new();
-        crate::config::clear_cache();
-        let _env_state_guard = ScopedEnvStateForTest::new();
-        let temp = tempfile::tempdir().expect("tempdir");
-        let bad_path = temp.path().join("config.json5");
-        std::fs::write(&bad_path, "{ unbalanced").expect("write bad config");
-        let mut env = crate::test_support::env::provider_env_cleared();
-        env.set("CARAPACE_CONFIG_PATH", bad_path.as_os_str());
-        // Cache enabled (no DISABLE flag) so the rollback's update_cache_arc
-        // write is observable via load_config_shared after the call.
-        env.set(TEST_PROVIDER_KEY, "test-initial-key");
-        crate::config::apply_config_env_for_test(HashMap::from([(
-            TEST_PROVIDER_KEY.to_string(),
-            "test-initial-key".to_string(),
-        )]));
-
-        let prior_raw = Arc::new(json!({ "marker": "prior-raw" }));
-        let prior_normalized = Arc::new(json!({ "marker": "prior-normalized" }));
-        let prior_fingerprint = crate::agent::factory::fingerprint_providers(&prior_normalized);
-        let mut state = ReloadState {
-            last_good_cache: Some((Arc::clone(&prior_raw), Arc::clone(&prior_normalized))),
-            last_good_env: crate::config::snapshot_env_state(),
-            current_fingerprint: prior_fingerprint.clone(),
-        };
-        let ws_state = Arc::new(WsServerState::new(WsServerConfig::default()));
-
-        // Mutate the env after snapshotting so restore_env_state has a
-        // distinguishable post-state to restore from.
-        env.unset(TEST_PROVIDER_KEY);
-
-        let outcome = handle_provider_reload(&ws_state, &mut state);
-
-        assert_eq!(outcome, ReloadOutcome::Reverted);
-        assert_eq!(state.current_fingerprint, prior_fingerprint);
-        // The rollback's update_cache_arc wrote prior_(raw, normalized) into
-        // CONFIG_CACHE — read them back via load_config_shared to pin the
-        // cache write. Without the rollback, the cache stays empty and the
-        // shared-load would re-read the still-bad disk file and Err.
-        let normalized_after =
-            crate::config::load_config_shared().expect("rollback wrote the normalized cache");
-        assert_eq!(*normalized_after, *prior_normalized);
-        let raw_after =
-            crate::config::load_raw_config_shared().expect("rollback wrote the raw cache");
-        assert_eq!(*raw_after, *prior_raw);
-        // last_good_cache itself untouched — revert_to_last_good takes &state.
-        let (cache_raw, cache_normalized) = state
-            .last_good_cache
-            .as_ref()
-            .expect("last_good_cache stays populated");
-        assert!(Arc::ptr_eq(cache_raw, &prior_raw));
-        assert!(Arc::ptr_eq(cache_normalized, &prior_normalized));
-        assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
-            Some("test-initial-key".to_string()),
-            "rollback must restore env on the load-failure arm too"
-        );
-    }
-
-    /// In `CARAPACE_DISABLE_CONFIG_CACHE` mode, `revert_to_last_good` still
+    /// In `CARAPACE_DISABLE_CONFIG_CACHE` mode, `revert_pending_env` still
     /// restores env (`CONFIG_ENV_STATE` is independent of `CONFIG_CACHE`)
     /// but cannot protect direct disk readers — `load_config_shared`
     /// bypasses the cache in this mode and re-reads the operator's bad
     /// file. This pins the documented partial-rollback contract.
     #[test]
-    fn revert_to_last_good_in_cache_disabled_mode_restores_env_but_disk_readers_see_bad_file() {
+    fn revert_pending_env_in_cache_disabled_mode_restores_env_but_disk_readers_see_bad_file() {
         use crate::config::ScopedEnvStateForTest;
         use crate::test_support::config::ScopedConfigCache;
 
@@ -2487,18 +2381,15 @@ mod tests {
             "test-initial-key".to_string(),
         )]));
 
-        let prior_raw = Arc::new(json!({ "marker": "prior-raw" }));
-        let prior_normalized = Arc::new(json!({ "marker": "prior-normalized" }));
         let state = ReloadState {
-            last_good_cache: Some((Arc::clone(&prior_raw), Arc::clone(&prior_normalized))),
             last_good_env: crate::config::snapshot_env_state(),
-            current_fingerprint: crate::agent::factory::fingerprint_providers(&prior_normalized),
+            current_fingerprint: crate::agent::factory::fingerprint_providers(&json!({})),
         };
 
         // Mutate the env so restore_env_state has observable work.
         env.unset(TEST_PROVIDER_KEY);
 
-        revert_to_last_good(&state);
+        revert_pending_env(&state);
 
         // Env restoration works regardless of cache mode.
         assert_eq!(
@@ -2509,7 +2400,7 @@ mod tests {
 
         // load_config_shared bypasses CONFIG_CACHE in disabled mode and
         // returns the on-disk bad content — the documented limitation that
-        // the warning log in revert_to_last_good announces to operators.
+        // the warning log in revert_pending_env announces to operators.
         let on_disk = crate::config::load_config_shared().expect("disk read");
         assert_eq!(
             on_disk["marker"],
@@ -2518,59 +2409,11 @@ mod tests {
         );
     }
 
-    /// `revert_to_last_good` with `last_good_cache: None` must leave the
-    /// cache untouched (no placeholder write) and still run env restoration.
-    /// Documented limitation: the bad config previously installed by the
-    /// watcher persists in `CONFIG_CACHE` until the TTL expires or a later
-    /// successful reload arrives — direct readers of `load_config_shared`
-    /// see it. The WS broadcast suppression and the warn-level log in
-    /// `revert_to_last_good` are the operator-visible escape valves for
-    /// this rare startup-time degraded mode. The post-call cache
-    /// assertions below pin that limitation explicitly.
-    #[test]
-    fn revert_to_last_good_skips_cache_when_no_snapshot_but_still_restores_env() {
-        use crate::config::ScopedEnvStateForTest;
-        use crate::test_support::config::ScopedConfigCache;
-
-        let _cache_guard = ScopedConfigCache::new();
-        crate::config::clear_cache();
-        let _env_state_guard = ScopedEnvStateForTest::new();
-        let mut env = crate::test_support::env::provider_env_cleared();
-        env.set(TEST_PROVIDER_KEY, "test-initial-key");
-
-        // Pre-populate CONFIG_ENV_STATE so the captured snapshot has a
-        // distinguishable post-mutation state to restore from.
-        crate::config::apply_config_env_for_test(HashMap::from([(
-            TEST_PROVIDER_KEY.to_string(),
-            "test-initial-key".to_string(),
-        )]));
-
-        let bad_raw = json!({ "marker": "bad-raw" });
-        let bad_normalized = json!({ "marker": "bad-normalized" });
-        crate::config::update_cache(bad_raw.clone(), bad_normalized.clone());
-
-        let state = ReloadState {
-            last_good_cache: None,
-            last_good_env: crate::config::snapshot_env_state(),
-            current_fingerprint: crate::agent::factory::fingerprint_providers(&json!({})),
-        };
-
-        // Mutate the env after the snapshot so restore_env_state has
-        // something observable to do.
-        env.unset(TEST_PROVIDER_KEY);
-
-        revert_to_last_good(&state);
-
-        let normalized_after = crate::config::load_config_shared().expect("normalized populated");
-        assert_eq!(*normalized_after, bad_normalized);
-        let raw_after = crate::config::load_raw_config_shared().expect("raw populated");
-        assert_eq!(*raw_after, bad_raw);
-        assert_eq!(
-            std::env::var(TEST_PROVIDER_KEY).ok(),
-            Some("test-initial-key".to_string()),
-            "degraded path must still restore env"
-        );
-    }
+    // The pre-#418 `revert_to_last_good_skips_cache_when_no_snapshot_but_still_restores_env`
+    // test is gone: with `last_good_cache` deleted from `ReloadState`, the
+    // "no snapshot" premise is meaningless. Env restoration is covered by
+    // `test_snapshot_then_restore_env_state_reverts_config_injected_var` in
+    // `config/mod.rs`.
 
     #[test]
     fn stop_plugin_services_stops_all_services_and_ignores_stop_errors() {

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -330,7 +330,6 @@ impl ServerHandle {
 /// cache or the WS broadcast directly.
 #[cfg(unix)]
 fn spawn_sighup_handler(
-    _ws_state: &Arc<WsServerState>,
     config_watcher: &config::watcher::ConfigWatcher,
     shutdown_rx: &watch::Receiver<bool>,
 ) {
@@ -512,7 +511,7 @@ pub fn spawn_background_tasks(
 
     // SIGHUP handler for manual config reload (Unix only)
     #[cfg(unix)]
-    spawn_sighup_handler(ws_state, &config_watcher, shutdown_rx);
+    spawn_sighup_handler(&config_watcher, shutdown_rx);
 
     // Resource monitor and session retention cleanup
     spawn_monitoring_and_retention(ws_state, raw_config, shutdown_rx);
@@ -2248,13 +2247,11 @@ mod tests {
         assert_eq!(*raw_after, new_raw);
     }
 
-    /// After #418's structural fix, a rejected reload fires zero ticks on
-    /// `CONFIG_CHANGE_TX`: the bridge owns the cache write, so when
-    /// `handle_provider_reload` returns `Reverted` it never calls
-    /// `update_cache_arc` at all. The cache stays at whatever the previous
-    /// validated reload installed — there is no transient bad-state
-    /// observable to subscribers. Replaces the pre-#418 "exactly two ticks,
-    /// cache ends at good" contract.
+    /// A rejected reload fires zero ticks on `CONFIG_CHANGE_TX`: the bridge
+    /// owns the cache write, so when `handle_provider_reload` returns
+    /// `Reverted` it never calls `update_cache_arc`. The cache stays at
+    /// whatever the previous validated reload installed — there is no
+    /// transient bad-state observable to subscribers.
     #[test]
     fn rejected_reload_fires_zero_change_ticks_and_keeps_cache_unchanged() {
         let (_cache, mut env, _env_state, ws_state, mut state) =
@@ -2265,9 +2262,8 @@ mod tests {
         let mut rx = crate::config::subscribe_config_changes();
         let counter_before = *rx.borrow_and_update();
 
-        // Bridge sees a no-provider reload payload directly from the
-        // watcher; no pre-call `update_cache` simulates a bad install
-        // (that's what #418 eliminates).
+        // Bridge sees a no-provider reload payload directly; no pre-call
+        // `update_cache` simulates a bad install — that's the whole point.
         crate::config::apply_config_env_for_test(HashMap::new());
         env.unset(TEST_PROVIDER_KEY);
         let bad_raw = json!({ "marker": "bad-raw" });
@@ -2349,13 +2345,6 @@ mod tests {
         );
     }
 
-    // The pre-#418 `handle_provider_reload_reverts_when_initial_load_fails`
-    // test is gone: the bridge no longer reads from the cache (it gets the
-    // payload directly from the watcher event), so the "initial-load fails"
-    // arm is gone. The watcher's load-failure path now produces a
-    // `ConfigEvent::ReloadFailed` event which the bridge ignores — that
-    // path is exercised by the watcher's own tests.
-
     /// In `CARAPACE_DISABLE_CONFIG_CACHE` mode, `revert_pending_env` still
     /// restores env (`CONFIG_ENV_STATE` is independent of `CONFIG_CACHE`)
     /// but cannot protect direct disk readers — `load_config_shared`
@@ -2408,12 +2397,6 @@ mod tests {
             "disabled-cache load must keep returning the bad disk file post-rollback"
         );
     }
-
-    // The pre-#418 `revert_to_last_good_skips_cache_when_no_snapshot_but_still_restores_env`
-    // test is gone: with `last_good_cache` deleted from `ReloadState`, the
-    // "no snapshot" premise is meaningless. Env restoration is covered by
-    // `test_snapshot_then_restore_env_state_reverts_config_injected_var` in
-    // `config/mod.rs`.
 
     #[test]
     fn stop_plugin_services_stops_all_services_and_ignores_stop_errors() {

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -364,12 +364,7 @@ fn spawn_sighup_handler(
                     // install it; the bridge owns cache install + WS broadcast
                     // after provider validation, so SIGHUP just routes the
                     // event and lets the bridge do the rest.
-                    let result = config::watcher::perform_reload_async(&mode).await;
-                    let event = if result.success {
-                        config::watcher::ConfigEvent::Reloaded(result)
-                    } else {
-                        config::watcher::ConfigEvent::ReloadFailed(result)
-                    };
+                    let event = config::watcher::perform_reload_async(&mode).await;
                     let _ = config_event_tx.send(event);
                 }
                 _ = sighup_shutdown_rx.changed() => {
@@ -582,6 +577,35 @@ enum ReloadOutcome {
     Reverted,
 }
 
+/// A command sent to the hot-reload bridge requesting a manual reload.
+///
+/// Used by callers that need a synchronous response (notably the WS
+/// `config.reload` admin RPC). Fire-and-forget callers (file watcher,
+/// SIGHUP) use the broadcast `ConfigEvent` channel instead.
+///
+/// The bridge does the load itself when handling the command — the caller
+/// does not pre-load — so the validated payload is always against current
+/// on-disk state, avoiding a TOCTOU between the WS handler's load and the
+/// bridge's processing.
+pub(crate) struct ReloadCommand {
+    /// Reload mode label to forward to `broadcast_config_changed` on Apply.
+    pub mode: String,
+    /// One-shot channel the bridge uses to report back the outcome.
+    pub respond_to: tokio::sync::oneshot::Sender<ReloadCommandResult>,
+}
+
+/// Bridge-side result of processing a [`ReloadCommand`].
+#[derive(Debug)]
+pub(crate) enum ReloadCommandResult {
+    /// New config validated and installed; WS broadcast fired.
+    Applied,
+    /// Reload rejected on provider validation (no provider, build failure).
+    /// Cache and env have been kept at / restored to last good.
+    Reverted,
+    /// The disk load itself failed (parse error, missing file, etc.).
+    LoadError(String),
+}
+
 /// Validate the freshly-loaded `(raw, normalized)` payload against provider
 /// invariants. On `Apply`, the bridge installs the payload in `CONFIG_CACHE`
 /// (single broadcast) and updates `state` with the new env snapshot and
@@ -638,6 +662,47 @@ fn handle_provider_reload(
     }
 }
 
+/// Discard everything currently buffered in the bridge's broadcast receiver.
+/// Called after a lag-recovery has already converged the bridge to the
+/// latest on-disk state — the still-buffered events are now stale and would
+/// cause provider thrashing if replayed.
+fn drain_pending_events(rx: &mut tokio::sync::broadcast::Receiver<config::watcher::ConfigEvent>) {
+    use tokio::sync::broadcast::error::TryRecvError;
+    loop {
+        match rx.try_recv() {
+            Ok(_) | Err(TryRecvError::Lagged(_)) => continue,
+            Err(TryRecvError::Empty) | Err(TryRecvError::Closed) => break,
+        }
+    }
+}
+
+/// Handle a synchronous reload command from the WS `config.reload` admin
+/// RPC (or any other caller that needs to know the outcome).
+///
+/// The bridge does the load itself rather than trusting a payload from the
+/// caller — this avoids a TOCTOU window between the WS handler's load and
+/// the bridge's processing. A successful Apply broadcasts the WS
+/// `config.changed` event so clients re-read.
+async fn handle_reload_command(
+    ws_state: &Arc<WsServerState>,
+    state: &mut ReloadState,
+    mode: &str,
+) -> ReloadCommandResult {
+    let pending = match tokio::task::spawn_blocking(config::load_pending_config).await {
+        Ok(Ok(p)) => p,
+        Ok(Err(e)) => return ReloadCommandResult::LoadError(e.to_string()),
+        Err(e) => return ReloadCommandResult::LoadError(format!("reload task join: {e}")),
+    };
+    let outcome = handle_provider_reload(ws_state, state, pending.raw, pending.normalized);
+    match outcome {
+        ReloadOutcome::Apply => {
+            crate::server::ws::broadcast_config_changed(ws_state, mode);
+            ReloadCommandResult::Applied
+        }
+        ReloadOutcome::Reverted => ReloadCommandResult::Reverted,
+    }
+}
+
 /// Undo the pending reload's env mutations and warn the operator if direct
 /// disk readers are still exposed (cache-disabled mode). The cache itself
 /// has nothing to undo: the bridge only writes on `Apply`.
@@ -672,29 +737,31 @@ fn spawn_config_watcher_bridge(
         last_good_env: config::snapshot_env_state(),
         current_fingerprint,
     };
+
+    // Command inbox for synchronous reload requests (e.g. WS `config.reload`).
+    // The mpsc sender is published on `WsServerState` so handlers can find
+    // it; the receiver is owned by this bridge task. Capacity 8 keeps a
+    // burst of admin reloads from blocking the WS handler thread.
+    let (command_tx, mut command_rx) = tokio::sync::mpsc::channel::<ReloadCommand>(8);
+    ws_state.set_reload_command_tx(Some(command_tx));
+
     tokio::spawn(async move {
         loop {
             tokio::select! {
                 event = config_rx.recv() => {
                     match event {
-                        Ok(config::watcher::ConfigEvent::Reloaded(result)) => {
-                            let Some(payload) = result.payload else {
-                                warn!(
-                                    "Config reload event missing payload; skipping bridge install"
-                                );
-                                continue;
-                            };
+                        Ok(config::watcher::ConfigEvent::Reloaded(success)) => {
                             let outcome = handle_provider_reload(
                                 &ws_state_for_config,
                                 &mut reload_state,
-                                payload.raw,
-                                payload.normalized,
+                                success.payload.raw,
+                                success.payload.normalized,
                             );
                             match outcome {
                                 ReloadOutcome::Apply => {
                                     crate::server::ws::broadcast_config_changed(
                                         &ws_state_for_config,
-                                        &result.mode,
+                                        &success.mode,
                                     );
                                 }
                                 ReloadOutcome::Reverted => {
@@ -724,10 +791,12 @@ fn spawn_config_watcher_bridge(
                                 Ok(Ok(p)) => p,
                                 Ok(Err(e)) => {
                                     error!("Lag-recovery load failed: {}", e);
+                                    drain_pending_events(&mut config_rx);
                                     continue;
                                 }
                                 Err(e) => {
                                     error!("Lag-recovery join failed: {}", e);
+                                    drain_pending_events(&mut config_rx);
                                     continue;
                                 }
                             };
@@ -743,12 +812,31 @@ fn spawn_config_watcher_bridge(
                                     "lag-recovery",
                                 );
                             }
+                            // Discard any events still buffered after the
+                            // lag — `tokio::sync::broadcast::Receiver`
+                            // advances its cursor to the oldest still-buffered
+                            // message after a `Lagged`, so without draining,
+                            // the next `recv()` would replay E3..En in
+                            // order, each running a full fingerprint check
+                            // and possibly rebuilding providers against
+                            // stale intermediate states. We've already
+                            // converged to the latest disk state above.
+                            drain_pending_events(&mut config_rx);
                             continue;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                             break;
                         }
                     }
+                }
+                Some(command) = command_rx.recv() => {
+                    let outcome = handle_reload_command(
+                        &ws_state_for_config,
+                        &mut reload_state,
+                        &command.mode,
+                    )
+                    .await;
+                    let _ = command.respond_to.send(outcome);
                 }
                 _ = config_shutdown_rx.changed() => {
                     if *config_shutdown_rx.borrow() {

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -803,19 +803,32 @@ fn spawn_config_watcher_bridge(
                                 &config::watcher::ReloadMode::Hot,
                             )
                             .await;
-                            if let ReloadCommandResult::LoadError(ref e) = outcome {
-                                error!("Lag-recovery load failed: {}", e);
+                            // Drain the buffered events that prompted the
+                            // lag iff the disk recovery actually converged.
+                            // On a transient `LoadError` (file being written,
+                            // I/O glitch) the buffered events may carry valid
+                            // payloads from completed earlier saves; let the
+                            // next `recv()` iteration process them in order
+                            // so we don't lose state until the next watcher
+                            // event.
+                            match outcome {
+                                ReloadCommandResult::Applied { .. } => {
+                                    crate::server::ws::broadcast_config_changed(
+                                        &ws_state_for_config,
+                                        LAG_RECOVERY_MODE_LABEL,
+                                    );
+                                    drain_pending_events(&mut config_rx);
+                                }
+                                ReloadCommandResult::Reverted => {
+                                    drain_pending_events(&mut config_rx);
+                                }
+                                ReloadCommandResult::LoadError(ref e) => {
+                                    error!(
+                                        "Lag-recovery load failed: {} (keeping buffered events for next iteration)",
+                                        e
+                                    );
+                                }
                             }
-                            // The bridge's broadcast for lag-recovery uses a
-                            // distinct mode label so clients can tell this
-                            // tick from a normal reload.
-                            if matches!(outcome, ReloadCommandResult::Applied { .. }) {
-                                crate::server::ws::broadcast_config_changed(
-                                    &ws_state_for_config,
-                                    LAG_RECOVERY_MODE_LABEL,
-                                );
-                            }
-                            drain_pending_events(&mut config_rx);
                             continue;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -348,22 +348,10 @@ fn spawn_sighup_handler(
             tokio::select! {
                 _ = sighup.recv() => {
                     info!("SIGHUP received, triggering config reload");
-                    let current_cfg = config::load_config()
-                        .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
-                    let mode_str = current_cfg
-                        .get("gateway")
-                        .and_then(|g| g.get("reload"))
-                        .and_then(|r| r.get("mode"))
-                        .and_then(|m| m.as_str())
-                        .unwrap_or("hot");
-                    let mode = match config::watcher::ReloadMode::parse_mode(mode_str) {
-                        config::watcher::ReloadMode::Off => config::watcher::ReloadMode::Hot,
-                        other => other,
-                    };
-                    // `perform_reload_async` loads the payload but does not
-                    // install it; the bridge owns cache install + WS broadcast
-                    // after provider validation, so SIGHUP just routes the
-                    // event and lets the bridge do the rest.
+                    let mode = config::watcher::manual_reload_mode();
+                    // perform_reload_async loads the payload but doesn't install
+                    // it — the bridge owns cache install + WS broadcast after
+                    // provider validation. SIGHUP just routes the event.
                     let event = config::watcher::perform_reload_async(&mode).await;
                     let _ = config_event_tx.send(event);
                 }
@@ -550,20 +538,14 @@ fn spawn_activity_feature_support_warnings(
     });
 }
 
-/// State carried across reload events for env-rollback and fingerprint
-/// comparison. The cache itself is no longer tracked here: the bridge owns
-/// the cache write, so by construction `CONFIG_CACHE` always reflects the
-/// last validated reload — there is no bad-state value for the cache to
-/// roll back to.
+/// Cross-event state for env-rollback and provider-fingerprint comparison.
 struct ReloadState {
-    /// Snapshot of `CONFIG_ENV_STATE` taken before the loader injected the
-    /// pending reload's env vars (the loader necessarily injects to support
-    /// `${VAR}` substitution). Restored on `Reverted` to undo a rejected
-    /// reload's env mutations.
+    /// Pre-load env snapshot used to revert `CONFIG_ENV_STATE` on a rejected
+    /// reload (the loader injects `${VAR}` env before later validation can
+    /// fail).
     last_good_env: config::InjectedConfigEnvState,
-    /// Fingerprint of the currently-installed provider. Used to short-circuit
-    /// `build_providers` when the new config doesn't change the provider
-    /// shape.
+    /// Fingerprint of the currently-installed provider; short-circuits
+    /// `build_providers` when the new config doesn't change provider shape.
     current_fingerprint: crate::agent::factory::ProviderFingerprint,
 }
 
@@ -588,11 +570,17 @@ enum ReloadOutcome {
 /// on-disk state, avoiding a TOCTOU between the WS handler's load and the
 /// bridge's processing.
 pub(crate) struct ReloadCommand {
-    /// Reload mode label to forward to `broadcast_config_changed` on Apply.
-    pub mode: String,
+    /// Reload mode requested by the caller; converted to a label only when
+    /// the bridge fires `broadcast_config_changed` on `Apply`.
+    pub mode: config::watcher::ReloadMode,
     /// One-shot channel the bridge uses to report back the outcome.
     pub respond_to: tokio::sync::oneshot::Sender<ReloadCommandResult>,
 }
+
+/// Mode label for a `config.changed` broadcast emitted from the
+/// lag-recovery path (no `ReloadMode` corresponds — the bridge converged
+/// to disk after dropping events).
+const LAG_RECOVERY_MODE_LABEL: &str = "lag-recovery";
 
 /// Bridge-side result of processing a [`ReloadCommand`].
 #[derive(Debug)]
@@ -608,16 +596,13 @@ pub(crate) enum ReloadCommandResult {
     LoadError(String),
 }
 
-/// Validate the freshly-loaded `(raw, normalized)` payload against provider
-/// invariants. On `Apply`, the bridge installs the payload in `CONFIG_CACHE`
-/// (single broadcast) and updates `state` with the new env snapshot and
-/// fingerprint. On `Reverted`, the cache is left untouched (it still holds
-/// the previously-validated config) and env is restored to `last_good_env`.
+/// Validate `(raw, normalized)` against provider invariants. On `Apply`,
+/// install the payload in `CONFIG_CACHE` and refresh `state`'s env snapshot
+/// + fingerprint. On `Reverted`, the caller is responsible for env restore.
 ///
 /// Disabled-cache caveat: with `CARAPACE_DISABLE_CONFIG_CACHE=1`, direct
-/// disk readers via `load_*_config_shared` continue to read the operator's
-/// bad save until the file is repaired. The warn-log in the `Reverted`
-/// branch announces this to operators.
+/// disk readers continue to read the operator's bad save until the file is
+/// repaired — the warn-log in `revert_pending_env` announces this.
 fn handle_provider_reload(
     ws_state: &Arc<WsServerState>,
     state: &mut ReloadState,
@@ -675,50 +660,40 @@ fn drain_pending_events(rx: &mut tokio::sync::broadcast::Receiver<config::watche
     while let Ok(_) | Err(TryRecvError::Lagged(_)) = rx.try_recv() {}
 }
 
-/// Handle a synchronous reload command from the WS `config.reload` admin
-/// RPC (or any other caller that needs to know the outcome).
+/// Run a fresh load + provider validation + cache install. Returns the
+/// outcome without broadcasting; the caller chooses the broadcast label so
+/// the lag-recovery path can label its tick distinctly from a normal reload.
 ///
-/// The bridge does the load itself rather than trusting a payload from the
-/// caller — this avoids a TOCTOU window between the WS handler's load and
-/// the bridge's processing. A successful Apply broadcasts the WS
-/// `config.changed` event so clients re-read.
-async fn handle_reload_command(
+/// `perform_reload_async` already handles `spawn_blocking` + JoinError. On
+/// `ReloadFailed` the loader may have partially mutated `CONFIG_ENV_STATE`
+/// before failing (env injection runs before secrets resolution); we
+/// `revert_pending_env` to put env back to last good. The cache itself
+/// never moved on a load failure.
+async fn dispatch_bridge_reload(
     ws_state: &Arc<WsServerState>,
     state: &mut ReloadState,
-    mode: &str,
+    mode: &config::watcher::ReloadMode,
 ) -> ReloadCommandResult {
-    // `load_pending_config` (via `load_raw_config_uncached`) can mutate
-    // `CONFIG_ENV_STATE` before failing — env vars get applied for `${VAR}`
-    // substitution and the loader only rolls them back on its own
-    // substitution-failure arm. Any later error (parse, schema, secret
-    // resolution) returns `Err` with env still drifted. We call
-    // `revert_pending_env` on every load-failure path so the process env
-    // and the tracker stay consistent with `state.last_good_env`.
-    let pending = match tokio::task::spawn_blocking(config::load_pending_config).await {
-        Ok(Ok(p)) => p,
-        Ok(Err(e)) => {
+    use config::watcher::{perform_reload_async, ConfigEvent};
+    match perform_reload_async(mode).await {
+        ConfigEvent::Reloaded(success) => {
+            let outcome = handle_provider_reload(
+                ws_state,
+                state,
+                success.payload.raw,
+                success.payload.normalized,
+            );
+            match outcome {
+                ReloadOutcome::Apply => ReloadCommandResult::Applied {
+                    warnings: success.warnings,
+                },
+                ReloadOutcome::Reverted => ReloadCommandResult::Reverted,
+            }
+        }
+        ConfigEvent::ReloadFailed(failure) => {
             revert_pending_env(state);
-            return ReloadCommandResult::LoadError(e.to_string());
+            ReloadCommandResult::LoadError(failure.error)
         }
-        Err(e) => {
-            revert_pending_env(state);
-            return ReloadCommandResult::LoadError(format!("reload task join: {e}"));
-        }
-    };
-    // Capture validation warnings before the move into handle_provider_reload
-    // so the WS handler can surface them to the requesting client.
-    let warnings: Vec<String> = pending
-        .issues
-        .iter()
-        .map(|i| format!("{}: {}", i.path, i.message))
-        .collect();
-    let outcome = handle_provider_reload(ws_state, state, pending.raw, pending.normalized);
-    match outcome {
-        ReloadOutcome::Apply => {
-            crate::server::ws::broadcast_config_changed(ws_state, mode);
-            ReloadCommandResult::Applied { warnings }
-        }
-        ReloadOutcome::Reverted => ReloadCommandResult::Reverted,
     }
 }
 
@@ -748,19 +723,18 @@ fn spawn_config_watcher_bridge(
     let mut config_rx = config_watcher.subscribe();
     let ws_state_for_config = ws_state.clone();
     let mut config_shutdown_rx = shutdown_rx.clone();
-    // `raw_config` is the normalized startup config (despite the name) — the
-    // server is already running with it, so use it as the fingerprint
-    // baseline. The cache itself is whatever the startup-time load installed.
+    // `raw_config` is the normalized startup config (parameter name is a
+    // historical misnomer) — the server is already running with it, so it's
+    // the right fingerprint baseline.
     let current_fingerprint = crate::agent::factory::fingerprint_providers(raw_config);
     let mut reload_state = ReloadState {
         last_good_env: config::snapshot_env_state(),
         current_fingerprint,
     };
 
-    // Command inbox for synchronous reload requests (e.g. WS `config.reload`).
-    // The mpsc sender is published on `WsServerState` so handlers can find
-    // it; the receiver is owned by this bridge task. Capacity 8 keeps a
-    // burst of admin reloads from blocking the WS handler thread.
+    // Command inbox for synchronous reload requests (WS `config.reload`).
+    // Capacity 8: enough headroom for an admin reload burst without
+    // blocking WS handler threads.
     let (command_tx, mut command_rx) = tokio::sync::mpsc::channel::<ReloadCommand>(8);
     ws_state.set_reload_command_tx(Some(command_tx));
 
@@ -793,62 +767,32 @@ fn spawn_config_watcher_bridge(
                         }
                         Ok(config::watcher::ConfigEvent::ReloadFailed(_)) => {}
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            // The broadcast buffer dropped `n` events. The
-                            // queued events the bridge would have processed
-                            // are now stale; reload from disk to converge to
-                            // the on-disk truth instead of catching up on
-                            // possibly-superseded payloads.
+                            // Buffered events are stale; reload from disk to
+                            // converge to current on-disk state, then drain
+                            // the buffer so the next recv() blocks on a fresh
+                            // event rather than replaying superseded ones.
                             warn!(
                                 "Config event receiver lagged by {} events; reloading from disk to converge",
                                 n
                             );
-                            // `load_pending_config` can leave `CONFIG_ENV_STATE`
-                            // and process env mutated when it fails partway
-                            // through (env injection happens before secrets
-                            // resolution and other validation). On every
-                            // load-failure arm we revert env to last good so
-                            // the rejected reload doesn't strand env vars in
-                            // the process. The cache itself never moved.
-                            let pending = match tokio::task::spawn_blocking(
-                                config::load_pending_config,
-                            )
-                            .await
-                            {
-                                Ok(Ok(p)) => p,
-                                Ok(Err(e)) => {
-                                    error!("Lag-recovery load failed: {}", e);
-                                    revert_pending_env(&reload_state);
-                                    drain_pending_events(&mut config_rx);
-                                    continue;
-                                }
-                                Err(e) => {
-                                    error!("Lag-recovery join failed: {}", e);
-                                    revert_pending_env(&reload_state);
-                                    drain_pending_events(&mut config_rx);
-                                    continue;
-                                }
-                            };
-                            let outcome = handle_provider_reload(
+                            let outcome = dispatch_bridge_reload(
                                 &ws_state_for_config,
                                 &mut reload_state,
-                                pending.raw,
-                                pending.normalized,
-                            );
-                            if outcome == ReloadOutcome::Apply {
+                                &config::watcher::ReloadMode::Hot,
+                            )
+                            .await;
+                            if let ReloadCommandResult::LoadError(ref e) = outcome {
+                                error!("Lag-recovery load failed: {}", e);
+                            }
+                            // The bridge's broadcast for lag-recovery uses a
+                            // distinct mode label so clients can tell this
+                            // tick from a normal reload.
+                            if matches!(outcome, ReloadCommandResult::Applied { .. }) {
                                 crate::server::ws::broadcast_config_changed(
                                     &ws_state_for_config,
-                                    "lag-recovery",
+                                    LAG_RECOVERY_MODE_LABEL,
                                 );
                             }
-                            // Discard any events still buffered after the
-                            // lag — `tokio::sync::broadcast::Receiver`
-                            // advances its cursor to the oldest still-buffered
-                            // message after a `Lagged`, so without draining,
-                            // the next `recv()` would replay E3..En in
-                            // order, each running a full fingerprint check
-                            // and possibly rebuilding providers against
-                            // stale intermediate states. We've already
-                            // converged to the latest disk state above.
                             drain_pending_events(&mut config_rx);
                             continue;
                         }
@@ -858,12 +802,18 @@ fn spawn_config_watcher_bridge(
                     }
                 }
                 Some(command) = command_rx.recv() => {
-                    let outcome = handle_reload_command(
+                    let outcome = dispatch_bridge_reload(
                         &ws_state_for_config,
                         &mut reload_state,
                         &command.mode,
                     )
                     .await;
+                    if matches!(outcome, ReloadCommandResult::Applied { .. }) {
+                        crate::server::ws::broadcast_config_changed(
+                            &ws_state_for_config,
+                            config::watcher::mode_label(&command.mode),
+                        );
+                    }
                     let _ = command.respond_to.send(outcome);
                 }
                 _ = config_shutdown_rx.changed() => {
@@ -873,12 +823,9 @@ fn spawn_config_watcher_bridge(
                 }
             }
         }
-        // Bridge is exiting; clear the command sender so any caller
-        // checking `state.reload_command_tx().is_some()` as a liveness
-        // signal sees the bridge as gone, not just unresponsive. Sends
-        // through the cloned tx in WS handlers will return Err once the
-        // receiver drops below, but clearing the slot keeps the visible
-        // state consistent.
+        // Clear the command sender so callers checking
+        // `reload_command_tx().is_some()` as a liveness gate see the
+        // bridge as gone rather than stuck-Some with a closed receiver.
         ws_state_for_config.set_reload_command_tx(None);
     });
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -687,10 +687,23 @@ async fn handle_reload_command(
     state: &mut ReloadState,
     mode: &str,
 ) -> ReloadCommandResult {
+    // `load_pending_config` (via `load_raw_config_uncached`) can mutate
+    // `CONFIG_ENV_STATE` before failing — env vars get applied for `${VAR}`
+    // substitution and the loader only rolls them back on its own
+    // substitution-failure arm. Any later error (parse, schema, secret
+    // resolution) returns `Err` with env still drifted. We call
+    // `revert_pending_env` on every load-failure path so the process env
+    // and the tracker stay consistent with `state.last_good_env`.
     let pending = match tokio::task::spawn_blocking(config::load_pending_config).await {
         Ok(Ok(p)) => p,
-        Ok(Err(e)) => return ReloadCommandResult::LoadError(e.to_string()),
-        Err(e) => return ReloadCommandResult::LoadError(format!("reload task join: {e}")),
+        Ok(Err(e)) => {
+            revert_pending_env(state);
+            return ReloadCommandResult::LoadError(e.to_string());
+        }
+        Err(e) => {
+            revert_pending_env(state);
+            return ReloadCommandResult::LoadError(format!("reload task join: {e}"));
+        }
     };
     // Capture validation warnings before the move into handle_provider_reload
     // so the WS handler can surface them to the requesting client.
@@ -789,6 +802,13 @@ fn spawn_config_watcher_bridge(
                                 "Config event receiver lagged by {} events; reloading from disk to converge",
                                 n
                             );
+                            // `load_pending_config` can leave `CONFIG_ENV_STATE`
+                            // and process env mutated when it fails partway
+                            // through (env injection happens before secrets
+                            // resolution and other validation). On every
+                            // load-failure arm we revert env to last good so
+                            // the rejected reload doesn't strand env vars in
+                            // the process. The cache itself never moved.
                             let pending = match tokio::task::spawn_blocking(
                                 config::load_pending_config,
                             )
@@ -797,11 +817,13 @@ fn spawn_config_watcher_bridge(
                                 Ok(Ok(p)) => p,
                                 Ok(Err(e)) => {
                                     error!("Lag-recovery load failed: {}", e);
+                                    revert_pending_env(&reload_state);
                                     drain_pending_events(&mut config_rx);
                                     continue;
                                 }
                                 Err(e) => {
                                     error!("Lag-recovery join failed: {}", e);
+                                    revert_pending_env(&reload_state);
                                     drain_pending_events(&mut config_rx);
                                     continue;
                                 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -707,7 +707,43 @@ fn spawn_config_watcher_bridge(
                         }
                         Ok(config::watcher::ConfigEvent::ReloadFailed(_)) => {}
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!("Config event receiver lagged by {} events", n);
+                            // The broadcast buffer dropped `n` events. The
+                            // queued events the bridge would have processed
+                            // are now stale; reload from disk to converge to
+                            // the on-disk truth instead of catching up on
+                            // possibly-superseded payloads.
+                            warn!(
+                                "Config event receiver lagged by {} events; reloading from disk to converge",
+                                n
+                            );
+                            let pending = match tokio::task::spawn_blocking(
+                                config::load_pending_config,
+                            )
+                            .await
+                            {
+                                Ok(Ok(p)) => p,
+                                Ok(Err(e)) => {
+                                    error!("Lag-recovery load failed: {}", e);
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!("Lag-recovery join failed: {}", e);
+                                    continue;
+                                }
+                            };
+                            let outcome = handle_provider_reload(
+                                &ws_state_for_config,
+                                &mut reload_state,
+                                pending.raw,
+                                pending.normalized,
+                            );
+                            if outcome == ReloadOutcome::Apply {
+                                crate::server::ws::broadcast_config_changed(
+                                    &ws_state_for_config,
+                                    "lag-recovery",
+                                );
+                            }
+                            continue;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                             break;

--- a/src/server/ws/handlers/config.rs
+++ b/src/server/ws/handlers/config.rs
@@ -435,7 +435,7 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
         other => other,
     };
 
-    let result = perform_reload_async(&mode).await;
+    let mut result = perform_reload_async(&mode).await;
 
     if result.success {
         // `perform_reload_async` no longer installs the cache — the bridge
@@ -445,7 +445,7 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
         // installs the payload directly. Bridge-routing migration is tracked
         // in puremachinery/carapace#418 along with the structural fix that
         // eliminates the bypass entirely.
-        if let Some(payload) = result.payload.clone() {
+        if let Some(payload) = result.payload.take() {
             crate::config::update_cache_arc(payload.raw, payload.normalized);
         }
         broadcast_config_changed(state, &result.mode);

--- a/src/server/ws/handlers/config.rs
+++ b/src/server/ws/handlers/config.rs
@@ -438,7 +438,16 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
     let result = perform_reload_async(&mode).await;
 
     if result.success {
-        // Broadcast config.changed event to all WS clients
+        // `perform_reload_async` no longer installs the cache — the bridge
+        // does that on validated reloads from the file watcher / SIGHUP.
+        // The WS reload path bypasses the bridge today (no provider hot-swap,
+        // no last-good rollback); to preserve that behavior the handler
+        // installs the payload directly. Bridge-routing migration is tracked
+        // in puremachinery/carapace#418 along with the structural fix that
+        // eliminates the bypass entirely.
+        if let Some(payload) = result.payload.clone() {
+            crate::config::update_cache_arc(payload.raw, payload.normalized);
+        }
         broadcast_config_changed(state, &result.mode);
 
         Ok(json!({

--- a/src/server/ws/handlers/config.rs
+++ b/src/server/ws/handlers/config.rs
@@ -437,31 +437,40 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
 
     let mut result = perform_reload_async(&mode).await;
 
-    if result.success {
-        // `perform_reload_async` no longer installs the cache — the bridge
-        // does that on validated reloads from the file watcher / SIGHUP.
-        // The WS reload path bypasses the bridge today (no provider hot-swap,
-        // no last-good rollback); to preserve that behavior the handler
-        // installs the payload directly. Bridge-routing migration is tracked
-        // in puremachinery/carapace#418 along with the structural fix that
-        // eliminates the bypass entirely.
-        if let Some(payload) = result.payload.take() {
-            crate::config::update_cache_arc(payload.raw, payload.normalized);
-        }
-        broadcast_config_changed(state, &result.mode);
-
-        Ok(json!({
-            "ok": true,
-            "mode": result.mode,
-            "warnings": result.warnings
-        }))
-    } else {
-        Err(error_shape(
+    if !result.success {
+        return Err(error_shape(
             ERROR_UNAVAILABLE,
             &result.error.unwrap_or_else(|| "reload failed".to_string()),
             None,
-        ))
+        ));
     }
+    // `perform_reload_async` no longer installs the cache — the bridge does
+    // that on validated reloads from the file watcher / SIGHUP. The WS
+    // reload path bypasses the bridge today (no provider hot-swap, no
+    // last-good rollback); to preserve that behavior the handler installs
+    // the payload directly. Bridge-routing migration is tracked in
+    // puremachinery/carapace#422 — it requires a separate command-inbox
+    // channel for synchronous response.
+    //
+    // Tie the broadcast to a confirmed cache install: if the payload is
+    // missing despite `success: true` (an internal invariant break), surface
+    // it as a reload failure rather than firing a broadcast that would push
+    // every connected client to re-read a stale cache value.
+    let Some(payload) = result.payload.take() else {
+        return Err(error_shape(
+            ERROR_UNAVAILABLE,
+            "reload reported success without a payload (internal invariant break)",
+            None,
+        ));
+    };
+    crate::config::update_cache_arc(payload.raw, payload.normalized);
+    broadcast_config_changed(state, &result.mode);
+
+    Ok(json!({
+        "ok": true,
+        "mode": result.mode,
+        "warnings": result.warnings
+    }))
 }
 
 /// Broadcast a `config.changed` event to all connected WS clients.

--- a/src/server/ws/handlers/config.rs
+++ b/src/server/ws/handlers/config.rs
@@ -460,9 +460,10 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
         ));
     }
     match response_rx.await {
-        Ok(ReloadCommandResult::Applied) => Ok(json!({
+        Ok(ReloadCommandResult::Applied { warnings }) => Ok(json!({
             "ok": true,
             "mode": mode,
+            "warnings": warnings,
         })),
         Ok(ReloadCommandResult::Reverted) => Err(error_shape(
             ERROR_UNAVAILABLE,
@@ -591,7 +592,9 @@ mod tests {
                 // pins the round-trip without depending on whatever
                 // gateway.reload.mode the ambient on-disk config carries.
                 let mode = cmd.mode.clone();
-                let _ = cmd.respond_to.send(ReloadCommandResult::Applied);
+                let _ = cmd.respond_to.send(ReloadCommandResult::Applied {
+                    warnings: vec!["a: warn-one".to_string()],
+                });
                 mode
             });
             let result = handle_config_reload(&state).await;
@@ -599,6 +602,13 @@ mod tests {
             let value = result.expect("Applied → Ok");
             assert_eq!(value["ok"], true);
             assert_eq!(value["mode"], serde_json::Value::String(resolved_mode));
+            // Warnings from the bridge must round-trip into the response so
+            // clients can surface non-fatal validation issues to the operator.
+            assert_eq!(
+                value["warnings"],
+                serde_json::json!(["a: warn-one"]),
+                "Applied warnings must be forwarded to the WS response"
+            );
         }
 
         // Reverted path → Err with provider-rejection message.

--- a/src/server/ws/handlers/config.rs
+++ b/src/server/ws/handlers/config.rs
@@ -465,7 +465,18 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
             None,
         )),
         ReloadCommandResult::LoadError(message) => {
-            Err(error_shape(ERROR_UNAVAILABLE, &message, None))
+            // Log the full diagnostic server-side and surface a generic
+            // summary to the WS client. The full message can include
+            // absolute file paths, OS errnos, and JSON5 parser positions —
+            // useful for the operator reading server logs but a leak vector
+            // when WS error responses get forwarded to logging aggregators
+            // or dashboards.
+            tracing::error!("config.reload failed: {}", message);
+            Err(error_shape(
+                ERROR_UNAVAILABLE,
+                "config reload failed; see server logs for details",
+                None,
+            ))
         }
     }
 }
@@ -530,10 +541,12 @@ mod tests {
         );
     }
 
-    /// `config.reload` reports a load error via ERROR_UNAVAILABLE when the
-    /// bridge's load fails (bad on-disk config). Pins that the WS handler
-    /// surfaces the bridge's `LoadError` outcome rather than installing a
-    /// stale cache or returning ok.
+    /// `config.reload` reports a generic ERROR_UNAVAILABLE when the bridge's
+    /// load fails. The bridge's raw error message (potentially containing
+    /// file paths, OS errnos, and parser positions) is logged server-side
+    /// but kept out of the WS response, so error-aggregation pipelines
+    /// don't unintentionally surface filesystem layout to less-privileged
+    /// log consumers.
     #[tokio::test]
     async fn test_handle_config_reload_surfaces_bridge_load_error() {
         use crate::server::startup::{ReloadCommand, ReloadCommandResult};
@@ -542,11 +555,12 @@ mod tests {
         let (command_tx, mut command_rx) = tokio::sync::mpsc::channel::<ReloadCommand>(1);
         state.set_reload_command_tx(Some(command_tx));
 
-        // Stand-in bridge: respond to the command with a synthetic LoadError.
+        // Stand-in bridge: respond with a synthetic LoadError that includes
+        // a path the WS response must NOT leak.
         let bridge = tokio::spawn(async move {
             let cmd = command_rx.recv().await.expect("bridge receives command");
             let _ = cmd.respond_to.send(ReloadCommandResult::LoadError(
-                "config.json5: parse failed at line 1".to_string(),
+                "/etc/carapace/config.json5: parse failed at line 1".to_string(),
             ));
         });
 
@@ -555,8 +569,13 @@ mod tests {
 
         let err = result.expect_err("LoadError must surface as Err");
         assert!(
-            err.message.contains("config.json5"),
-            "load-error message must propagate: {}",
+            !err.message.contains("config.json5") && !err.message.contains("/etc/carapace"),
+            "WS response must not leak the raw load-error path: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("config reload failed") && err.message.contains("server logs"),
+            "WS response must point operators at server logs: {}",
             err.message
         );
     }

--- a/src/server/ws/handlers/config.rs
+++ b/src/server/ws/handlers/config.rs
@@ -412,14 +412,17 @@ pub(super) fn handle_config_schema() -> Result<Value, ErrorShape> {
 
 /// Handle the `config.reload` WS method (admin-only).
 ///
-/// Triggers a manual config reload, re-reading the config file from disk,
-/// validating it, and updating the config cache. The reload mode used is
-/// read from the current config's `gateway.reload.mode` (defaulting to "hot"
-/// for manual reloads).
+/// Routes the reload through the hot-reload bridge: the bridge owns the
+/// load + provider validation + cache install + WS broadcast, identical to
+/// the file-watcher and SIGHUP paths. A reload that drops the LLM provider
+/// (or otherwise fails validation) is rejected before the cache is touched
+/// and the client receives an error response.
 pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value, ErrorShape> {
-    use crate::config::watcher::{perform_reload_async, ReloadMode};
+    use crate::config::watcher::ReloadMode;
+    use crate::server::startup::{ReloadCommand, ReloadCommandResult};
 
-    // Determine reload mode from current config
+    // Determine reload mode from current config (default "hot" for manual
+    // reloads; never "off" since the operator explicitly asked to reload).
     let current_config =
         config::load_config().unwrap_or_else(|_| Value::Object(serde_json::Map::new()));
     let mode_str = current_config
@@ -428,49 +431,54 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
         .and_then(|r| r.get("mode"))
         .and_then(|m| m.as_str())
         .unwrap_or("hot");
-
-    // For manual reload, use the configured mode (or "hot" if "off")
     let mode = match ReloadMode::parse_mode(mode_str) {
-        ReloadMode::Off => ReloadMode::Hot, // Manual reload always does at least hot
-        other => other,
+        ReloadMode::Off => "hot".to_string(),
+        ReloadMode::Hot => "hot".to_string(),
+        ReloadMode::Hybrid => "hybrid".to_string(),
     };
 
-    let mut result = perform_reload_async(&mode).await;
-
-    if !result.success {
+    let Some(command_tx) = state.reload_command_tx() else {
         return Err(error_shape(
             ERROR_UNAVAILABLE,
-            &result.error.unwrap_or_else(|| "reload failed".to_string()),
+            "config-reload bridge is not running; reload requests cannot be processed",
+            None,
+        ));
+    };
+    let (respond_to, response_rx) = tokio::sync::oneshot::channel();
+    if command_tx
+        .send(ReloadCommand {
+            mode: mode.clone(),
+            respond_to,
+        })
+        .await
+        .is_err()
+    {
+        return Err(error_shape(
+            ERROR_UNAVAILABLE,
+            "config-reload bridge has shut down; reload not delivered",
             None,
         ));
     }
-    // `perform_reload_async` no longer installs the cache — the bridge does
-    // that on validated reloads from the file watcher / SIGHUP. The WS
-    // reload path bypasses the bridge today (no provider hot-swap, no
-    // last-good rollback); to preserve that behavior the handler installs
-    // the payload directly. Bridge-routing migration is tracked in
-    // puremachinery/carapace#422 — it requires a separate command-inbox
-    // channel for synchronous response.
-    //
-    // Tie the broadcast to a confirmed cache install: if the payload is
-    // missing despite `success: true` (an internal invariant break), surface
-    // it as a reload failure rather than firing a broadcast that would push
-    // every connected client to re-read a stale cache value.
-    let Some(payload) = result.payload.take() else {
-        return Err(error_shape(
+    match response_rx.await {
+        Ok(ReloadCommandResult::Applied) => Ok(json!({
+            "ok": true,
+            "mode": mode,
+        })),
+        Ok(ReloadCommandResult::Reverted) => Err(error_shape(
             ERROR_UNAVAILABLE,
-            "reload reported success without a payload (internal invariant break)",
+            "reload rejected: the new config has no LLM provider configured (or build_providers \
+             failed). The previous config is still active.",
             None,
-        ));
-    };
-    crate::config::update_cache_arc(payload.raw, payload.normalized);
-    broadcast_config_changed(state, &result.mode);
-
-    Ok(json!({
-        "ok": true,
-        "mode": result.mode,
-        "warnings": result.warnings
-    }))
+        )),
+        Ok(ReloadCommandResult::LoadError(message)) => {
+            Err(error_shape(ERROR_UNAVAILABLE, &message, None))
+        }
+        Err(_) => Err(error_shape(
+            ERROR_UNAVAILABLE,
+            "config-reload bridge dropped the response without replying",
+            None,
+        )),
+    }
 }
 
 /// Broadcast a `config.changed` event to all connected WS clients.
@@ -511,5 +519,105 @@ mod tests {
         let value = result.unwrap();
         assert_eq!(value["ok"], true);
         assert_eq!(value["valid"], true);
+    }
+
+    /// `config.reload` returns ERROR_UNAVAILABLE when the hot-reload bridge
+    /// is not running. The bridge sets `reload_command_tx` on
+    /// `WsServerState` once it spawns; without it, the handler refuses to
+    /// process the request rather than installing a payload directly (which
+    /// would skip provider validation).
+    #[tokio::test]
+    async fn test_handle_config_reload_errors_when_bridge_not_running() {
+        let state = WsServerState::new(WsServerConfig::default());
+        // No `set_reload_command_tx(Some(...))` here — bridge never spawned.
+
+        let result = handle_config_reload(&state).await;
+
+        let err = result.expect_err("must fail without a bridge");
+        assert!(
+            err.message.contains("config-reload bridge is not running"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    /// `config.reload` reports a load error via ERROR_UNAVAILABLE when the
+    /// bridge's load fails (bad on-disk config). Pins that the WS handler
+    /// surfaces the bridge's `LoadError` outcome rather than installing a
+    /// stale cache or returning ok.
+    #[tokio::test]
+    async fn test_handle_config_reload_surfaces_bridge_load_error() {
+        use crate::server::startup::{ReloadCommand, ReloadCommandResult};
+
+        let state = WsServerState::new(WsServerConfig::default());
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::channel::<ReloadCommand>(1);
+        state.set_reload_command_tx(Some(command_tx));
+
+        // Stand-in bridge: respond to the command with a synthetic LoadError.
+        let bridge = tokio::spawn(async move {
+            let cmd = command_rx.recv().await.expect("bridge receives command");
+            let _ = cmd.respond_to.send(ReloadCommandResult::LoadError(
+                "config.json5: parse failed at line 1".to_string(),
+            ));
+        });
+
+        let result = handle_config_reload(&state).await;
+        bridge.await.expect("bridge task joins");
+
+        let err = result.expect_err("LoadError must surface as Err");
+        assert!(
+            err.message.contains("config.json5"),
+            "load-error message must propagate: {}",
+            err.message
+        );
+    }
+
+    /// `config.reload` returns ok+ERROR_UNAVAILABLE based on the bridge's
+    /// outcome. `Reverted` (no provider in new config) maps to an error
+    /// response that names the rejection reason; `Applied` maps to ok with
+    /// the mode field populated from whatever the handler resolved.
+    #[tokio::test]
+    async fn test_handle_config_reload_maps_bridge_outcomes_to_responses() {
+        use crate::server::startup::{ReloadCommand, ReloadCommandResult};
+
+        // Applied path → Ok response with mode field set.
+        {
+            let state = WsServerState::new(WsServerConfig::default());
+            let (command_tx, mut command_rx) = tokio::sync::mpsc::channel::<ReloadCommand>(1);
+            state.set_reload_command_tx(Some(command_tx));
+            let bridge = tokio::spawn(async move {
+                let cmd = command_rx.recv().await.expect("command received");
+                // Echo back the mode the handler resolved so the assertion
+                // pins the round-trip without depending on whatever
+                // gateway.reload.mode the ambient on-disk config carries.
+                let mode = cmd.mode.clone();
+                let _ = cmd.respond_to.send(ReloadCommandResult::Applied);
+                mode
+            });
+            let result = handle_config_reload(&state).await;
+            let resolved_mode = bridge.await.unwrap();
+            let value = result.expect("Applied → Ok");
+            assert_eq!(value["ok"], true);
+            assert_eq!(value["mode"], serde_json::Value::String(resolved_mode));
+        }
+
+        // Reverted path → Err with provider-rejection message.
+        {
+            let state = WsServerState::new(WsServerConfig::default());
+            let (command_tx, mut command_rx) = tokio::sync::mpsc::channel::<ReloadCommand>(1);
+            state.set_reload_command_tx(Some(command_tx));
+            let bridge = tokio::spawn(async move {
+                let cmd = command_rx.recv().await.expect("command received");
+                let _ = cmd.respond_to.send(ReloadCommandResult::Reverted);
+            });
+            let result = handle_config_reload(&state).await;
+            bridge.await.unwrap();
+            let err = result.expect_err("Reverted → Err");
+            assert!(
+                err.message.contains("no LLM provider"),
+                "Reverted reason must surface: {}",
+                err.message
+            );
+        }
     }
 }

--- a/src/server/ws/handlers/config.rs
+++ b/src/server/ws/handlers/config.rs
@@ -412,30 +412,15 @@ pub(super) fn handle_config_schema() -> Result<Value, ErrorShape> {
 
 /// Handle the `config.reload` WS method (admin-only).
 ///
-/// Routes the reload through the hot-reload bridge: the bridge owns the
-/// load + provider validation + cache install + WS broadcast, identical to
-/// the file-watcher and SIGHUP paths. A reload that drops the LLM provider
-/// (or otherwise fails validation) is rejected before the cache is touched
-/// and the client receives an error response.
+/// Routes through the hot-reload bridge so the WS reload exercises the
+/// same provider-validation pipeline as the file-watcher and SIGHUP paths.
+/// A reload that drops the LLM provider is rejected before the cache is
+/// touched; the client gets an error response.
 pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value, ErrorShape> {
-    use crate::config::watcher::ReloadMode;
+    use crate::config::watcher::{manual_reload_mode, mode_label};
     use crate::server::startup::{ReloadCommand, ReloadCommandResult};
 
-    // Determine reload mode from current config (default "hot" for manual
-    // reloads; never "off" since the operator explicitly asked to reload).
-    let current_config =
-        config::load_config().unwrap_or_else(|_| Value::Object(serde_json::Map::new()));
-    let mode_str = current_config
-        .get("gateway")
-        .and_then(|g| g.get("reload"))
-        .and_then(|r| r.get("mode"))
-        .and_then(|m| m.as_str())
-        .unwrap_or("hot");
-    let mode = match ReloadMode::parse_mode(mode_str) {
-        ReloadMode::Off => "hot".to_string(),
-        ReloadMode::Hot => "hot".to_string(),
-        ReloadMode::Hybrid => "hybrid".to_string(),
-    };
+    let mode = manual_reload_mode();
 
     let Some(command_tx) = state.reload_command_tx() else {
         return Err(error_shape(
@@ -459,26 +444,29 @@ pub(super) async fn handle_config_reload(state: &WsServerState) -> Result<Value,
             None,
         ));
     }
-    match response_rx.await {
-        Ok(ReloadCommandResult::Applied { warnings }) => Ok(json!({
+    // The bridge always replies; an `Err(_)` here would mean the bridge task
+    // panicked between command receipt and respond_to.send — fold it into a
+    // generic LoadError so the WS handler never silently no-ops.
+    let result = response_rx.await.unwrap_or_else(|_| {
+        ReloadCommandResult::LoadError(
+            "config-reload bridge dropped the response without replying".into(),
+        )
+    });
+    match result {
+        ReloadCommandResult::Applied { warnings } => Ok(json!({
             "ok": true,
-            "mode": mode,
+            "mode": mode_label(&mode),
             "warnings": warnings,
         })),
-        Ok(ReloadCommandResult::Reverted) => Err(error_shape(
+        ReloadCommandResult::Reverted => Err(error_shape(
             ERROR_UNAVAILABLE,
             "reload rejected: the new config has no LLM provider configured (or build_providers \
              failed). The previous config is still active.",
             None,
         )),
-        Ok(ReloadCommandResult::LoadError(message)) => {
+        ReloadCommandResult::LoadError(message) => {
             Err(error_shape(ERROR_UNAVAILABLE, &message, None))
         }
-        Err(_) => Err(error_shape(
-            ERROR_UNAVAILABLE,
-            "config-reload bridge dropped the response without replying",
-            None,
-        )),
     }
 }
 
@@ -588,20 +576,20 @@ mod tests {
             state.set_reload_command_tx(Some(command_tx));
             let bridge = tokio::spawn(async move {
                 let cmd = command_rx.recv().await.expect("command received");
-                // Echo back the mode the handler resolved so the assertion
+                // Echo the mode label the handler resolved so the assertion
                 // pins the round-trip without depending on whatever
                 // gateway.reload.mode the ambient on-disk config carries.
-                let mode = cmd.mode.clone();
+                let label = crate::config::watcher::mode_label(&cmd.mode).to_string();
                 let _ = cmd.respond_to.send(ReloadCommandResult::Applied {
                     warnings: vec!["a: warn-one".to_string()],
                 });
-                mode
+                label
             });
             let result = handle_config_reload(&state).await;
-            let resolved_mode = bridge.await.unwrap();
+            let resolved_label = bridge.await.unwrap();
             let value = result.expect("Applied → Ok");
             assert_eq!(value["ok"], true);
-            assert_eq!(value["mode"], serde_json::Value::String(resolved_mode));
+            assert_eq!(value["mode"], serde_json::Value::String(resolved_label));
             // Warnings from the bridge must round-trip into the response so
             // clients can surface non-fatal validation issues to the operator.
             assert_eq!(

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -500,6 +500,12 @@ pub struct WsServerState {
     system_event_history: Mutex<Vec<SystemEvent>>,
     /// LLM provider for agent execution (hot-swappable via RwLock)
     llm_provider: parking_lot::RwLock<Option<Arc<dyn agent::LlmProvider>>>,
+    /// Sender for synchronous reload commands routed to the hot-reload
+    /// bridge. Set once after the bridge spawns; left `None` in test setups
+    /// that don't run the bridge.
+    reload_command_tx: parking_lot::RwLock<
+        Option<tokio::sync::mpsc::Sender<crate::server::startup::ReloadCommand>>,
+    >,
     /// Tools registry for agent tool dispatch
     tools_registry: Option<Arc<plugins::ToolsRegistry>>,
     /// Plugin registry for channel/tool/webhook plugins
@@ -522,6 +528,10 @@ impl std::fmt::Debug for WsServerState {
             .field(
                 "llm_provider",
                 &self.llm_provider.read().as_ref().map(|_| ".."),
+            )
+            .field(
+                "reload_command_tx",
+                &self.reload_command_tx.read().as_ref().map(|_| ".."),
             )
             .field(
                 "tools_registry",
@@ -604,6 +614,7 @@ impl WsServerState {
             agent_run_registry: Mutex::new(handlers::AgentRunRegistry::new()),
             system_event_history: Mutex::new(Vec::new()),
             llm_provider: parking_lot::RwLock::new(None),
+            reload_command_tx: parking_lot::RwLock::new(None),
             tools_registry: None,
             plugin_registry: None,
             activity_service: Arc::new(activity_service_factory()?),
@@ -689,6 +700,7 @@ impl WsServerState {
             agent_run_registry: Mutex::new(handlers::AgentRunRegistry::new()),
             system_event_history: Mutex::new(Vec::new()),
             llm_provider: parking_lot::RwLock::new(None),
+            reload_command_tx: parking_lot::RwLock::new(None),
             tools_registry: None,
             plugin_registry: None,
             activity_service: Arc::new(activity_service),
@@ -892,6 +904,24 @@ impl WsServerState {
     /// Hot-swap the LLM provider at runtime (e.g. on config reload).
     pub fn set_llm_provider(&self, provider: Option<Arc<dyn agent::LlmProvider>>) {
         *self.llm_provider.write() = provider;
+    }
+
+    /// Return a clone of the reload-command sender if the hot-reload bridge
+    /// is running. WS handlers use this to route manual reloads through the
+    /// bridge for provider validation.
+    pub(crate) fn reload_command_tx(
+        &self,
+    ) -> Option<tokio::sync::mpsc::Sender<crate::server::startup::ReloadCommand>> {
+        self.reload_command_tx.read().clone()
+    }
+
+    /// Publish the reload-command sender; called once by the hot-reload
+    /// bridge after it spawns. `None` clears the slot (e.g. on shutdown).
+    pub(crate) fn set_reload_command_tx(
+        &self,
+        tx: Option<tokio::sync::mpsc::Sender<crate::server::startup::ReloadCommand>>,
+    ) {
+        *self.reload_command_tx.write() = tx;
     }
 
     /// Get the plugin registry, if configured.


### PR DESCRIPTION
Closes #418. Closes #422.

## Summary

Move config-cache-write ownership from the watcher to the hot-reload bridge so that all three reload entry points (file watcher, SIGHUP, WS `config.reload`) go through the same provider-validation pipeline.

**Result:**
- A rejected reload (no provider, build_providers Err, parse error) fires **zero** ticks on `CONFIG_CHANGE_TX`. Prior behavior fired two (watcher install + bridge revert).
- A successful reload fires **exactly one** tick (the bridge's install).
- Rapid double-save TOCTOU eliminated — the bridge validates the payload it received, not the latest cache.
- WS `config.reload` no longer bypasses provider validation.
- `ReloadResult` is structurally typed (no `success: true, payload: None` representable state).

## Architecture

```
File change → watcher (debounced) ─┐
                                   │
SIGHUP    ──→ load_pending_config ─┴→ ConfigEvent::Reloaded { payload }
                                                    ↓
                                             config_event_tx (broadcast)
                                                    ↓
                                                 bridge ─┬─→ Apply: update_cache_arc + WS broadcast
                                                         └─→ Reverted: restore env
                                                    ↑
WS config.reload ────────────────────────→ ReloadCommand { mode, respond_to }
                                                    ↑
                                             reload_command_tx (mpsc)
```

The bridge:
- Owns `CONFIG_CACHE` writes; runs `update_cache_arc` only after provider validation succeeds.
- Listens on a broadcast channel (file watcher + SIGHUP fan-out) and an mpsc command inbox (WS reload, synchronous response).
- On lag (`RecvError::Lagged`), reloads from disk and **drains** still-buffered events to prevent provider thrashing on stale intermediate states.

## Changes

- `config::reload_config` delegates to `load_pending_config` (cache-less load primitive). `load_pending_config` and `PendingConfig` are `pub(crate)`.
- `config::watcher::ReloadResult` replaced by typed `SuccessfulReload` and `FailedReload` structs as variants of `ConfigEvent`. Invariant ("success implies payload") is now structural.
- `perform_reload[_async]` return `ConfigEvent` directly.
- `ReloadState` shrinks to `{ last_good_env, current_fingerprint }`.
- `revert_to_last_good` replaced by `revert_pending_env` (only restores env; cache stays at last good by construction).
- New `ReloadCommand { mode, respond_to: oneshot::Sender<ReloadCommandResult> }` type for synchronous reload requests; `ReloadCommandResult { Applied, Reverted, LoadError(String) }`.
- `WsServerState` gains `reload_command_tx() / set_reload_command_tx()` accessors.
- `handle_config_reload` (WS admin RPC) routes through the bridge instead of installing the cache directly. Returns `ERROR_UNAVAILABLE` if the bridge is not running.
- SIGHUP handler simplified — emits `ConfigEvent` only, bridge owns install + broadcast.
- `subscribe_config_changes` doc comment drops the "tolerate transient bad-state read" idempotency caveat.

## Out of scope (tracked follow-ups)

- **Env injection still happens during `load_pending_config`** (necessary for `${VAR}` substitution). Rejected reloads roll back env via `restore_env_state`. Deferring env injection to the bridge requires deeper changes to the load path.

## Test plan

- [x] 7 reload tests in `src/server/startup.rs` migrated and passing under the enum-variant refactor:
  - `rejected_reload_fires_zero_change_ticks_and_keeps_cache_unchanged` — pins zero-tick guarantee on rejection.
  - `handle_provider_reload_installs_cache_and_provider_on_first_valid_swap_from_clean_state` — pins cache install on Apply.
  - `revert_pending_env_in_cache_disabled_mode_*` — pins cache-disabled partial-rollback contract.
- [x] 3 new tests for `handle_config_reload` covering: bridge-not-running errors, LoadError surfacing, Applied/Reverted outcome mapping.
- [x] Watcher tests destructure on `ConfigEvent` variants (no `result.success`/`result.error.is_some()`).
- [x] Full nextest suite: 3753/3753 passing.
- [x] fmt clean.
