### PR TITLE
refactor: remove dead code surfaces (#241)

### DIFF
--- a/docs/protocol/websocket.md
+++ b/docs/protocol/websocket.md
@@ -383,13 +383,6 @@ extending that set.
 | `missing_model` | Resolution found no `route` or `model` for the request | No |
 | `provider_not_configured` | No LLM provider is configured. Operator must set an API key or auth profile; not retryable. | No |
 
-### Reserved codes (documented but not yet emitted)
-
-| Code | Description |
-|------|-------------|
-| `not_linked` | Channel not configured. Constant `ERROR_NOT_LINKED` is reserved in `src/server/ws/mod.rs`; no live emit site yet. |
-| `agent_timeout` | Agent exceeded timeout. Reserved for clients; no live emit at the top-level `error.code` position currently. |
-
 ### Codes that are NOT top-level `error.code` values
 
 These appear in nested positions or are emitted by non-WebSocket

--- a/src/plugins/tests.rs
+++ b/src/plugins/tests.rs
@@ -171,15 +171,12 @@ mod integration_tests {
 
     /// Mock service plugin for testing
     struct MockServicePlugin {
-        #[allow(dead_code)]
-        id: String,
         started: std::sync::atomic::AtomicBool,
     }
 
     impl MockServicePlugin {
-        fn new(id: &str) -> Self {
+        fn new() -> Self {
             Self {
-                id: id.to_string(),
                 started: std::sync::atomic::AtomicBool::new(false),
             }
         }
@@ -313,7 +310,7 @@ mod integration_tests {
     #[test]
     fn test_plugin_registry_service() {
         let registry = PluginRegistry::new();
-        let plugin = Arc::new(MockServicePlugin::new("service-plugin"));
+        let plugin = Arc::new(MockServicePlugin::new());
 
         registry.register_service("service-plugin".to_string(), plugin.clone());
 

--- a/src/server/csrf.rs
+++ b/src/server/csrf.rs
@@ -392,39 +392,6 @@ fn check_origin(
     }
 }
 
-/// CSRF middleware shared state
-#[derive(Clone)]
-pub struct CsrfLayer {
-    store: CsrfTokenStore,
-}
-
-impl CsrfLayer {
-    /// Create a new CSRF layer with default configuration
-    pub fn new() -> Self {
-        Self {
-            store: CsrfTokenStore::new(CsrfConfig::default()),
-        }
-    }
-
-    /// Create a new CSRF layer with custom configuration
-    pub fn with_config(config: CsrfConfig) -> Self {
-        Self {
-            store: CsrfTokenStore::new(config),
-        }
-    }
-
-    /// Get the token store
-    pub fn store(&self) -> &CsrfTokenStore {
-        &self.store
-    }
-}
-
-impl Default for CsrfLayer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Determine if CSRF validation is needed for this request.
 ///
 /// Returns `true` when the HTTP method is state-changing (POST, PUT, DELETE,
@@ -623,16 +590,6 @@ pub fn ensure_csrf_cookies(
     Ok(set_cookies)
 }
 
-/// Convenience function to create CSRF layer
-pub fn layer() -> CsrfLayer {
-    CsrfLayer::new()
-}
-
-/// Convenience function to create CSRF layer with config
-pub fn layer_with_config(config: CsrfConfig) -> CsrfLayer {
-    CsrfLayer::with_config(config)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -777,12 +734,6 @@ mod tests {
     }
 
     #[test]
-    fn test_layer_creation() {
-        let _layer = layer();
-        let _layer_with_config = layer_with_config(CsrfConfig::default());
-    }
-
-    #[test]
     fn test_default_config() {
         let config = CsrfConfig::default();
         assert_eq!(config.cookie_name, "__Host-csrf");
@@ -922,12 +873,5 @@ mod tests {
 
         assert_eq!(csrf_cookie_name(&config), "csrf");
         assert_eq!(session_cookie_name(&config), "session");
-    }
-
-    #[test]
-    fn test_csrf_layer_store_access() {
-        let layer = CsrfLayer::new();
-        let token = layer.store().generate_token("test-session").unwrap();
-        assert!(!token.value.is_empty());
     }
 }

--- a/src/server/headers.rs
+++ b/src/server/headers.rs
@@ -189,35 +189,6 @@ impl SecurityHeadersConfigBuilder {
     }
 }
 
-/// Shared state for security headers middleware
-#[derive(Clone)]
-pub struct SecurityHeadersLayer {
-    #[allow(dead_code)] // stored for Clone
-    config: Arc<SecurityHeadersConfig>,
-}
-
-impl SecurityHeadersLayer {
-    /// Create a new security headers layer with default configuration
-    pub fn new() -> Self {
-        Self {
-            config: Arc::new(SecurityHeadersConfig::default()),
-        }
-    }
-
-    /// Create a new security headers layer with custom configuration
-    pub fn with_config(config: SecurityHeadersConfig) -> Self {
-        Self {
-            config: Arc::new(config),
-        }
-    }
-}
-
-impl Default for SecurityHeadersLayer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Security headers middleware function
 ///
 /// This middleware adds security headers to all responses.
@@ -274,16 +245,6 @@ pub async fn security_headers_middleware(
     }
 
     response
-}
-
-/// Convenience function to create security headers middleware layer
-pub fn layer() -> SecurityHeadersLayer {
-    SecurityHeadersLayer::new()
-}
-
-/// Convenience function to create security headers middleware layer with config
-pub fn layer_with_config(config: SecurityHeadersConfig) -> SecurityHeadersLayer {
-    SecurityHeadersLayer::with_config(config)
 }
 
 #[cfg(test)]
@@ -488,11 +449,5 @@ mod tests {
         assert_eq!(config.frame_options, "DENY");
         assert_eq!(config.content_type_options, "nosniff");
         assert!(!config.enable_hsts); // Default should be false
-    }
-
-    #[test]
-    fn test_layer_creation() {
-        let _layer = layer();
-        let _layer_with_config = layer_with_config(SecurityHeadersConfig::default());
     }
 }

--- a/src/server/ratelimit.rs
+++ b/src/server/ratelimit.rs
@@ -436,39 +436,6 @@ fn extract_client_ip(
     remote_addr.map(|addr| addr.ip())
 }
 
-/// Rate limiting middleware layer
-#[derive(Clone)]
-pub struct RateLimitLayer {
-    limiter: RateLimiter,
-}
-
-impl RateLimitLayer {
-    /// Create a new rate limit layer with default configuration
-    pub fn new() -> Self {
-        Self {
-            limiter: RateLimiter::new(RateLimitConfig::default()),
-        }
-    }
-
-    /// Create a new rate limit layer with custom configuration
-    pub fn with_config(config: RateLimitConfig) -> Self {
-        Self {
-            limiter: RateLimiter::new(config),
-        }
-    }
-
-    /// Get the underlying rate limiter
-    pub fn limiter(&self) -> &RateLimiter {
-        &self.limiter
-    }
-}
-
-impl Default for RateLimitLayer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Resolve the client IP from the request, returning `None` when the
 /// address cannot be determined.
 fn resolve_client_ip(
@@ -566,16 +533,6 @@ fn rate_limit_exceeded_response(retry_after_secs: u64) -> Response<Body> {
         ),
     )
         .into_response()
-}
-
-/// Convenience function to create rate limit layer
-pub fn layer() -> RateLimitLayer {
-    RateLimitLayer::new()
-}
-
-/// Convenience function to create rate limit layer with config
-pub fn layer_with_config(config: RateLimitConfig) -> RateLimitLayer {
-    RateLimitLayer::with_config(config)
 }
 
 // ============================================================================
@@ -861,12 +818,6 @@ mod tests {
 
         let ip = extract_client_ip(addr, &headers, true);
         assert_eq!(ip, Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 100))));
-    }
-
-    #[test]
-    fn test_layer_creation() {
-        let _layer = layer();
-        let _layer_with_config = layer_with_config(RateLimitConfig::default());
     }
 
     #[test]

--- a/src/server/ws/handlers/node.rs
+++ b/src/server/ws/handlers/node.rs
@@ -898,7 +898,6 @@ pub(crate) async fn handle_node_invoke(
             invoke_id.clone(),
             PendingInvoke {
                 node_id: invoke_params.node_id.to_string(),
-                command: invoke_params.command.to_string(),
                 responder,
             },
         );

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -1676,6 +1676,10 @@ struct ConnectParams {
     device: Option<DeviceIdentity>,
     #[serde(default)]
     auth: Option<AuthParams>,
+    #[serde(default, rename = "locale")]
+    _locale: Option<String>,
+    #[serde(default, rename = "userAgent")]
+    _user_agent: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -76,14 +76,6 @@ const ERROR_INVALID_REQUEST: &str = "invalid_request";
 const ERROR_NOT_PAIRED: &str = "not_paired";
 const ERROR_UNAVAILABLE: &str = "unavailable";
 const ERROR_RATE_LIMITED: &str = "rate_limited";
-/// Documented in `docs/protocol/websocket.md` and exercised by the
-/// `tests/golden/ws/errors.json` schema, but not yet emitted from any
-/// live Rust code path. Reserved for future "channel not configured"
-/// errors. Kept here so the wire-code set is discoverable from one
-/// place and a future emit site can `use ERROR_NOT_LINKED` rather than
-/// re-introducing a string literal.
-#[allow(dead_code)]
-const ERROR_NOT_LINKED: &str = "not_linked";
 // Note: Node doesn't use ERROR_FORBIDDEN - use ERROR_INVALID_REQUEST for auth errors
 
 /// Wire codes whose `retryable` field is `true` in the error response.
@@ -1557,8 +1549,6 @@ struct NodeSession {
 #[derive(Debug)]
 struct PendingInvoke {
     node_id: String,
-    #[allow(dead_code)] // populated, read later
-    command: String,
     responder: oneshot::Sender<NodeInvokeResult>,
 }
 
@@ -1641,12 +1631,6 @@ impl NodeRegistry {
         self.nodes_by_id.values().cloned().collect()
     }
 
-    fn conn_id_for_node(&self, node_id: &str) -> Option<String> {
-        self.nodes_by_id
-            .get(node_id)
-            .map(|session| session.conn_id.clone())
-    }
-
     fn insert_pending_invoke(&mut self, invoke_id: String, pending: PendingInvoke) {
         self.pending_invokes.insert(invoke_id, pending);
     }
@@ -1692,12 +1676,6 @@ struct ConnectParams {
     device: Option<DeviceIdentity>,
     #[serde(default)]
     auth: Option<AuthParams>,
-    #[serde(default)]
-    #[allow(dead_code)] // deserialized from client
-    locale: Option<String>,
-    #[serde(default)]
-    #[allow(dead_code)] // deserialized from client
-    user_agent: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -3565,55 +3543,6 @@ pub fn broadcast_talk_mode(state: &WsServerState, enabled: bool, channel: Option
         payload["channel"] = json!(ch);
     }
     broadcast_event(state, "talk.mode", payload);
-}
-
-/// Send an event to a specific node connection (for node.invoke.request).
-/// This is used to request a node to invoke a command.
-///
-/// # Arguments
-/// * `state` - Server state
-/// * `node_id` - Target node identifier
-/// * `invoke_id` - Invocation identifier
-/// * `command` - Command to invoke
-/// * `args` - Command arguments
-/// * `cwd` - Optional working directory
-/// * `env` - Optional environment variables
-/// * `timeout_ms` - Optional timeout in milliseconds
-///
-/// Returns true if the event was sent successfully
-#[allow(clippy::too_many_arguments)]
-pub fn send_node_invoke_request(
-    state: &WsServerState,
-    node_id: &str,
-    invoke_id: &str,
-    command: &str,
-    args: Vec<String>,
-    cwd: Option<&str>,
-    env: Option<HashMap<String, String>>,
-    timeout_ms: Option<u64>,
-) -> bool {
-    let node_registry = state.node_registry.lock();
-    let Some(conn_id) = node_registry.conn_id_for_node(node_id) else {
-        return false;
-    };
-    drop(node_registry);
-
-    let mut payload = json!({
-        "id": invoke_id,
-        "command": command,
-        "args": args
-    });
-    if let Some(c) = cwd {
-        payload["cwd"] = json!(c);
-    }
-    if let Some(e) = env {
-        payload["env"] = serde_json::to_value(e).unwrap_or(json!({}));
-    }
-    if let Some(t) = timeout_ms {
-        payload["timeoutMs"] = json!(t);
-    }
-
-    send_event_to_connection(state, &conn_id, "node.invoke.request", payload)
 }
 
 fn send_response(

--- a/src/server/ws/tests.rs
+++ b/src/server/ws/tests.rs
@@ -177,6 +177,40 @@ fn test_error_shape_config_errors_are_not_retryable() {
     assert!(!err2.retryable);
 }
 
+#[test]
+fn test_connect_params_validate_optional_client_metadata_types() {
+    let base = json!({
+        "minProtocol": 3,
+        "maxProtocol": 3,
+        "client": {
+            "id": "webchat-ui",
+            "version": "test",
+            "platform": "web",
+            "mode": "control"
+        }
+    });
+
+    let mut valid = base.clone();
+    valid["locale"] = json!("en-US");
+    valid["userAgent"] = json!("carapace-test");
+    serde_json::from_value::<ConnectParams>(valid)
+        .expect("string locale/userAgent should remain accepted");
+
+    let mut invalid_locale = base.clone();
+    invalid_locale["locale"] = json!({});
+    assert!(
+        serde_json::from_value::<ConnectParams>(invalid_locale).is_err(),
+        "locale must remain type-validated when present"
+    );
+
+    let mut invalid_user_agent = base;
+    invalid_user_agent["userAgent"] = json!({});
+    assert!(
+        serde_json::from_value::<ConnectParams>(invalid_user_agent).is_err(),
+        "userAgent must remain type-validated when present"
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn test_startup_rejects_plaintext_credential_file() {
     let temp = tempdir().expect("tempdir");

--- a/tests/golden/ws/errors.json
+++ b/tests/golden/ws/errors.json
@@ -42,6 +42,11 @@
         "description": "Service temporarily unavailable",
         "retryable": true,
         "example_message": "service temporarily unavailable"
+      },
+      "rate_limited": {
+        "description": "Per-resource rate limit exceeded",
+        "retryable": true,
+        "example_message": "rate limit exceeded"
       }
     }
   },

--- a/tests/golden/ws/errors.json
+++ b/tests/golden/ws/errors.json
@@ -9,11 +9,6 @@
   "error_codes": {
     "source": "src/gateway/protocol/schema/error-codes.ts ErrorCodes",
     "codes": {
-      "not_linked": {
-        "description": "Channel or service not linked/configured",
-        "retryable": false,
-        "example_message": "channel not linked"
-      },
       "not_paired": {
         "description": "Device identity not paired with gateway",
         "retryable": false,
@@ -22,11 +17,6 @@
           "Returned when device identity is required but not provided",
           "Also returned when device needs to re-pair (role/scope upgrade)"
         ]
-      },
-      "agent_timeout": {
-        "description": "Agent execution timed out",
-        "retryable": true,
-        "example_message": "agent timed out after 300000ms"
       },
       "invalid_request": {
         "description": "Request validation failed or invalid operation",
@@ -83,11 +73,6 @@
         "code": "not_paired",
         "message": "pairing required",
         "details": { "requestId": "req-abc123" }
-      },
-      {
-        "code": "agent_timeout",
-        "message": "agent timed out after 300000ms",
-        "retryable": true
       }
     ]
   },

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -362,7 +362,12 @@ fn test_ws_errors_trace_valid() {
     );
 
     // Validate required error codes
-    let required_error_codes = ["invalid_request", "not_paired", "unavailable"];
+    let required_error_codes = [
+        "invalid_request",
+        "not_paired",
+        "unavailable",
+        "rate_limited",
+    ];
     for code in required_error_codes {
         assert!(
             trace.error_codes.codes.contains_key(code),
@@ -388,8 +393,9 @@ fn test_ws_errors_trace_valid() {
             "error code '{}' should have description",
             code
         );
-        if code == "unavailable" {
-            assert!(def.retryable, "unavailable should be retryable");
+        let retryable_codes = ["unavailable", "rate_limited"];
+        if retryable_codes.contains(&code.as_str()) {
+            assert!(def.retryable, "error code '{}' should be retryable", code);
         } else {
             assert!(
                 !def.retryable,

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -9,24 +9,10 @@
 //! Integration tests (against a running gateway) are separate and gated behind
 //! a feature flag since they require a live server.
 
-#![allow(dead_code)] // Many fields are used only for validation via deserialization
-
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
-
-/// Root structure for golden trace files
-#[derive(Debug, Deserialize)]
-struct GoldenTrace {
-    #[serde(rename = "$schema")]
-    schema: Option<String>,
-    description: String,
-    #[serde(default)]
-    source_files: Vec<String>,
-    #[serde(flatten)]
-    extra: HashMap<String, Value>,
-}
 
 /// WebSocket handshake trace structure
 #[derive(Debug, Deserialize)]
@@ -36,7 +22,6 @@ struct WsHandshakeTrace {
     description: String,
     source_files: Vec<String>,
     protocol_version: u32,
-    notes: Vec<String>,
     scenarios: Vec<WsScenario>,
     connect_params_schema: Value,
     hello_ok_schema: Value,
@@ -47,17 +32,12 @@ struct WsScenario {
     name: String,
     description: String,
     #[serde(default)]
-    source_reference: Option<String>,
     steps: Vec<WsStep>,
-    #[serde(default)]
-    notes: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct WsStep {
     action: String,
-    #[serde(flatten)]
-    extra: HashMap<String, Value>,
 }
 
 /// WebSocket messages trace structure
@@ -85,12 +65,6 @@ struct WsEventsTrace {
 #[derive(Debug, Deserialize)]
 struct EventDefinition {
     description: String,
-    #[serde(default)]
-    source: Option<String>,
-    #[serde(default)]
-    payload_schema: Option<Value>,
-    #[serde(flatten)]
-    extra: HashMap<String, Value>,
 }
 
 /// WebSocket errors trace structure
@@ -102,8 +76,6 @@ struct WsErrorsTrace {
     source_files: Vec<String>,
     error_codes: ErrorCodesSection,
     close_codes: CloseCodesSection,
-    #[serde(flatten)]
-    extra: HashMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -115,8 +87,6 @@ struct ErrorCodesSection {
 
 #[derive(Debug, Deserialize)]
 struct CloseCodesSection {
-    #[serde(default)]
-    notes: Option<Vec<String>>,
     codes: HashMap<String, Value>,
 }
 
@@ -124,8 +94,6 @@ struct CloseCodesSection {
 struct ErrorCodeDef {
     description: String,
     retryable: bool,
-    #[serde(flatten)]
-    extra: HashMap<String, Value>,
 }
 
 /// HTTP endpoint trace structure
@@ -135,12 +103,6 @@ struct HttpEndpointTrace {
     schema: Option<String>,
     description: String,
     source_files: Vec<String>,
-    #[serde(default)]
-    endpoint: Option<String>,
-    #[serde(default)]
-    method: Option<String>,
-    #[serde(flatten)]
-    extra: HashMap<String, Value>,
 }
 
 // ============================================================================
@@ -298,11 +260,16 @@ fn test_ws_messages_trace_valid() {
         serde_json::from_str(&content).expect("Failed to parse messages.json");
 
     assert_eq!(trace.schema.as_deref(), Some("golden-trace-v1"));
+    assert!(
+        !trace.description.is_empty(),
+        "description should not be empty"
+    );
     assert!(!trace.source_files.is_empty());
     assert!(
         !trace.frame_types.is_empty(),
         "frame_types should not be empty"
     );
+    assert!(trace.methods.is_object(), "methods should be an object");
 
     // Validate frame types include req, res, event
     assert!(
@@ -327,6 +294,10 @@ fn test_ws_events_trace_valid() {
     let trace: WsEventsTrace = serde_json::from_str(&content).expect("Failed to parse events.json");
 
     assert_eq!(trace.schema.as_deref(), Some("golden-trace-v1"));
+    assert!(
+        !trace.description.is_empty(),
+        "description should not be empty"
+    );
     assert!(!trace.source_files.is_empty());
     assert!(!trace.events.is_empty(), "events should not be empty");
     assert!(
@@ -368,7 +339,19 @@ fn test_ws_errors_trace_valid() {
     let trace: WsErrorsTrace = serde_json::from_str(&content).expect("Failed to parse errors.json");
 
     assert_eq!(trace.schema.as_deref(), Some("golden-trace-v1"));
+    assert!(
+        !trace.description.is_empty(),
+        "description should not be empty"
+    );
     assert!(!trace.source_files.is_empty());
+    assert!(
+        trace
+            .error_codes
+            .source
+            .as_deref()
+            .is_some_and(|s| !s.is_empty()),
+        "error_codes.source should not be empty"
+    );
     assert!(
         !trace.error_codes.codes.is_empty(),
         "error_codes.codes should not be empty"
@@ -379,7 +362,7 @@ fn test_ws_errors_trace_valid() {
     );
 
     // Validate required error codes
-    let required_error_codes = ["invalid_request", "not_linked", "not_paired"];
+    let required_error_codes = ["invalid_request", "not_paired", "unavailable"];
     for code in required_error_codes {
         assert!(
             trace.error_codes.codes.contains_key(code),
@@ -405,6 +388,15 @@ fn test_ws_errors_trace_valid() {
             "error code '{}' should have description",
             code
         );
+        if code == "unavailable" {
+            assert!(def.retryable, "unavailable should be retryable");
+        } else {
+            assert!(
+                !def.retryable,
+                "error code '{}' should not be retryable",
+                code
+            );
+        }
     }
 }
 

--- a/tests/plugin_e2e.rs
+++ b/tests/plugin_e2e.rs
@@ -229,31 +229,18 @@ impl WebhookPluginInstance for MockWebhookPlugin {
 
 /// Mock service plugin
 struct MockServicePlugin {
-    #[allow(dead_code)]
-    id: String,
     running: AtomicBool,
     start_count: AtomicUsize,
     stop_count: AtomicUsize,
 }
 
 impl MockServicePlugin {
-    fn new(id: &str) -> Self {
+    fn new() -> Self {
         Self {
-            id: id.to_string(),
             running: AtomicBool::new(false),
             start_count: AtomicUsize::new(0),
             stop_count: AtomicUsize::new(0),
         }
-    }
-
-    #[allow(dead_code)]
-    fn start_count(&self) -> usize {
-        self.start_count.load(Ordering::SeqCst)
-    }
-
-    #[allow(dead_code)]
-    fn stop_count(&self) -> usize {
-        self.stop_count.load(Ordering::SeqCst)
     }
 }
 
@@ -734,8 +721,8 @@ fn test_registry_get_by_id() {
 fn test_service_lifecycle() {
     let registry = PluginRegistry::new();
 
-    let service1 = Arc::new(MockServicePlugin::new("worker-1"));
-    let service2 = Arc::new(MockServicePlugin::new("worker-2"));
+    let service1 = Arc::new(MockServicePlugin::new());
+    let service2 = Arc::new(MockServicePlugin::new());
 
     registry.register_service("worker-1".to_string(), service1.clone());
     registry.register_service("worker-2".to_string(), service2.clone());

--- a/tests/plugin_e2e.rs
+++ b/tests/plugin_e2e.rs
@@ -730,6 +730,10 @@ fn test_service_lifecycle() {
     // Initially not healthy
     assert!(!service1.health().unwrap());
     assert!(!service2.health().unwrap());
+    assert_eq!(service1.start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(service2.start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(service1.stop_count.load(Ordering::SeqCst), 0);
+    assert_eq!(service2.stop_count.load(Ordering::SeqCst), 0);
 
     // Start services
     for (_, service) in registry.get_services() {
@@ -738,6 +742,10 @@ fn test_service_lifecycle() {
 
     assert!(service1.health().unwrap());
     assert!(service2.health().unwrap());
+    assert_eq!(service1.start_count.load(Ordering::SeqCst), 1);
+    assert_eq!(service2.start_count.load(Ordering::SeqCst), 1);
+    assert_eq!(service1.stop_count.load(Ordering::SeqCst), 0);
+    assert_eq!(service2.stop_count.load(Ordering::SeqCst), 0);
 
     // Stop services
     for (_, service) in registry.get_services() {
@@ -746,6 +754,10 @@ fn test_service_lifecycle() {
 
     assert!(!service1.health().unwrap());
     assert!(!service2.health().unwrap());
+    assert_eq!(service1.start_count.load(Ordering::SeqCst), 1);
+    assert_eq!(service2.start_count.load(Ordering::SeqCst), 1);
+    assert_eq!(service1.stop_count.load(Ordering::SeqCst), 1);
+    assert_eq!(service2.stop_count.load(Ordering::SeqCst), 1);
 }
 
 // ============== Channel Plugin Tests ==============


### PR DESCRIPTION
## Summary

Closes #241.

This does the dead-code cleanup in one PR against current `master`.

Inventory/classification:

- Removed: explicit `dead_code` suppressions in tests/server code by deleting stale fields/helpers or turning deserialized golden fields into asserted validation.
- Removed: unused server middleware wrapper structs/functions (`SecurityHeadersLayer`, `CsrfLayer`, `RateLimitLayer`, and `layer*` helpers). The live router uses `middleware::from_fn_with_state` directly.
- Removed: unused node invoke helper surface (`send_node_invoke_request`), its now-unused registry lookup helper, and the unused pending invoke `command` field. The active node invoke path is `handle_node_invoke`.
- Removed: reserved-but-unemitted WebSocket error codes from code/golden/docs (`not_linked`, `agent_timeout`). Live emitted codes remain documented.
- Retained active contracts: importer modules, plugin/WIT ABI surfaces, config schema, persisted/security rejection paths, and credential/import behavior were not removed merely for looking old or compatibility-related.

## Validation

- `scripts/cargo-serial fmt`
- `scripts/cargo-serial check --all-targets`
- `scripts/cargo-serial clippy --all-targets -- -D warnings`
- `scripts/cargo-serial nextest run -p carapace --filter-expr 'test(golden) | test(security_headers) | test(csrf) | test(rate_limit) | test(plugin_registry_service) | test(service_lifecycle) | test(node_invoke)'`
- `scripts/cargo-serial nextest run` (3754/3754 passed)
