### PR TITLE
chore: prepare v0.8.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "carapace"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carapace"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.93"
 description = "A security-focused personal AI assistant — hardened alternative to openclaw/clawdbot"

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,178 @@
+## Summary
+
+- Provider setup and runtime routing now require explicit `provider:model`
+  IDs across config, request bodies, and WebSocket surfaces; bare and
+  slash-form model strings are rejected.
+- Provider coverage extends to Codex subscription-login, Vertex AI, Bedrock,
+  Venice AI, and the local Claude CLI alongside Anthropic, OpenAI, Gemini,
+  and Ollama.
+- WebSocket and HTTP configuration/model errors expose public-safe messages
+  and typed error codes while logging operator hints server-side.
+- Hot-reload bridge owns the provider-cache write so rejected reloads no
+  longer broadcast spurious change ticks; `build_providers` runs on
+  `spawn_blocking` so the runtime worker is not blocked during reload.
+- Built-in usage pricing table has been removed; `cost_usd` and per-period
+  `cost` fields are computed only from operator-configured rates under
+  `gateway.usage.pricing.{default,overrides}`. Cost-bearing WS responses
+  carry `pricingConfigured: bool` so clients can tell "not configured" from
+  "actually $0".
+- Security hardening rejects known plaintext credential files at startup
+  and unsupported encrypted config-secret envelopes at config load.
+
+## Breaking Changes
+
+- **Built-in usage pricing table removed.** `usage.status`, `usage.cost`,
+  `usage.session`, `usage.providers`, `usage.daily`, and `usage.monthly`
+  continue to track input/output tokens and request counts, but
+  `cost_usd` (and the per-period `cost` field on daily/monthly) is `0.0`
+  unless the operator configures rates under
+  `gateway.usage.pricing.{default,overrides}`. Each cost-bearing
+  response includes a top-level `pricingConfigured: bool`. A startup
+  warn fires once per process when usage tracking is enabled but no
+  pricing rates are configured. Carapace is not a billing source of
+  truth — provider rates change frequently with region, batch/flex
+  modes, cached-token discounts, subscriptions, and OpenAI-compatible
+  proxies, and we will not carry stale numbers that silently mislead.
+- **Bare and slash-form model IDs are rejected.** Use canonical
+  `provider:model` values: `anthropic:claude-sonnet-4-6`,
+  `anthropic:claude-opus-4-7`, `openai:gpt-5.5`,
+  `gemini:gemini-2.5-flash`, `vertex:gemini-2.5-flash`,
+  `bedrock:anthropic.claude-sonnet-4-6`, `ollama:llama3.2`,
+  `codex:default`, `venice:llama-3.3-70b`, or `claude-cli:default`.
+- **Classifier fallback rebound to the agent's primary model.**
+  `agents.defaults.classifier.model` previously defaulted to a
+  hard-coded `gpt-4o-mini` that was unroutable for non-OpenAI setups.
+  It now falls back to the agent's primary `model`. If your agent runs
+  on a strong model (e.g. `anthropic:claude-opus-4-7`,
+  `openai:gpt-5.5`), every classified message now hits that model.
+  Set `gateway.classifier.model` explicitly to a small/cheap model
+  like `openai:gpt-5-nano` or `anthropic:claude-haiku-4-5` for
+  cost-sensitive deployments.
+- **Plugin sandbox defaults are snake_case.**
+  `gateway.plugins.sandbox.defaults` keys are `allow_http`,
+  `allow_credentials`, `allow_media`. The camelCase form was always
+  silently ignored at runtime; the schema validator now warns on it
+  during config load.
+- **Removed compatibility shapes fail closed.** Config aliases removed
+  in earlier releases, old WebSocket method aliases, and removed wire
+  shapes now fail validation or return method errors instead of being
+  accepted.
+- **Plaintext credential files rejected at startup.** Gateway startup
+  refuses known plaintext credential files in the state directory.
+  Delete those files and re-enroll via current setup/import flows.
+- **Unsupported config-secret envelopes fail config load.** Re-enter or
+  re-encrypt secrets as supported `enc:v2` values.
+- **`cara backup` covers handled sections only.** Archives `sessions`,
+  `config`, `memory`, `cron`, `tasks`, and `usage`. Excludes OS
+  credential-store secrets, `auth_profiles.json`, managed plugin
+  binaries, node/device registries, and arbitrary state-dir files.
+  Preserve credential recovery material separately.
+- **Direct `/hooks/agent` JSON wire format is camelCase.** Field names
+  are `wakeMode`, `timeoutSeconds`, `allowUnsafeExternalContent`,
+  `veniceParameters`, `sessionKey`. Unchanged from v0.7 in shape; this
+  release supersedes intermediate doc drafts that suggested
+  snake_case.
+
+## Migration Steps
+
+1. Create a backup before upgrading and store credential recovery
+   material separately:
+   - `cara backup --output ./carapace-backup-v0.7.x.tar.gz`
+2. Convert any bare or slash-form model IDs in `config.json5` and
+   request bodies to canonical `provider:model` form.
+3. If you rely on cost reporting, set per-model rates under
+   `gateway.usage.pricing` before upgrading. Example:
+   ```json5
+   {
+     gateway: {
+       usage: {
+         pricing: {
+           default: { input_per_1m_usd: 0, output_per_1m_usd: 0 },
+           overrides: {
+             "anthropic:claude-sonnet-4-6": {
+               input_per_1m_usd: 3.0,
+               output_per_1m_usd: 15.0
+             }
+           }
+         }
+       }
+     }
+   }
+   ```
+4. If your agents rely on classifier-driven routing and you have not
+   set `gateway.classifier.model`, set it now to a small/cheap model
+   so every classified message does not run on your primary model.
+5. If your config uses `gateway.plugins.sandbox.defaults` with
+   camelCase keys (`allowHttp` etc.), rename them to snake_case.
+6. Remove any plaintext credential files reported by startup, then
+   re-run setup/import flows.
+7. Re-enter or re-encrypt unsupported encrypted config secrets as
+   `enc:v2` values.
+8. Recreate backups under the current format after the upgraded
+   binary is verified.
+
+## Rollback Steps
+
+1. Stop Cara.
+2. Reinstall the previous known-good binary (`v0.7.0` pinned tag).
+3. Restore the backup created before upgrade:
+   - `cara restore ./carapace-backup-v0.7.x.tar.gz`
+4. Revert any v0.8.0-only config changes (added `gateway.usage.pricing`
+   keys, snake_case sandbox key renames) before starting `v0.7.0`.
+5. Re-enroll any credentials intentionally excluded from
+   `cara backup`.
+6. Verify:
+   - `cara status --port 18789`
+   - `cara verify --outcome auto --port 18789`
+   - `cara verify --outcome autonomy --port 18789`
+
+## Security
+
+- Startup fails closed when known plaintext credential files are
+  detected.
+- Current config-secret envelopes use `enc:v2` with Argon2id-derived
+  keys; legacy envelopes are rejected at config load.
+- Session integrity uses HMAC sidecars for metadata, history, and
+  archives; with `sessions.integrity.action = "reject"`, tampered
+  state is rejected.
+- Encrypted sessions require `.crypto-manifest` plus
+  `CARAPACE_CONFIG_PASSWORD` for recovery.
+- CLI device identity uses the OS credential store when available
+  and falls back to `{state_dir}/device-identity.json`; set
+  `CARAPACE_DEVICE_IDENTITY_STRICT=1` to disable that fallback.
+- Bumped hickory-{net,proto,resolver} to 0.26.1 to address
+  RUSTSEC-2026-0119 and RUSTSEC-2026-0120 (DNS DoS).
+
+## Verification
+
+- Verify published artifacts and Sigstore bundles:
+  - `RELEASE_TAG=v0.8.0 ./scripts/smoke/verify-release-artifacts.sh`
+- After upgrading, verify runtime behavior:
+  - `cara verify --outcome auto`
+  - `cara verify --outcome autonomy`
+- Confirm `/health/ready` is ready and logs do not report provider
+  reload rollback, credential-shape rejection, or unconfigured-pricing
+  warnings you did not expect.
+- If you configured `gateway.usage.pricing`, issue a real request and
+  call `usage.cost`; confirm `pricingConfigured: true` and a non-zero
+  `totalCost`.
+
+## Known Caveats
+
+- Carapace does not ship per-provider price defaults. `cost_usd` is
+  `0.0` until rates are configured. This is intentional — operators
+  know their own contracts (region, batch mode, cached-token
+  discounts, subscriptions) better than we can encode in a shared
+  table.
+- Hot-reload bridge runs `build_providers` on `spawn_blocking`; the
+  runtime worker is no longer blocked during a provider rebuild.
+  Rejected reloads broadcast zero ticks on `CONFIG_CHANGE_TX` and
+  validate against the payload they carry rather than the latest
+  cache value.
+- WS `config.reload` routes through the same provider-validation
+  pipeline as the file-watcher and SIGHUP paths; reloads that drop
+  the LLM provider return `ERROR_UNAVAILABLE` to the WS client.
+- Signal read receipts, when enabled, are sent after durable append
+  and before assistant reply generation/delivery.
+- Plugin ABI remains `carapace:plugin@1.0.0`; WASM provider plugins
+  are identifiable but not wired into agent model selection.

--- a/src/server/ws/handlers/update.rs
+++ b/src/server/ws/handlers/update.rs
@@ -526,6 +526,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     async fn test_update_install_no_update() {
         let _lock = TEST_LOCK.lock().unwrap();
+        let (_tmp, _guard) = set_temp_state_dir();
         reset_state();
         let err = handle_update_install()
             .await
@@ -556,6 +557,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     async fn test_update_install_force_bypasses_no_update_guard() {
         let _lock = TEST_LOCK.lock().unwrap();
+        let (_tmp, _guard) = set_temp_state_dir();
         reset_state();
         let err = handle_update_install_with_force(true)
             .await


### PR DESCRIPTION
## Summary

- Bump `carapace` 0.7.0 → 0.8.0 in `Cargo.toml` / `Cargo.lock`.
- Commit `docs/releases/v0.8.0.md` so the tag-triggered release workflow has the required release-note file (it fails closed if missing).
- Isolate two `handle_update_install` tests from the host's real state dir so a leftover `updates/transaction.json` from prior `cara update` use does not flip the suite locally.

## Release-notes content

`docs/releases/v0.8.0.md` follows the template in `docs/RELEASE.md` (Summary, Breaking Changes, Migration Steps, Rollback Steps, Security, Verification, Known Caveats). Highlights:

- Provider setup and runtime routing now require explicit `provider:model` IDs.
- Provider coverage extends to Codex subscription-login, Vertex AI, Bedrock, Venice AI, and the local Claude CLI.
- Hot-reload bridge owns the cache write and runs `build_providers` on `spawn_blocking`; rejected reloads no longer broadcast spurious change ticks.
- Built-in usage pricing table removed. `cost_usd` is `0.0` unless the operator configures `gateway.usage.pricing.{default,overrides}`. Cost-bearing WS responses include `pricingConfigured: bool`.
- Classifier fallback now uses the agent's primary model instead of an unroutable hardcoded `gpt-4o-mini`.
- Plugin sandbox `defaults` keys are snake_case (camelCase warned and ignored).
- hickory-{net,proto,resolver} 0.26.1 (RUSTSEC-2026-0119, RUSTSEC-2026-0120).

## Validation

- `scripts/cargo-serial fmt --all --check` — clean
- `scripts/cargo-serial clippy --all-targets -- -D warnings` — clean
- `scripts/cargo-serial nextest run --all-targets -P fast` — 3754 passed (1 leaky, expected), 0 skipped
- `scripts/check-docs-state-messaging.sh` — clean
- Pre-push hook re-runs the full nextest suite — clean

## Next steps after merge

1. Confirm `master` CI green on the merge commit.
2. Tag `v0.8.0` annotated, push tag, watch `release.yml`.
3. Run `RELEASE_TAG=v0.8.0 ./scripts/smoke/verify-release-artifacts.sh`.
4. Smoke updates on macOS/Linux per `docs/RELEASE.md`.