### PR TITLE
test: add Matrix stabilization pins

### DIFF
--- a/src/agent/bedrock.rs
+++ b/src/agent/bedrock.rs
@@ -866,18 +866,12 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn random_hex(bytes_len: usize) -> String {
-        let mut bytes = vec![0u8; bytes_len];
-        getrandom::fill(&mut bytes).expect("random test bytes");
-        hex::encode(bytes)
-    }
-
     fn test_access_key() -> String {
-        format!("TESTACCESS{}", random_hex(8).to_uppercase())
+        crate::test_support::secrets::random_test_secret(16).to_uppercase()
     }
 
     fn test_secret_key() -> String {
-        format!("test-secret-{}", random_hex(16))
+        crate::test_support::secrets::random_test_secret(32)
     }
 
     fn test_provider(region: &str) -> BedrockProvider {

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -19472,6 +19472,23 @@ mod tests {
     /// `continue` is dropped.
     #[test]
     fn test_handle_invites_gates_on_allowlist_pin() {
+        fn matching_closing_brace(source: &str, open_brace_idx: usize) -> usize {
+            let mut depth = 0usize;
+            for (relative_idx, ch) in source[open_brace_idx..].char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth = depth.checked_sub(1).expect("brace depth underflow");
+                        if depth == 0 {
+                            return open_brace_idx + relative_idx;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            panic!("allowlist rejection arm must have a matching closing brace");
+        }
+
         let body = matrix_rs_fn_body("async fn handle_invites");
         let body = body.as_str();
         assert!(
@@ -19493,11 +19510,21 @@ mod tests {
         let allowlist_gate = body
             .find("if !allowed {")
             .expect("allowlist rejection arm must exist");
+        let rejection_open = allowlist_gate
+            + body[allowlist_gate..]
+                .find('{')
+                .expect("allowlist rejection arm must open with a brace");
+        let rejection_close = matching_closing_brace(body, rejection_open);
         let encrypted_room_gate = body[allowlist_gate..]
             .find("if !config.encrypted()")
             .map(|idx| allowlist_gate + idx)
             .expect("encrypted-room gate must follow allowlist rejection");
-        let rejection_arm = &body[allowlist_gate..encrypted_room_gate];
+        assert!(
+            rejection_close < encrypted_room_gate,
+            "allowlist rejection arm must close before encrypted-room handling; \
+             move this source-shape pin with any refactor that nests config.encrypted() in the arm"
+        );
+        let rejection_arm = &body[rejection_open..rejection_close];
         let leave_idx = rejection_arm
             .find("room.leave().await")
             .expect("allowlist rejection arm must leave the room");

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -19490,9 +19490,27 @@ mod tests {
             body.contains("room.leave().await"),
             "non-allowlisted invites must be rejected via room.leave()"
         );
+        let allowlist_gate = body
+            .find("if !allowed {")
+            .expect("allowlist rejection arm must exist");
+        let encrypted_room_gate = body[allowlist_gate..]
+            .find("if !config.encrypted()")
+            .map(|idx| allowlist_gate + idx)
+            .expect("encrypted-room gate must follow allowlist rejection");
+        let rejection_arm = &body[allowlist_gate..encrypted_room_gate];
+        let leave_idx = rejection_arm
+            .find("room.leave().await")
+            .expect("allowlist rejection arm must leave the room");
+        let continue_idx = rejection_arm
+            .rfind("continue;")
+            .expect("allowlist rejection arm must continue before later handling");
         assert!(
-            body.contains("continue;\n        }\n        if !config.encrypted()"),
-            "the allowlist rejection arm must continue before encrypted-room and join handling"
+            leave_idx < continue_idx,
+            "allowlist rejection must leave the room before continuing"
+        );
+        assert!(
+            !rejection_arm.contains("room.join().await"),
+            "allowlist rejection arm must not join the room"
         );
     }
 }

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -16279,6 +16279,44 @@ mod tests {
             json.get("last_error_kind").is_none(),
             "snake_case form must NOT appear; rename_all=camelCase governs"
         );
+
+        // Forensic timestamps are optional and usually absent, so
+        // the base shape above would not catch a rename regression.
+        // Pin the camelCase keys explicitly while populated.
+        let metadata_with_forensic_timestamps = MatrixStatusMetadata {
+            inbound_dlq_durability_error_at: Some(1_700_000_000_001),
+            inbound_dlq_lost_event_ids_at: Some(1_700_000_000_002),
+            last_inbound_failure_at: Some(1_700_000_000_003),
+            last_inbound_dlq_append_failure_at: Some(1_700_000_000_004),
+            first_recovery_key_minted_at: Some(1_700_000_000_005),
+            ..MatrixStatusMetadata::default()
+        };
+        let json = serde_json::to_value(&metadata_with_forensic_timestamps).expect("serialize");
+        for (key, expected) in [
+            ("inboundDlqDurabilityErrorAt", 1_700_000_000_001_i64),
+            ("inboundDlqLostEventIdsAt", 1_700_000_000_002_i64),
+            ("lastInboundFailureAt", 1_700_000_000_003_i64),
+            ("lastInboundDlqAppendFailureAt", 1_700_000_000_004_i64),
+            ("firstRecoveryKeyMintedAt", 1_700_000_000_005_i64),
+        ] {
+            assert_eq!(
+                json.get(key).and_then(|v| v.as_i64()),
+                Some(expected),
+                "{key} must serialize in camelCase when populated"
+            );
+        }
+        for snake_key in [
+            "inbound_dlq_durability_error_at",
+            "inbound_dlq_lost_event_ids_at",
+            "last_inbound_failure_at",
+            "last_inbound_dlq_append_failure_at",
+            "first_recovery_key_minted_at",
+        ] {
+            assert!(
+                json.get(snake_key).is_none(),
+                "{snake_key} must NOT appear on the MatrixStatusMetadata wire surface"
+            );
+        }
     }
 
     #[test]
@@ -19424,5 +19462,37 @@ mod tests {
                 "to-device verification classifier must include {event_type}"
             );
         }
+    }
+
+    /// Static-analysis pin for `handle_invites`: a non-allowlisted
+    /// inviter must always leave the invited room and continue the
+    /// loop before any join path can run. The SDK-heavy integration
+    /// fixture belongs with the fake-client seam; this pin catches
+    /// the local refactor class where the gate is loosened or the
+    /// `continue` is dropped.
+    #[test]
+    fn test_handle_invites_gates_on_allowlist_pin() {
+        let body = matrix_rs_fn_body("async fn handle_invites");
+        let body = body.as_str();
+        assert!(
+            body.contains("config.auto_join.allows_user(user_id)"),
+            "handle_invites must evaluate the raw inviter against the auto-join allowlist"
+        );
+        assert!(
+            body.contains("if !allowed {"),
+            "handle_invites must branch on the allowlist decision before attempting joins"
+        );
+        assert!(
+            body.contains("Matrix invite rejected by auto-join allowlist"),
+            "allowlist rejection must remain operator-visible"
+        );
+        assert!(
+            body.contains("room.leave().await"),
+            "non-allowlisted invites must be rejected via room.leave()"
+        );
+        assert!(
+            body.contains("continue;\n        }\n        if !config.encrypted()"),
+            "the allowlist rejection arm must continue before encrypted-room and join handling"
+        );
     }
 }

--- a/src/channels/slack_inbound.rs
+++ b/src/channels/slack_inbound.rs
@@ -86,9 +86,7 @@ mod tests {
     fn test_verify_slack_signature() {
         let body = br#"{"type":"url_verification","challenge":"abc"}"#;
         let timestamp = 1_700_000_000i64;
-        let mut secret_bytes = [0u8; 16];
-        getrandom::fill(&mut secret_bytes).expect("random slack test secret");
-        let secret = format!("test-signing-secret-{}", hex::encode(secret_bytes));
+        let secret = crate::test_support::secrets::random_test_secret(32);
         let base = format!("v0:{timestamp}:{}", String::from_utf8_lossy(body));
         let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
         mac.update(base.as_bytes());

--- a/src/server/control.rs
+++ b/src/server/control.rs
@@ -4295,7 +4295,19 @@ mod tests {
             .await
             .expect("body bytes");
         let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
-        let extra = &body["channels"][0]["extra"];
+        let channels = body["channels"]
+            .as_array()
+            .expect("channels must be a JSON array");
+        assert_eq!(
+            channels.len(),
+            1,
+            "test fixture must contain exactly the Matrix channel so projection failures are explicit"
+        );
+        let channel = channels
+            .iter()
+            .find(|channel| channel["id"] == "matrix")
+            .expect("Matrix channel must be present");
+        let extra = &channel["extra"];
         assert_eq!(extra["joinedRoomCount"], serde_json::json!(2));
         assert_eq!(extra["encryptedRoomCount"], serde_json::json!(1));
         assert_eq!(extra["unencryptedRoomCount"], serde_json::json!(1));

--- a/src/server/control.rs
+++ b/src/server/control.rs
@@ -4257,6 +4257,74 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_channels_handler_preserves_matrix_extra_wire_shape() {
+        use crate::channels::matrix::MatrixStatusMetadata;
+        use crate::channels::{ChannelInfo, ChannelMetadata, ChannelStatus};
+        use crate::server::connect_info::MaybeConnectInfo;
+
+        let (state, headers, addr) = loopback_test_state_no_auth();
+        let matrix_extra = MatrixStatusMetadata {
+            joined_room_count: 2,
+            encrypted_room_count: 1,
+            unencrypted_room_count: 1,
+            pending_verification_count: 1,
+            inbound_dlq_lost_event_ids: vec!["$lost:example.com".to_string()],
+            last_error_kind: Some("auth-token-revoked".to_string()),
+            inbound_dlq_durability_error_at: Some(1_700_000_000_001),
+            first_recovery_key_minted_at: Some(1_700_000_000_002),
+            ..MatrixStatusMetadata::default()
+        };
+        state.channel_registry.register(
+            ChannelInfo::new("matrix", "Matrix")
+                .with_status(ChannelStatus::Error)
+                .with_metadata(ChannelMetadata {
+                    last_error: Some("Matrix auth token revoked".to_string()),
+                    extra: Some(serde_json::to_value(matrix_extra).expect("matrix extra json")),
+                    ..ChannelMetadata::default()
+                }),
+        );
+
+        let response = super::channels_handler(
+            axum::extract::State(state),
+            MaybeConnectInfo(Some(addr)),
+            headers,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let extra = &body["channels"][0]["extra"];
+        assert_eq!(extra["joinedRoomCount"], serde_json::json!(2));
+        assert_eq!(extra["encryptedRoomCount"], serde_json::json!(1));
+        assert_eq!(extra["unencryptedRoomCount"], serde_json::json!(1));
+        assert_eq!(extra["pendingVerificationCount"], serde_json::json!(1));
+        assert_eq!(
+            extra["inboundDlqLostEventIds"],
+            serde_json::json!(["$lost:example.com"])
+        );
+        assert_eq!(
+            extra["lastErrorKind"],
+            serde_json::json!("auth-token-revoked")
+        );
+        assert_eq!(
+            extra["inboundDlqDurabilityErrorAt"],
+            serde_json::json!(1_700_000_000_001_i64)
+        );
+        assert_eq!(
+            extra["firstRecoveryKeyMintedAt"],
+            serde_json::json!(1_700_000_000_002_i64)
+        );
+        assert!(
+            extra.get("joined_room_count").is_none()
+                && extra.get("last_error_kind").is_none()
+                && extra.get("inbound_dlq_durability_error_at").is_none(),
+            "Matrix extra must preserve the camelCase wire shape through /control/channels"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_config_patch_rejects_blank_base_hash() {
         let _env_state_guard = crate::config::ScopedEnvStateForTest::new();
         let mut env = crate::test_support::env::ScopedEnv::new();

--- a/src/server/ws/handlers/sessions.rs
+++ b/src/server/ws/handlers/sessions.rs
@@ -3249,7 +3249,7 @@ mod tests {
     use crate::sessions;
 
     fn test_key_material() -> Vec<u8> {
-        format!("fixture-{}", uuid::Uuid::new_v4()).into_bytes()
+        crate::test_support::secrets::random_test_secret_bytes(32)
     }
 
     fn make_state_with_temp_sessions() -> (WsServerState, tempfile::TempDir) {

--- a/src/server/ws/tests.rs
+++ b/src/server/ws/tests.rs
@@ -1,12 +1,12 @@
 use super::*;
-use crate::test_support::env::ScopedEnv;
+use crate::test_support::{env::ScopedEnv, secrets::random_test_secret};
 use std::error::Error as _;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
 
 fn test_integrity_value() -> String {
-    format!("fixture-{}", uuid::Uuid::new_v4())
+    random_test_secret(32)
 }
 
 #[test]

--- a/src/sessions/crypto.rs
+++ b/src/sessions/crypto.rs
@@ -748,7 +748,7 @@ mod tests {
     use sha2::Digest;
 
     fn test_key_material() -> Vec<u8> {
-        format!("fixture-{}", uuid::Uuid::new_v4()).into_bytes()
+        crate::test_support::secrets::random_test_secret_bytes(32)
     }
 
     /// Pinned vector for the session-encryption per-purpose key

--- a/src/sessions/store.rs
+++ b/src/sessions/store.rs
@@ -5586,7 +5586,7 @@ mod tests {
     }
 
     fn test_key_material() -> Vec<u8> {
-        format!("fixture-{}", uuid::Uuid::new_v4()).into_bytes()
+        crate::test_support::secrets::random_test_secret_bytes(32)
     }
 
     fn create_matrix_test_session(store: &SessionStore, name: &str) -> Session {

--- a/src/test_support/mod.rs
+++ b/src/test_support/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod agent;
 pub(crate) mod config;
 pub(crate) mod env;
 pub(crate) mod plugins;
+pub(crate) mod secrets;

--- a/src/test_support/secrets.rs
+++ b/src/test_support/secrets.rs
@@ -5,5 +5,5 @@ pub(crate) fn random_test_secret(byte_len: usize) -> String {
 }
 
 pub(crate) fn random_test_secret_bytes(byte_len: usize) -> Vec<u8> {
-    random_test_secret(byte_len).into_bytes()
+    hex::decode(random_test_secret(byte_len)).expect("decode random test secret")
 }

--- a/src/test_support/secrets.rs
+++ b/src/test_support/secrets.rs
@@ -1,9 +1,14 @@
 //! Shared random secret fixtures for tests.
 
-pub(crate) fn random_test_secret(byte_len: usize) -> String {
-    crate::crypto::generate_hex_secret(byte_len).expect("generate random test secret")
+/// Generate a hex-encoded random test secret with `entropy_byte_len`
+/// bytes of entropy. The returned string is 2 * `entropy_byte_len`
+/// ASCII hex characters.
+pub(crate) fn random_test_secret(entropy_byte_len: usize) -> String {
+    crate::crypto::generate_hex_secret(entropy_byte_len).expect("generate random test secret")
 }
 
 pub(crate) fn random_test_secret_bytes(byte_len: usize) -> Vec<u8> {
-    hex::decode(random_test_secret(byte_len)).expect("decode random test secret")
+    let mut bytes = vec![0u8; byte_len];
+    getrandom::fill(&mut bytes).expect("generate random test secret bytes");
+    bytes
 }

--- a/src/test_support/secrets.rs
+++ b/src/test_support/secrets.rs
@@ -1,0 +1,9 @@
+//! Shared random secret fixtures for tests.
+
+pub(crate) fn random_test_secret(byte_len: usize) -> String {
+    crate::crypto::generate_hex_secret(byte_len).expect("generate random test secret")
+}
+
+pub(crate) fn random_test_secret_bytes(byte_len: usize) -> Vec<u8> {
+    random_test_secret(byte_len).into_bytes()
+}


### PR DESCRIPTION
## Summary

- replace the remaining crypto-adjacent test secret fixtures from #444 with a shared random test-secret helper
- add Matrix regression pins for status metadata forensic timestamp casing, `/control/channels` Matrix `extra` projection, and invite allowlist fallthrough

## Validation

- `rg -n 'format!\(\s*"fixture-|fixture-\{\}|test-secret-|test-signing-secret-|TESTACCESS|random_hex\(' src/server/ws/tests.rs src/server/ws/handlers/sessions.rs src/sessions/store.rs src/sessions/crypto.rs src/agent/bedrock.rs src/channels/slack_inbound.rs src/test_support/secrets.rs`
- `scripts/cargo-serial nextest run --all-targets -E 'test(test_pinned_matrix_status_metadata_wire_shape) or test(test_handle_invites_gates_on_allowlist_pin) or test(test_channels_handler_preserves_matrix_extra_wire_shape) or test(test_strip_carapace_secret_env_removes_documented_secrets) or test(test_verify_slack_signature) or test(test_new_accepts_valid_credentials) or test(test_sign_request_produces_required_headers) or test(test_sign_request_authorization_format)'`
- `scripts/cargo-serial nextest run --all-targets -E 'test(test_crypto_context_round_trip) or test(test_encrypted_session_store_round_trip) or test(test_handle_sessions_list_surfaces_locked_encrypted_sessions) or test(test_handle_sessions_list_applies_locked_filters_conjunctively)'`
- `scripts/cargo-serial fmt --check`
- `scripts/cargo-serial check --all-targets`
- `git diff --check`

Closes #444.
Refs #441.
