### PR TITLE
test: add matrix fake runtime seams

### DIFF
--- a/src/channels/inbound.rs
+++ b/src/channels/inbound.rs
@@ -624,7 +624,7 @@ mod tests {
 
     // The returned StableConfigFixture owns the installed config lifetime; bind
     // it by name in each async test so it is not dropped before the awaits.
-    fn install_empty_config() -> (
+    fn install_matrix_session_config() -> (
         serde_json::Value,
         crate::test_support::config::StableConfigFixture,
     ) {
@@ -661,7 +661,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_releases_claim_and_sends_no_receipt_when_append_fails() {
-        let (cfg, _fixture) = install_empty_config();
+        let (cfg, _fixture) = install_matrix_session_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -738,7 +738,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_continues_when_receipt_completion_fails() {
-        let (_cfg, _fixture) = install_empty_config();
+        let (_cfg, _fixture) = install_matrix_session_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(
@@ -812,7 +812,7 @@ mod tests {
     /// and `session_key` is returned so out-of-band callers can correlate.
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_no_provider_skips_register_without_orphan() {
-        let (_cfg, _fixture) = install_empty_config();
+        let (_cfg, _fixture) = install_matrix_session_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -874,7 +874,7 @@ mod tests {
     /// while production silently devolves to permanent retry.
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_classifies_history_file_full_as_permanent() {
-        let (_cfg, _fixture) = install_empty_config();
+        let (_cfg, _fixture) = install_matrix_session_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -945,7 +945,7 @@ mod tests {
     /// branch.
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_appends_without_dedupe_when_event_id_missing() {
-        let (_cfg, _fixture) = install_empty_config();
+        let (_cfg, _fixture) = install_matrix_session_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -1008,7 +1008,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_persists_inbound_event_id() {
-        let (_cfg, _fixture) = install_empty_config();
+        let (_cfg, _fixture) = install_matrix_session_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -1062,7 +1062,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_dedupes_inbound_event_id() {
-        let (_cfg, _fixture) = install_empty_config();
+        let (_cfg, _fixture) = install_matrix_session_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));

--- a/src/channels/inbound.rs
+++ b/src/channels/inbound.rs
@@ -622,6 +622,8 @@ mod tests {
 
     use crate::test_support::agent::StaticTestProvider;
 
+    // The returned StableConfigFixture owns the installed config lifetime; bind
+    // it by name in each async test so it is not dropped before the awaits.
     fn install_empty_config() -> (
         serde_json::Value,
         crate::test_support::config::StableConfigFixture,

--- a/src/channels/inbound.rs
+++ b/src/channels/inbound.rs
@@ -622,11 +622,25 @@ mod tests {
 
     use crate::test_support::agent::StaticTestProvider;
 
-    fn install_empty_config() -> serde_json::Value {
-        let cfg = json!({});
-        crate::config::clear_cache();
-        crate::config::update_cache(cfg.clone(), cfg.clone());
-        cfg
+    fn install_empty_config() -> (
+        serde_json::Value,
+        crate::test_support::config::StableConfigFixture,
+    ) {
+        let cfg = json!({
+            "channels": {
+                "matrix": {
+                    "session": {
+                        "scope": "per-channel-peer"
+                    }
+                }
+            }
+        });
+        let fixture = crate::test_support::config::StableConfigFixture::new(cfg.clone());
+        let resolved = crate::config::load_config_shared()
+            .expect("stable fixture config must load")
+            .as_ref()
+            .clone();
+        (resolved, fixture)
     }
 
     fn build_state(
@@ -645,7 +659,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_releases_claim_and_sends_no_receipt_when_append_fails() {
-        let cfg = install_empty_config();
+        let (cfg, _fixture) = install_empty_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -718,12 +732,11 @@ mod tests {
         );
 
         state.shutdown_activity_service().await;
-        crate::config::clear_cache();
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_continues_when_receipt_completion_fails() {
-        install_empty_config();
+        let (_cfg, _fixture) = install_empty_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(
@@ -788,7 +801,6 @@ mod tests {
         );
 
         state.shutdown_activity_service().await;
-        crate::config::clear_cache();
     }
 
     /// Pin the no-provider observable behavior on the inbound path: dispatch
@@ -798,7 +810,7 @@ mod tests {
     /// and `session_key` is returned so out-of-band callers can correlate.
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_no_provider_skips_register_without_orphan() {
-        install_empty_config();
+        let (_cfg, _fixture) = install_empty_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -844,7 +856,6 @@ mod tests {
         );
 
         state.shutdown_activity_service().await;
-        crate::config::clear_cache();
     }
 
     /// Integration pin for the HistoryFileFull classifier branch in
@@ -861,7 +872,7 @@ mod tests {
     /// while production silently devolves to permanent retry.
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_classifies_history_file_full_as_permanent() {
-        install_empty_config();
+        let (_cfg, _fixture) = install_empty_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -920,7 +931,6 @@ mod tests {
         );
 
         state.shutdown_activity_service().await;
-        crate::config::clear_cache();
     }
 
     /// Pin the `inbound_event_id = None` branch — the unguarded
@@ -933,7 +943,7 @@ mod tests {
     /// branch.
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_appends_without_dedupe_when_event_id_missing() {
-        install_empty_config();
+        let (_cfg, _fixture) = install_empty_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -992,12 +1002,11 @@ mod tests {
         }
 
         state.shutdown_activity_service().await;
-        crate::config::clear_cache();
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_persists_inbound_event_id() {
-        install_empty_config();
+        let (_cfg, _fixture) = install_empty_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -1047,12 +1056,11 @@ mod tests {
         );
 
         state.shutdown_activity_service().await;
-        crate::config::clear_cache();
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_dispatch_inbound_text_dedupes_inbound_event_id() {
-        install_empty_config();
+        let (_cfg, _fixture) = install_empty_config();
         let temp = tempfile::tempdir().expect("tempdir");
         let session_store = Arc::new(SessionStore::with_base_path(temp.path().to_path_buf()));
         let activity_service = Arc::new(ActivityService::with_limits_for_test(8, 1));
@@ -1134,6 +1142,5 @@ mod tests {
         );
 
         state.shutdown_activity_service().await;
-        crate::config::clear_cache();
     }
 }

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -11206,7 +11206,7 @@ async fn apply_verification_action(
     // MatrixVerificationAction variant compile-fails here, forcing
     // the contributor to deliberately classify whether the new
     // action needs the terminal-state guard.
-    guard_verification_action_terminal_state(flow_id, &action, flow.state.clone())?;
+    guard_verification_action_terminal_state(flow_id, &action, &flow.state)?;
     let audit_successful_confirm =
         matches!(action, MatrixVerificationAction::Confirm { matches: true });
     let parsed_user_id: OwnedUserId = flow
@@ -11389,7 +11389,7 @@ async fn apply_verification_action(
 fn guard_verification_action_terminal_state(
     flow_id: &str,
     action: &MatrixVerificationAction,
-    flow_state: MatrixVerificationState,
+    flow_state: &MatrixVerificationState,
 ) -> Result<(), MatrixError> {
     let needs_terminal_guard = match action {
         MatrixVerificationAction::Accept | MatrixVerificationAction::Confirm { .. } => true,
@@ -11399,7 +11399,7 @@ fn guard_verification_action_terminal_state(
     if needs_terminal_guard && flow_state.is_terminal() {
         return Err(MatrixError::VerificationCancelled {
             flow_id: flow_id.to_string(),
-            state: flow_state,
+            state: flow_state.clone(),
         });
     }
     Ok(())
@@ -18726,25 +18726,30 @@ mod tests {
     }
 
     #[test]
-    fn test_verification_terminal_guard_rejects_confirm_but_allows_cancel() {
-        let err = guard_verification_action_terminal_state(
-            "flow-1",
-            &MatrixVerificationAction::Confirm { matches: true },
-            MatrixVerificationState::Cancelled,
-        )
-        .expect_err("confirm against cancelled flow must be rejected before SDK lookup");
-        assert!(matches!(
-            err,
-            MatrixError::VerificationCancelled {
-                flow_id,
-                state: MatrixVerificationState::Cancelled,
-            } if flow_id == "flow-1"
-        ));
+    fn test_verification_terminal_guard_rejects_accept_and_confirm_but_allows_cancel() {
+        for action in [
+            MatrixVerificationAction::Accept,
+            MatrixVerificationAction::Confirm { matches: true },
+        ] {
+            let err = guard_verification_action_terminal_state(
+                "flow-1",
+                &action,
+                &MatrixVerificationState::Cancelled,
+            )
+            .expect_err("accept/confirm against cancelled flow must be rejected before SDK lookup");
+            assert!(matches!(
+                err,
+                MatrixError::VerificationCancelled {
+                    flow_id,
+                    state: MatrixVerificationState::Cancelled,
+                } if flow_id == "flow-1"
+            ));
+        }
 
         guard_verification_action_terminal_state(
             "flow-1",
             &MatrixVerificationAction::Cancel,
-            MatrixVerificationState::Cancelled,
+            &MatrixVerificationState::Cancelled,
         )
         .expect("cancel against cancelled flow is idempotent");
     }

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -7954,6 +7954,54 @@ async fn replay_matrix_inbound_dlq(
     ws_state: Arc<WsServerState>,
     state: Arc<RwLock<MatrixRuntimeState>>,
 ) -> Result<(), MatrixError> {
+    replay_matrix_inbound_dlq_with_dispatcher(
+        state_dir,
+        config,
+        ws_state,
+        state,
+        &ProductionMatrixDlqDispatcher,
+    )
+    .await
+}
+
+#[async_trait::async_trait]
+trait MatrixDlqDispatcher: Send + Sync {
+    async fn dispatch(
+        &self,
+        ws_state: Arc<WsServerState>,
+        state: Arc<RwLock<MatrixRuntimeState>>,
+        state_dir: &Path,
+        config: &MatrixConfig,
+        record: &MatrixInboundDlqRecord,
+    ) -> Result<(), MatrixError>;
+}
+
+struct ProductionMatrixDlqDispatcher;
+
+#[async_trait::async_trait]
+impl MatrixDlqDispatcher for ProductionMatrixDlqDispatcher {
+    async fn dispatch(
+        &self,
+        ws_state: Arc<WsServerState>,
+        state: Arc<RwLock<MatrixRuntimeState>>,
+        state_dir: &Path,
+        config: &MatrixConfig,
+        record: &MatrixInboundDlqRecord,
+    ) -> Result<(), MatrixError> {
+        dispatch_matrix_dlq_record(ws_state, state, state_dir, config, record).await
+    }
+}
+
+async fn replay_matrix_inbound_dlq_with_dispatcher<D>(
+    state_dir: &Path,
+    config: &MatrixConfig,
+    ws_state: Arc<WsServerState>,
+    state: Arc<RwLock<MatrixRuntimeState>>,
+    dispatcher: &D,
+) -> Result<(), MatrixError>
+where
+    D: MatrixDlqDispatcher,
+{
     let path = matrix_inbound_dlq_path(state_dir);
     let lock = state.read().dlq_io_lock();
 
@@ -8102,14 +8150,9 @@ async fn replay_matrix_inbound_dlq(
                 record,
                 legacy_envelope_version,
             } => {
-                match dispatch_matrix_dlq_record(
-                    ws_state.clone(),
-                    state.clone(),
-                    state_dir,
-                    config,
-                    &record,
-                )
-                .await
+                match dispatcher
+                    .dispatch(ws_state.clone(), state.clone(), state_dir, config, &record)
+                    .await
                 {
                     Ok(()) => {
                         if legacy_envelope_version.is_some() {
@@ -10222,6 +10265,98 @@ async fn handle_invites(
     config: &MatrixConfig,
     state: &Arc<RwLock<MatrixRuntimeState>>,
 ) -> Result<(), MatrixError> {
+    handle_invites_from_source(client.as_ref(), config, state).await
+}
+
+trait MatrixInviteSource {
+    type Room: MatrixInviteRoom;
+
+    fn invited_rooms(&self) -> Vec<Self::Room>;
+}
+
+#[async_trait::async_trait]
+trait MatrixInviteRoom: Send + Sync {
+    fn room_id_for_log(&self) -> String;
+    async fn invite_inviter(&self) -> Result<Option<String>, MatrixInviteFailure>;
+    fn definitely_encrypted(&self) -> bool;
+    async fn leave_invite(&self) -> Result<(), MatrixInviteFailure>;
+    async fn join_invite(&self) -> Result<(), MatrixInviteFailure>;
+}
+
+impl MatrixInviteSource for Client {
+    type Room = Room;
+
+    fn invited_rooms(&self) -> Vec<Self::Room> {
+        Client::invited_rooms(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl MatrixInviteRoom for Room {
+    fn room_id_for_log(&self) -> String {
+        self.room_id().to_string()
+    }
+
+    async fn invite_inviter(&self) -> Result<Option<String>, MatrixInviteFailure> {
+        let invite = self
+            .invite_details()
+            .await
+            .map_err(MatrixInviteFailure::from_display)?;
+        Ok(invite
+            .inviter
+            .as_ref()
+            .map(|member| member.user_id().to_string()))
+    }
+
+    fn definitely_encrypted(&self) -> bool {
+        is_invite_room_definitely_encrypted(self)
+    }
+
+    async fn leave_invite(&self) -> Result<(), MatrixInviteFailure> {
+        self.leave()
+            .await
+            .map_err(MatrixInviteFailure::from_display)
+    }
+
+    async fn join_invite(&self) -> Result<(), MatrixInviteFailure> {
+        self.join().await.map_err(MatrixInviteFailure::from_display)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MatrixInviteFailure {
+    message: String,
+}
+
+impl MatrixInviteFailure {
+    fn from_display(err: impl std::fmt::Display) -> Self {
+        Self {
+            message: crate::logging::redact::RedactedDisplay(&err).to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for MatrixInviteFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+async fn handle_invites_from_source<S>(
+    source: &S,
+    config: &MatrixConfig,
+    state: &Arc<RwLock<MatrixRuntimeState>>,
+) -> Result<(), MatrixError>
+where
+    S: MatrixInviteSource + Sync,
+{
     let mut failures = Vec::new();
     // Per-tick warn-emission cap for SDK call failures inside the
     // invite-handling loop. A hostile homeserver delivering 10K
@@ -10241,7 +10376,7 @@ async fn handle_invites(
     let mut suppressed_reject_failure_count = 0usize;
     let mut suppressed_encrypted_reject_failure_count = 0usize;
     let mut suppressed_join_failure_count = 0usize;
-    for room in client.invited_rooms() {
+    for room in source.invited_rooms() {
         // Sanitize peer-controlled identifiers once per iteration so
         // every log emission and operator-visible failure summary
         // below uses defense-in-depth-cleaned values. ruma's
@@ -10253,9 +10388,9 @@ async fn handle_invites(
         // allowlist match — sanitizing the allowlist input would
         // make a legitimate operator-configured allowlist entry
         // fail to match its own user.
-        let room_id_san = sanitize_homeserver_identifier(room.room_id().as_str());
-        let invite = match room.invite_details().await {
-            Ok(invite) => invite,
+        let room_id_san = sanitize_homeserver_identifier(&room.room_id_for_log());
+        let inviter = match room.invite_inviter().await {
+            Ok(inviter) => inviter,
             Err(err) => {
                 if inspect_failure_warn_count < INVITE_HANDLER_PER_KIND_WARN_CAP {
                     inspect_failure_warn_count += 1;
@@ -10278,10 +10413,6 @@ async fn handle_invites(
                 continue;
             }
         };
-        let inviter = invite
-            .inviter
-            .as_ref()
-            .map(|member| member.user_id().to_string());
         let inviter_san = inviter.as_deref().map(sanitize_homeserver_identifier);
         let allowed = inviter
             .as_deref()
@@ -10319,7 +10450,7 @@ async fn handle_invites(
                     "Matrix invite rejected by auto-join allowlist"
                 );
             }
-            if let Err(err) = room.leave().await {
+            if let Err(err) = room.leave_invite().await {
                 if reject_failure_warn_count < INVITE_HANDLER_PER_KIND_WARN_CAP {
                     reject_failure_warn_count += 1;
                     warn!(
@@ -10334,7 +10465,7 @@ async fn handle_invites(
             }
             continue;
         }
-        if !config.encrypted() && is_invite_room_definitely_encrypted(&room) {
+        if !config.encrypted() && room.definitely_encrypted() {
             let drop_total = record_matrix_peer_drop(state, MatrixPeerDropKind::EncryptedRoom);
             if should_log_matrix_peer_drop(drop_total) {
                 warn!(
@@ -10345,7 +10476,7 @@ async fn handle_invites(
                     "Matrix invite refused because room is encrypted and matrix.encrypted=false"
                 );
             }
-            if let Err(err) = room.leave().await {
+            if let Err(err) = room.leave_invite().await {
                 if encrypted_reject_failure_warn_count < INVITE_HANDLER_PER_KIND_WARN_CAP {
                     encrypted_reject_failure_warn_count += 1;
                     warn!(
@@ -10360,7 +10491,7 @@ async fn handle_invites(
             }
             continue;
         }
-        if let Err(err) = room.join().await {
+        if let Err(err) = room.join_invite().await {
             if join_failure_warn_count < INVITE_HANDLER_PER_KIND_WARN_CAP {
                 join_failure_warn_count += 1;
                 warn!(
@@ -11074,17 +11205,7 @@ async fn apply_verification_action(
     // MatrixVerificationAction variant compile-fails here, forcing
     // the contributor to deliberately classify whether the new
     // action needs the terminal-state guard.
-    let needs_terminal_guard = match action {
-        MatrixVerificationAction::Accept | MatrixVerificationAction::Confirm { .. } => true,
-        // Cancel is idempotent on terminal flows.
-        MatrixVerificationAction::Cancel => false,
-    };
-    if needs_terminal_guard && flow.state.is_terminal() {
-        return Err(MatrixError::VerificationCancelled {
-            flow_id: flow_id.to_string(),
-            state: flow.state,
-        });
-    }
+    guard_verification_action_terminal_state(flow_id, &action, flow.state.clone())?;
     let audit_successful_confirm =
         matches!(action, MatrixVerificationAction::Confirm { matches: true });
     let parsed_user_id: OwnedUserId = flow
@@ -11262,6 +11383,25 @@ async fn apply_verification_action(
     }
     prune_finished_verification_records(state);
     Ok(info)
+}
+
+fn guard_verification_action_terminal_state(
+    flow_id: &str,
+    action: &MatrixVerificationAction,
+    flow_state: MatrixVerificationState,
+) -> Result<(), MatrixError> {
+    let needs_terminal_guard = match action {
+        MatrixVerificationAction::Accept | MatrixVerificationAction::Confirm { .. } => true,
+        // Cancel is idempotent on terminal flows.
+        MatrixVerificationAction::Cancel => false,
+    };
+    if needs_terminal_guard && flow_state.is_terminal() {
+        return Err(MatrixError::VerificationCancelled {
+            flow_id: flow_id.to_string(),
+            state: flow_state,
+        });
+    }
+    Ok(())
 }
 
 /// How a verification-state update should treat the stored SAS data.
@@ -13179,6 +13319,140 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct FakeInviteSource {
+        rooms: Vec<FakeInviteRoom>,
+    }
+
+    impl MatrixInviteSource for FakeInviteSource {
+        type Room = FakeInviteRoom;
+
+        fn invited_rooms(&self) -> Vec<Self::Room> {
+            self.rooms.clone()
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeInviteRoom {
+        room_id: String,
+        inviter: Result<Option<String>, String>,
+        definitely_encrypted: bool,
+        leave_error: Option<String>,
+        join_error: Option<String>,
+        leave_count: Arc<std::sync::atomic::AtomicUsize>,
+        join_count: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl FakeInviteRoom {
+        fn new(room_id: &str, inviter: Option<&str>, definitely_encrypted: bool) -> Self {
+            Self {
+                room_id: room_id.to_string(),
+                inviter: Ok(inviter.map(str::to_string)),
+                definitely_encrypted,
+                leave_error: None,
+                join_error: None,
+                leave_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                join_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }
+        }
+
+        fn inspect_error(room_id: &str, message: &str) -> Self {
+            Self {
+                room_id: room_id.to_string(),
+                inviter: Err(message.to_string()),
+                definitely_encrypted: false,
+                leave_error: None,
+                join_error: None,
+                leave_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                join_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }
+        }
+
+        fn leave_count(&self) -> usize {
+            self.leave_count.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn join_count(&self) -> usize {
+            self.join_count.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MatrixInviteRoom for FakeInviteRoom {
+        fn room_id_for_log(&self) -> String {
+            self.room_id.clone()
+        }
+
+        async fn invite_inviter(&self) -> Result<Option<String>, MatrixInviteFailure> {
+            self.inviter
+                .clone()
+                .map_err(MatrixInviteFailure::from_message)
+        }
+
+        fn definitely_encrypted(&self) -> bool {
+            self.definitely_encrypted
+        }
+
+        async fn leave_invite(&self) -> Result<(), MatrixInviteFailure> {
+            self.leave_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.leave_error
+                .clone()
+                .map(MatrixInviteFailure::from_message)
+                .map_or(Ok(()), Err)
+        }
+
+        async fn join_invite(&self) -> Result<(), MatrixInviteFailure> {
+            self.join_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.join_error
+                .clone()
+                .map(MatrixInviteFailure::from_message)
+                .map_or(Ok(()), Err)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingDlqDispatcher {
+        records: ParkingMutex<Vec<MatrixInboundDlqRecord>>,
+        fail_dispatch: bool,
+    }
+
+    impl RecordingDlqDispatcher {
+        fn failing() -> Self {
+            Self {
+                records: ParkingMutex::new(Vec::new()),
+                fail_dispatch: true,
+            }
+        }
+
+        fn records(&self) -> Vec<MatrixInboundDlqRecord> {
+            self.records.lock().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MatrixDlqDispatcher for RecordingDlqDispatcher {
+        async fn dispatch(
+            &self,
+            _ws_state: Arc<WsServerState>,
+            state: Arc<RwLock<MatrixRuntimeState>>,
+            _state_dir: &Path,
+            _config: &MatrixConfig,
+            record: &MatrixInboundDlqRecord,
+        ) -> Result<(), MatrixError> {
+            self.records.lock().push(record.clone());
+            if self.fail_dispatch {
+                Err(MatrixError::SyncFailed(
+                    "scripted DLQ dispatch failure".into(),
+                ))
+            } else {
+                state.write().reset_inbound_failures();
+                Ok(())
+            }
+        }
+    }
+
     #[test]
     fn test_sha256_hasher_zeroizes_on_drop_for_recovery_digests() {
         fn assert_zeroizes_on_drop<T: zeroize::ZeroizeOnDrop>() {}
@@ -14241,6 +14515,93 @@ mod tests {
         assert!(
             !state.read().inbound_streak_is_sticky(),
             "successful dispatch must reset the inbound failure streak"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_dlq_replay_decodes_encrypted_record_through_fake_dispatcher() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = matrix_test_config(true);
+        let state = Arc::new(RwLock::new(MatrixRuntimeState::default()));
+        let record = matrix_test_dlq_record();
+        let path = matrix_inbound_dlq_path(temp.path());
+        std::fs::create_dir_all(path.parent().expect("DLQ parent")).expect("create DLQ parent");
+        let line =
+            encode_matrix_inbound_dlq_record(temp.path(), &config, &record).expect("encode DLQ");
+        assert!(
+            line.contains("\"version\":2"),
+            "encrypted replay fixture must use the current v2 DLQ envelope"
+        );
+        std::fs::write(&path, format!("{line}\n")).expect("write DLQ line");
+
+        let dispatcher = RecordingDlqDispatcher::default();
+        let ws_state = Arc::new(crate::server::ws::WsServerState::new(
+            crate::server::ws::WsServerConfig::default(),
+        ));
+        replay_matrix_inbound_dlq_with_dispatcher(
+            temp.path(),
+            &config,
+            ws_state,
+            state.clone(),
+            &dispatcher,
+        )
+        .await
+        .expect("encrypted DLQ replay must dispatch successfully");
+
+        assert_eq!(
+            dispatcher.records(),
+            vec![record],
+            "fake dispatcher must see the decoded plaintext record from the encrypted on-disk line"
+        );
+        assert!(
+            !path.exists(),
+            "successful fake-dispatched replay must drain the encrypted DLQ file"
+        );
+        assert!(
+            !state.read().inbound_durability_error_is_sticky(),
+            "successful fake-dispatched replay must leave no sticky durability error"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_dlq_replay_fake_dispatch_failure_retains_decoded_record() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = matrix_test_config(true);
+        let state = Arc::new(RwLock::new(MatrixRuntimeState::default()));
+        let record = matrix_test_dlq_record();
+        let path = matrix_inbound_dlq_path(temp.path());
+        std::fs::create_dir_all(path.parent().expect("DLQ parent")).expect("create DLQ parent");
+        let line =
+            encode_matrix_inbound_dlq_record(temp.path(), &config, &record).expect("encode DLQ");
+        std::fs::write(&path, format!("{line}\n")).expect("write DLQ line");
+
+        let dispatcher = RecordingDlqDispatcher::failing();
+        let ws_state = Arc::new(crate::server::ws::WsServerState::new(
+            crate::server::ws::WsServerConfig::default(),
+        ));
+        let err = replay_matrix_inbound_dlq_with_dispatcher(
+            temp.path(),
+            &config,
+            ws_state,
+            state,
+            &dispatcher,
+        )
+        .await
+        .expect_err("scripted dispatch failure must keep the record retryable");
+
+        assert!(
+            err.to_string()
+                .contains("Matrix inbound DLQ replay still has 1 undelivered"),
+            "dispatch failure must propagate the replay-retention summary: {err}"
+        );
+        assert_eq!(
+            dispatcher.records(),
+            vec![record],
+            "fake dispatcher must receive the decoded record before replay retains it"
+        );
+        assert!(
+            path.exists(),
+            "dispatch-failed encrypted record must remain on disk for the next replay tick"
         );
     }
 
@@ -17434,7 +17795,7 @@ mod tests {
     /// becomes empty before decoding).
     #[test]
     fn test_replay_matrix_inbound_dlq_cap_clamp_wiring_pinned() {
-        let body = matrix_rs_fn_body("async fn replay_matrix_inbound_dlq");
+        let body = matrix_rs_fn_body("async fn replay_matrix_inbound_dlq_with_dispatcher");
         let body = body.as_str();
 
         // The tail must be sliced from the cap (not to it). A
@@ -17865,6 +18226,98 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_invites_fake_sdk_allowlist_and_encryption_paths() {
+        let allowed =
+            FakeInviteRoom::new("!allowed:example.com", Some("@alice:example.com"), false);
+        let rejected = FakeInviteRoom::new(
+            "!rejected\x1b[31m:example.com",
+            Some("@mallory:evil.com"),
+            false,
+        );
+        let encrypted =
+            FakeInviteRoom::new("!encrypted:example.com", Some("@alice:example.com"), true);
+        let source = FakeInviteSource {
+            rooms: vec![allowed.clone(), rejected.clone(), encrypted.clone()],
+        };
+        let config = matrix_test_config(false);
+        let state = Arc::new(RwLock::new(MatrixRuntimeState::default()));
+
+        handle_invites_from_source(&source, &config, &state)
+            .await
+            .expect("non-failing fake invite operations must succeed");
+
+        assert_eq!(allowed.join_count(), 1, "allowlisted invite must join");
+        assert_eq!(
+            allowed.leave_count(),
+            0,
+            "allowlisted invite must not leave"
+        );
+        assert_eq!(
+            rejected.join_count(),
+            0,
+            "non-allowlisted invite must not join"
+        );
+        assert_eq!(
+            rejected.leave_count(),
+            1,
+            "non-allowlisted invite must be rejected"
+        );
+        assert_eq!(
+            encrypted.join_count(),
+            0,
+            "definitely encrypted invite must not join when matrix.encrypted=false"
+        );
+        assert_eq!(
+            encrypted.leave_count(),
+            1,
+            "definitely encrypted invite must be rejected when matrix.encrypted=false"
+        );
+
+        let status = state.read().status();
+        assert_eq!(status.peer_drop_allowlist_rejection_total, 1);
+        assert_eq!(status.peer_drop_encrypted_room_total, 1);
+        assert!(
+            state.read().invite_systemic_error().is_none(),
+            "successful leave/join operations must not stamp a systemic invite error"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_invites_fake_sdk_systemic_failures_stamp_state() {
+        let source = FakeInviteSource {
+            rooms: vec![
+                FakeInviteRoom::inspect_error("!one:example.com", "inspect 500"),
+                FakeInviteRoom::inspect_error("!two:example.com", "inspect 501"),
+                FakeInviteRoom::inspect_error("!three:example.com", "inspect 502"),
+            ],
+        };
+        let config = matrix_test_config(false);
+        let state = Arc::new(RwLock::new(MatrixRuntimeState::default()));
+
+        let err = handle_invites_from_source(&source, &config, &state)
+            .await
+            .expect_err("threshold fake failures must surface as invite handling failure");
+        assert!(
+            err.to_string()
+                .starts_with("Matrix sync failed: Matrix invite handling failures (3):"),
+            "invite handler must return the aggregate failure shape: {err}"
+        );
+        let marker = state
+            .read()
+            .invite_systemic_error()
+            .expect("threshold fake failures must stamp systemic marker")
+            .to_string();
+        assert!(
+            marker.starts_with("Matrix invite handling: 3 failures in one maintenance tick:"),
+            "systemic marker must carry the operator-facing failure count: {marker}"
+        );
+        assert!(
+            marker.contains("!one:example.com inspect failed: inspect 500"),
+            "systemic marker must include the sanitized first failure preview: {marker}"
+        );
+    }
+
     /// Sanitizer must strip control bytes, bidi/zero-width
     /// formatting, combining marks (so `D` + U+0301 doesn't visually
     /// duplicate `D`, defeating SAS-confirm), and TAG codepoints
@@ -18199,6 +18652,30 @@ mod tests {
             .expect("flow-1 must exist");
         assert!(found.state.is_terminal());
         assert_eq!(found.state, MatrixVerificationState::Cancelled);
+    }
+
+    #[test]
+    fn test_verification_terminal_guard_rejects_confirm_but_allows_cancel() {
+        let err = guard_verification_action_terminal_state(
+            "flow-1",
+            &MatrixVerificationAction::Confirm { matches: true },
+            MatrixVerificationState::Cancelled,
+        )
+        .expect_err("confirm against cancelled flow must be rejected before SDK lookup");
+        assert!(matches!(
+            err,
+            MatrixError::VerificationCancelled {
+                flow_id,
+                state: MatrixVerificationState::Cancelled,
+            } if flow_id == "flow-1"
+        ));
+
+        guard_verification_action_terminal_state(
+            "flow-1",
+            &MatrixVerificationAction::Cancel,
+            MatrixVerificationState::Cancelled,
+        )
+        .expect("cancel against cancelled flow is idempotent");
     }
 
     /// `MatrixError::InterruptedRekey`'s Display starts with a
@@ -19489,23 +19966,23 @@ mod tests {
             panic!("allowlist rejection arm must have a matching closing brace");
         }
 
-        let body = matrix_rs_fn_body("async fn handle_invites");
+        let body = matrix_rs_fn_body("async fn handle_invites_from_source");
         let body = body.as_str();
         assert!(
             body.contains("config.auto_join.allows_user(user_id)"),
-            "handle_invites must evaluate the raw inviter against the auto-join allowlist"
+            "handle_invites_from_source must evaluate the raw inviter against the auto-join allowlist"
         );
         assert!(
             body.contains("if !allowed {"),
-            "handle_invites must branch on the allowlist decision before attempting joins"
+            "handle_invites_from_source must branch on the allowlist decision before attempting joins"
         );
         assert!(
             body.contains("Matrix invite rejected by auto-join allowlist"),
             "allowlist rejection must remain operator-visible"
         );
         assert!(
-            body.contains("room.leave().await"),
-            "non-allowlisted invites must be rejected via room.leave()"
+            body.contains("room.leave_invite().await"),
+            "non-allowlisted invites must be rejected via room.leave_invite()"
         );
         let allowlist_gate = body
             .find("if !allowed {")
@@ -19526,7 +20003,7 @@ mod tests {
         );
         let rejection_arm = &body[rejection_open..rejection_close];
         let leave_idx = rejection_arm
-            .find("room.leave().await")
+            .find("room.leave_invite().await")
             .expect("allowlist rejection arm must leave the room");
         let continue_idx = rejection_arm
             .rfind("continue;")
@@ -19536,7 +20013,7 @@ mod tests {
             "allowlist rejection must leave the room before continuing"
         );
         assert!(
-            !rejection_arm.contains("room.join().await"),
+            !rejection_arm.contains("room.join_invite().await"),
             "allowlist rejection arm must not join the room"
         );
     }

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -14551,6 +14551,14 @@ mod tests {
         );
         std::fs::write(&path, format!("{line}\n")).expect("write DLQ line");
 
+        state
+            .write()
+            .record_inbound_dlq_append_failure("transient EIO".to_string());
+        assert!(
+            state.read().inbound_durability_error_is_sticky(),
+            "test precondition: fake-dispatched replay must clear a planted durability error"
+        );
+
         let dispatcher = RecordingDlqDispatcher::default();
         let ws_state = Arc::new(crate::server::ws::WsServerState::new(
             crate::server::ws::WsServerConfig::default(),
@@ -18734,31 +18742,36 @@ mod tests {
 
     #[test]
     fn test_verification_terminal_guard_rejects_accept_and_confirm_but_allows_cancel() {
-        for action in [
-            MatrixVerificationAction::Accept,
-            MatrixVerificationAction::Confirm { matches: true },
+        for terminal_state in [
+            MatrixVerificationState::Cancelled,
+            MatrixVerificationState::Done,
+            MatrixVerificationState::Mismatched,
         ] {
-            let err = guard_verification_action_terminal_state(
-                "flow-1",
-                &action,
-                &MatrixVerificationState::Cancelled,
-            )
-            .expect_err("accept/confirm against cancelled flow must be rejected before SDK lookup");
-            assert!(matches!(
-                err,
-                MatrixError::VerificationCancelled {
-                    flow_id,
-                    state: MatrixVerificationState::Cancelled,
-                } if flow_id == "flow-1"
-            ));
-        }
+            for action in [
+                MatrixVerificationAction::Accept,
+                MatrixVerificationAction::Confirm { matches: true },
+            ] {
+                let err =
+                    guard_verification_action_terminal_state("flow-1", &action, &terminal_state)
+                        .expect_err(
+                        "accept/confirm against terminal flow must be rejected before SDK lookup",
+                    );
+                assert!(matches!(
+                    err,
+                    MatrixError::VerificationCancelled {
+                        flow_id,
+                        state,
+                    } if flow_id == "flow-1" && state == terminal_state
+                ));
+            }
 
-        guard_verification_action_terminal_state(
-            "flow-1",
-            &MatrixVerificationAction::Cancel,
-            &MatrixVerificationState::Cancelled,
-        )
-        .expect("cancel against cancelled flow is idempotent");
+            guard_verification_action_terminal_state(
+                "flow-1",
+                &MatrixVerificationAction::Cancel,
+                &terminal_state,
+            )
+            .expect("cancel against terminal flow is idempotent");
+        }
     }
 
     /// `MatrixError::InterruptedRekey`'s Display starts with a

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -13447,7 +13447,7 @@ mod tests {
         async fn dispatch(
             &self,
             _ws_state: Arc<WsServerState>,
-            state: Arc<RwLock<MatrixRuntimeState>>,
+            _state: Arc<RwLock<MatrixRuntimeState>>,
             _state_dir: &Path,
             _config: &MatrixConfig,
             record: &MatrixInboundDlqRecord,
@@ -13458,7 +13458,6 @@ mod tests {
                     "scripted DLQ dispatch failure".into(),
                 ))
             } else {
-                state.write().reset_inbound_failures();
                 Ok(())
             }
         }

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -7965,6 +7965,9 @@ async fn replay_matrix_inbound_dlq(
     .await
 }
 
+// Internal test seam: production dispatch still delegates to
+// dispatch_matrix_dlq_record, while tests can record or fail dispatches without
+// taking ownership of the replay loop's state-reset behavior.
 #[async_trait::async_trait]
 trait MatrixDlqDispatcher: Send + Sync {
     async fn dispatch(
@@ -10269,6 +10272,8 @@ async fn handle_invites(
     handle_invites_from_source(client.as_ref(), config, state).await
 }
 
+// Internal test seam: production impls delegate to the Matrix SDK, while unit
+// tests provide fakes for invite policy and failure accounting.
 trait MatrixInviteSource: Sync {
     type Room: MatrixInviteRoom;
 
@@ -10337,6 +10342,8 @@ impl MatrixInviteFailure {
     }
 
     #[cfg(test)]
+    // Intentionally unredacted for scripted fake errors. Production call sites
+    // must use from_display so homeserver-controlled errors pass RedactedDisplay.
     fn from_message(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -4,6 +4,7 @@
 //! sync loop, invite policy, and the bounded outbound actor used by the
 //! synchronous channel plugin contract.
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::io::{BufRead, BufReader};
@@ -10268,7 +10269,7 @@ async fn handle_invites(
     handle_invites_from_source(client.as_ref(), config, state).await
 }
 
-trait MatrixInviteSource {
+trait MatrixInviteSource: Sync {
     type Room: MatrixInviteRoom;
 
     fn invited_rooms(&self) -> Vec<Self::Room>;
@@ -10276,7 +10277,7 @@ trait MatrixInviteSource {
 
 #[async_trait::async_trait]
 trait MatrixInviteRoom: Send + Sync {
-    fn room_id_for_log(&self) -> String;
+    fn room_id_for_log(&self) -> Cow<'_, str>;
     async fn invite_inviter(&self) -> Result<Option<String>, MatrixInviteFailure>;
     fn definitely_encrypted(&self) -> bool;
     async fn leave_invite(&self) -> Result<(), MatrixInviteFailure>;
@@ -10293,8 +10294,8 @@ impl MatrixInviteSource for Client {
 
 #[async_trait::async_trait]
 impl MatrixInviteRoom for Room {
-    fn room_id_for_log(&self) -> String {
-        self.room_id().to_string()
+    fn room_id_for_log(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self.room_id().as_str())
     }
 
     async fn invite_inviter(&self) -> Result<Option<String>, MatrixInviteFailure> {
@@ -10355,7 +10356,7 @@ async fn handle_invites_from_source<S>(
     state: &Arc<RwLock<MatrixRuntimeState>>,
 ) -> Result<(), MatrixError>
 where
-    S: MatrixInviteSource + Sync,
+    S: MatrixInviteSource,
 {
     let mut failures = Vec::new();
     // Per-tick warn-emission cap for SDK call failures inside the
@@ -10388,7 +10389,7 @@ where
         // allowlist match — sanitizing the allowlist input would
         // make a legitimate operator-configured allowlist entry
         // fail to match its own user.
-        let room_id_san = sanitize_homeserver_identifier(&room.room_id_for_log());
+        let room_id_san = sanitize_homeserver_identifier(room.room_id_for_log().as_ref());
         let inviter = match room.invite_inviter().await {
             Ok(inviter) => inviter,
             Err(err) => {
@@ -13368,6 +13369,16 @@ mod tests {
             }
         }
 
+        fn with_leave_error(mut self, message: &str) -> Self {
+            self.leave_error = Some(message.to_string());
+            self
+        }
+
+        fn with_join_error(mut self, message: &str) -> Self {
+            self.join_error = Some(message.to_string());
+            self
+        }
+
         fn leave_count(&self) -> usize {
             self.leave_count.load(std::sync::atomic::Ordering::SeqCst)
         }
@@ -13379,8 +13390,8 @@ mod tests {
 
     #[async_trait::async_trait]
     impl MatrixInviteRoom for FakeInviteRoom {
-        fn room_id_for_log(&self) -> String {
-            self.room_id.clone()
+        fn room_id_for_log(&self) -> Cow<'_, str> {
+            Cow::Borrowed(self.room_id.as_str())
         }
 
         async fn invite_inviter(&self) -> Result<Option<String>, MatrixInviteFailure> {
@@ -18315,6 +18326,67 @@ mod tests {
         assert!(
             marker.contains("!one:example.com inspect failed: inspect 500"),
             "systemic marker must include the sanitized first failure preview: {marker}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_invites_fake_sdk_leave_and_join_failures_stamp_state() {
+        let reject_leave = FakeInviteRoom::new(
+            "!reject-leave:example.com",
+            Some("@mallory:evil.com"),
+            false,
+        )
+        .with_leave_error("reject EIO");
+        let encrypted_leave = FakeInviteRoom::new(
+            "!encrypted-leave:example.com",
+            Some("@alice:example.com"),
+            true,
+        )
+        .with_leave_error("encrypted EIO");
+        let join_failure = FakeInviteRoom::new(
+            "!join-failure:example.com",
+            Some("@alice:example.com"),
+            false,
+        )
+        .with_join_error("join EIO");
+        let source = FakeInviteSource {
+            rooms: vec![
+                reject_leave.clone(),
+                encrypted_leave.clone(),
+                join_failure.clone(),
+            ],
+        };
+        let config = matrix_test_config(false);
+        let state = Arc::new(RwLock::new(MatrixRuntimeState::default()));
+
+        let err = handle_invites_from_source(&source, &config, &state)
+            .await
+            .expect_err("scripted leave/join failures must surface as invite handling failure");
+        assert!(
+            err.to_string()
+                .starts_with("Matrix sync failed: Matrix invite handling failures (3):"),
+            "leave/join failures must return the aggregate failure shape: {err}"
+        );
+        assert_eq!(reject_leave.leave_count(), 1);
+        assert_eq!(encrypted_leave.leave_count(), 1);
+        assert_eq!(join_failure.join_count(), 1);
+
+        let marker = state
+            .read()
+            .invite_systemic_error()
+            .expect("threshold leave/join failures must stamp systemic marker")
+            .to_string();
+        assert!(
+            marker.contains("!reject-leave:example.com reject failed: reject EIO"),
+            "allowlist leave failure must feed the systemic failure preview: {marker}"
+        );
+        assert!(
+            marker.contains("!encrypted-leave:example.com encrypted reject failed: encrypted EIO"),
+            "encrypted-room leave failure must feed the systemic failure preview: {marker}"
+        );
+        assert!(
+            marker.contains("!join-failure:example.com join failed: join EIO"),
+            "join failure must feed the systemic failure preview: {marker}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add trait-backed fake seams for Matrix invite maintenance and inbound DLQ replay dispatch.
- Add fake-driven tests for invite allowlist join/reject behavior, encrypted-room refusal, systemic invite failure stamping, encrypted DLQ replay success, encrypted DLQ replay retention on dispatch failure, and the verification terminal-state guard.
- Update source-shape pins to follow the new production-owned helper boundaries.

## Validation

- `scripts/cargo-serial nextest run --all-targets -E 'test(/channels::matrix::tests::/)'`
- `scripts/cargo-serial fmt --check`
- `scripts/cargo-serial check --all-targets`
- `scripts/cargo-serial clippy --all-targets --all-features -- -D warnings`

Refs #446.
Refs #441.
