### PR TITLE
docs: README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Active and planned work is tracked on
 The [feature inventory](docs/feature-status.yaml) is the source of truth for
 what currently ships.
 
-Recently shipped highlights are tracked in
-[docs/releases/v0.8.0.md](docs/releases/v0.8.0.md) (most recent stable release).
+Recently shipped highlights are tracked on the
+[GitHub Releases](https://github.com/puremachinery/carapace/releases) page.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,7 @@ A hardened alternative to openclaw / clawdbot — for when your assistant needs 
 - **Tooling and local workspace access** — built-in agent tools, guarded filesystem tools for explicit roots, and channel-specific tool schemas
 - **Signed plugin runtime** — plugins are signature-verified and run with strict permissions and resource limits
 - **Secure defaults** — local-first binding, locked-down auth behavior, encrypted secret storage, guarded tool execution, root-scoped filesystem access, and OS-level subprocess sandboxing for protected paths
-- **Infrastructure** — TLS, mTLS, mDNS discovery, config hot-reload, Tailscale integration, Prometheus metrics, audit logging. Multi-node clustering is partially implemented
-
-## Expectations vs OpenClaw
-
-Carapace focuses on a hardened core first. If you're coming from openclaw, the
-following are **planned** but not yet on par:
-
-- Broader channel coverage (e.g., WhatsApp/iMessage/Teams/WebChat)
-- Companion apps / nodes (macOS + iOS/Android clients)
-- Browser control and live canvas/A2UI experiences
-- Broader managed skills UX and companion-app onboarding
-- Automatic model/provider failover
+- **Infrastructure** — TLS, mTLS, mDNS discovery, config hot-reload, Tailscale integration, Prometheus metrics, audit logging
 
 ## Security
 
@@ -93,15 +82,8 @@ Active and planned work is tracked on
 The [feature inventory](docs/feature-status.yaml) is the source of truth for
 what currently ships.
 
-Recently shipped: long-running assistant MVP (durable queue + autonomy
-verify), cross-platform subprocess sandboxing, guided setup
-(`cara setup`), first-run verifier (`cara verify`), Gemini onboarding
-(Google sign-in or API key via CLI and Control UI), Codex onboarding
-(OpenAI subscription login via CLI and Control UI), Vertex AI provider
-support, per-channel activity features with Signal typing indicators and
-append-time read receipts, guarded filesystem tools for explicit workspace
-roots, named execution routes, session encryption at rest, and configuration
-import from OpenClaw, OpenCode, Aider, and NemoClaw.
+Recently shipped highlights are tracked in
+[docs/releases/v0.8.0.md](docs/releases/v0.8.0.md) (most recent stable release).
 
 ## Docs
 


### PR DESCRIPTION
## Summary

- **Removes** the `## Expectations vs OpenClaw` section. The section enumerated features Carapace doesn't have by naming a competitor — it neither pointed at our actual roadmap (which lives in GitHub Issues + feature-status.yaml) nor framed the project in its own terms.
- **Trims** the "Multi-node clustering is partially implemented" hedge from the Infrastructure Features bullet. Partial state is canonically carried by `docs/feature-status.yaml` (already linked from the Security section); inline hedges in an otherwise-confident Features list read as out-of-place.
- **Replaces** the inline "Recently shipped:" laundry-list paragraph with a link to `docs/releases/v0.8.0.md` (the most recent stable release). The inline list had no time anchor and went stale invisibly.

Out of band: dismissed 6 open CodeQL `rust/cleartext-logging` alerts (#226–#231) as `used in tests` false positives. The rule matches the substring `password` in the helper function name `session_locked_without_password` and `user_id` in a test fixture (`@alice:example.com`); no actual sensitive-value flows are involved. In-code rationale at `src/sessions/store.rs:1130-1136`.

## Test plan

- [x] Read README.md to confirm wording.
- [x] All 6 CodeQL alerts (#226, #227, #228, #229, #230, #231) confirmed in `dismissed` state with `used in tests` reason.