### PR TITLE
Complete Matrix live smoke evidence

### DIFF
--- a/docs/channel-smoke.md
+++ b/docs/channel-smoke.md
@@ -181,6 +181,33 @@ issue. The artifacts must demonstrate:
 - recovery key presence + restore evidence without plaintext key capture (step 10)
 - rekey-store rotation (step 11)
 
+### Recorded Local Synapse + Element Run (2026-05-22)
+
+The issue #447 sign-off run used local Synapse + Element Web on macOS with
+OrbStack. The per-run raw report directory stayed local to the runner because
+it can contain host-specific paths, screenshots, and log excerpts, so the
+committed audit record is this summary plus the reusable harness and checklist
+above.
+
+Stable result:
+
+- token reuse across restart passed
+- unencrypted Matrix inbound and assistant reply passed
+- encrypted Element inbound and assistant reply passed
+- allowlisted invite auto-join passed
+- non-allowlisted invite refusal passed
+- recovery-key restore passed without storing the plaintext key in report
+  artifacts
+- SDK SQLite store rekey passed
+- SAS verification passed after Python Playwright compared Carapace control
+  SAS values with Element-visible emoji descriptions and confirmed the match
+
+The harness's first `summary.json` is a preliminary machine summary and can
+record manual-required markers before browser/manual supplemental coverage is
+folded in. For this run, the supplemental issue #447 summary was the sign-off
+artifact and mapped those manual-required markers to the passing Element,
+invite, recovery, rekey, and SAS checks above.
+
 Common failure indicators:
 
 - missing `CARAPACE_CONFIG_PASSWORD` or `MATRIX_STORE_PASSPHRASE`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -196,6 +196,7 @@ Health/status check via HTTP.
 
 ```bash
 cara status --port 18789
+cara status --port 18789 --json
 ```
 
 ### `cara logs`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -192,7 +192,9 @@ can exit non-zero after writing the restored key if stale marker/pending cleanup
 fails, so resolve that cleanup error before restarting the daemon.
 
 ### `cara status`
-Health/status check via HTTP.
+Health/status check via HTTP. `--json` emits a terminal-sanitized JSON object
+with the lightweight `/health` payload under `health` and, when available, the
+richer `/control/status` payload under `controlStatus`.
 
 ```bash
 cara status --port 18789

--- a/docs/feature-evidence.yaml
+++ b/docs/feature-evidence.yaml
@@ -139,12 +139,12 @@ features:
   - feature: "channels.matrix live smoke"
     status: "verified_done"
     notes:
-      - "Evidence artifacts: docs/channel-smoke.md (Matrix Smoke section, 11-step procedure); scripts/smoke/matrix-smoke.sh gated evidence harness; .github/ISSUE_TEMPLATE/channel-smoke-report.yml"
+      - "Evidence artifacts: docs/channel-smoke.md (Matrix Smoke procedure and recorded 2026-05-22 Synapse + Element summary); scripts/smoke/matrix-smoke.sh gated evidence harness; .github/ISSUE_TEMPLATE/channel-smoke-report.yml"
       - "Procedure covers token reuse + restart, encrypted send + receive, unencrypted send + receive, allowlisted + non-allowlisted invites, SAS verification, recovery key show + restore, and rekey-store rotation. The harness captures cara status, control-channel responses, send-test outputs, CLI outputs, and available journald excerpts under .local/reports/matrix-smoke-<date>/ when MATRIX_SMOKE_* env is present."
       - "Encrypted Matrix smoke is Unix/macOS-only for this PR; Windows fails closed for matrix.encrypted=true until owner-only ACL enforcement exists."
-      - "2026-05-22 local Synapse + Element Web smoke passed on macOS/OrbStack; evidence directory `.local/reports/matrix-smoke-20260522T150716Z-34446/` includes `issue-447-supplemental-summary.json`, `api-smoke-summary.json`, `manual-local-coverage-summary.json`, `element-e2ee-summary.json`, and `element-sas-summary.json`."
-      - "The pass covered token reuse across restart, unencrypted inbound/reply, encrypted Element inbound/reply, allowlisted and refused invites, recovery-key restore without plaintext report capture, SDK store rekey, and SAS verification. Playwright compared Carapace control SAS values to Element-visible emoji descriptions before confirming; `element-sas-confirmed.png` captures Element's completion state."
-      - "The original harness `summary.json` in that report remains `failed` because it records manual-required markers before supplemental local coverage; `issue-447-supplemental-summary.json` maps those markers to the passing artifacts."
+      - "2026-05-22 local Synapse + Element Web smoke passed on macOS/OrbStack; docs/channel-smoke.md records the committed sign-off summary so reviewers do not need runner-local .local artifacts."
+      - "The pass covered token reuse across restart, unencrypted inbound/reply, encrypted Element inbound/reply, allowlisted and refused invites, recovery-key restore without plaintext report capture, SDK store rekey, and SAS verification. Playwright compared Carapace control SAS values to Element-visible emoji descriptions before confirming the match."
+      - "The harness's first summary.json is a preliminary machine summary and can record manual-required markers before supplemental browser/manual coverage is folded in; the committed 2026-05-22 summary documents the supplemental issue #447 pass mapping."
 
   - feature: "cron.*"
     status: "verified_done"

--- a/docs/feature-evidence.yaml
+++ b/docs/feature-evidence.yaml
@@ -137,12 +137,14 @@ features:
       - "src/server/ws/handlers/config.rs::test_handle_config_patch_persists_placeholder_not_resolved_value"
 
   - feature: "channels.matrix live smoke"
-    status: "partial"
+    status: "verified_done"
     notes:
       - "Evidence artifacts: docs/channel-smoke.md (Matrix Smoke section, 11-step procedure); scripts/smoke/matrix-smoke.sh gated evidence harness; .github/ISSUE_TEMPLATE/channel-smoke-report.yml"
       - "Procedure covers token reuse + restart, encrypted send + receive, unencrypted send + receive, allowlisted + non-allowlisted invites, SAS verification, recovery key show + restore, and rekey-store rotation. The harness captures cara status, control-channel responses, send-test outputs, CLI outputs, and available journald excerpts under .local/reports/matrix-smoke-<date>/ when MATRIX_SMOKE_* env is present."
       - "Encrypted Matrix smoke is Unix/macOS-only for this PR; Windows fails closed for matrix.encrypted=true until owner-only ACL enforcement exists."
-      - "Pending: published pass/fail evidence from a live homeserver execution. The procedure is in place; the artifact set is operator work, not code."
+      - "2026-05-22 local Synapse + Element Web smoke passed on macOS/OrbStack; evidence directory `.local/reports/matrix-smoke-20260522T150716Z-34446/` includes `issue-447-supplemental-summary.json`, `api-smoke-summary.json`, `manual-local-coverage-summary.json`, `element-e2ee-summary.json`, and `element-sas-summary.json`."
+      - "The pass covered token reuse across restart, unencrypted inbound/reply, encrypted Element inbound/reply, allowlisted and refused invites, recovery-key restore without plaintext report capture, SDK store rekey, and SAS verification. Playwright compared Carapace control SAS values to Element-visible emoji descriptions before confirming; `element-sas-confirmed.png` captures Element's completion state."
+      - "The original harness `summary.json` in that report remains `failed` because it records manual-required markers before supplemental local coverage; `issue-447-supplemental-summary.json` maps those markers to the passing artifacts."
 
   - feature: "cron.*"
     status: "verified_done"

--- a/docs/feature-status.yaml
+++ b/docs/feature-status.yaml
@@ -71,7 +71,7 @@ feature_inventory_markdown: |
   - [x] **Matrix recovery key** — CLI-only show/restore/rotate (`cara matrix recovery-key {show,restore,rotate}`); never traverses the control API.
   - [x] **Matrix store rekey** — `cara matrix rekey-store --new` rotates the SDK store cipher with crash-safe two-phase advance + daemon-side fail-closed startup detection of an interrupted rotation.
   - [x] **Matrix DLQ + quarantine** — failed inbound dispatches durably queued under owner-only `inbound_dlq.jsonl`; undecodable lines moved to `inbound_dlq.corrupt.jsonl` quarantine sibling for forensic recovery.
-  - [~] **Matrix real-world smoke** — pending reproducible pass/fail evidence from a live homeserver (login, send, encrypted send/receive, verification, store-rekey, restart).
+  - [x] **Matrix real-world smoke** — local Synapse + Element Web evidence captured for login/token reuse, send, encrypted send/receive, verification, store-rekey, restart, recovery-key restore, and invite allowlist behavior.
 
   ### CLI (`src/cli/`)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -63,6 +63,10 @@ pub enum Command {
         /// Host of the running instance.
         #[arg(long, default_value = "127.0.0.1")]
         host: String,
+
+        /// Print JSON instead of human-readable output.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Tail log entries from a running instance.
@@ -894,6 +898,7 @@ pub fn handle_config_path() {
 pub async fn handle_status(
     host: &str,
     port: Option<u16>,
+    json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let port = resolve_port(port);
     let url = format!("http://{}:{}/health", host, port);
@@ -942,6 +947,11 @@ pub async fn handle_status(
     )
     .await?;
     let body: Value = serde_json::from_str(&body_text)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        return Ok(());
+    }
 
     // Pretty-print the status summary.
     println!("Carapace gateway status");
@@ -3354,6 +3364,7 @@ fn matrix_sqlite_store_paths(state_dir: &Path) -> Result<Vec<PathBuf>, Box<dyn s
         matrix_dir
             .join("cache")
             .join("matrix-sdk-event-cache.sqlite3"),
+        matrix_dir.join("cache").join("matrix-sdk-media.sqlite3"),
     ] {
         if cli_path_exists_strict(&path, "Matrix SQLite store")? {
             paths.push(path);
@@ -10877,7 +10888,7 @@ async fn run_setup_post_checks(
     };
 
     if run_status {
-        let status_result = handle_status("127.0.0.1", Some(port))
+        let status_result = handle_status("127.0.0.1", Some(port), false)
             .await
             .map_err(|e| format!("status check failed: {e}"));
         if status_result.is_err() {
@@ -14100,9 +14111,14 @@ mod tests {
     fn test_cli_status_defaults() {
         let cli = Cli::try_parse_from(["cara", "status"]).unwrap();
         match cli.command {
-            Some(Command::Status { port, ref host }) => {
+            Some(Command::Status {
+                port,
+                ref host,
+                json,
+            }) => {
                 assert_eq!(port, None);
                 assert_eq!(host, "127.0.0.1");
+                assert!(!json);
             }
             other => panic!("Expected Status, got {:?}", other),
         }
@@ -14114,6 +14130,17 @@ mod tests {
         match cli.command {
             Some(Command::Status { port, .. }) => {
                 assert_eq!(port, Some(9000));
+            }
+            other => panic!("Expected Status, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_cli_status_json_flag() {
+        let cli = Cli::try_parse_from(["cara", "status", "--json"]).unwrap();
+        match cli.command {
+            Some(Command::Status { json, .. }) => {
+                assert!(json);
             }
             other => panic!("Expected Status, got {:?}", other),
         }
@@ -17960,6 +17987,57 @@ mod tests {
             }
             MatrixRekeyAdvance::Failed { error, .. } => {
                 panic!("expected second advance to be no-op, got Failed: {error}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_advance_matrix_sqlite_store_ciphers_rotates_all_sdk_stores() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let matrix_dir = temp.path().join("matrix");
+        let cache_dir = matrix_dir.join("cache");
+        std::fs::create_dir_all(&cache_dir).expect("matrix cache dir");
+
+        for path in [
+            matrix_dir.join("matrix-sdk-state.sqlite3"),
+            matrix_dir.join("matrix-sdk-crypto.sqlite3"),
+            cache_dir.join("matrix-sdk-event-cache.sqlite3"),
+            cache_dir.join("matrix-sdk-media.sqlite3"),
+        ] {
+            seed_test_matrix_store(&path, "old-passphrase");
+        }
+
+        match advance_matrix_sqlite_store_ciphers(temp.path(), "old-passphrase", "new-passphrase")
+            .expect("advance rotates every SDK store")
+        {
+            MatrixRekeyAdvance::Completed {
+                rotated,
+                already_new,
+            } => {
+                assert_eq!(
+                    rotated.len(),
+                    4,
+                    "state, crypto, event cache, and media stores must all rotate"
+                );
+                assert!(already_new.is_empty());
+            }
+            MatrixRekeyAdvance::Failed { error, .. } => {
+                panic!("expected all-store rotation to complete, got Failed: {error}")
+            }
+        }
+
+        match advance_matrix_sqlite_store_ciphers(temp.path(), "old-passphrase", "new-passphrase")
+            .expect("advance is idempotent after all-store rotation")
+        {
+            MatrixRekeyAdvance::Completed {
+                rotated,
+                already_new,
+            } => {
+                assert!(rotated.is_empty());
+                assert_eq!(already_new.len(), 4);
+            }
+            MatrixRekeyAdvance::Failed { error, .. } => {
+                panic!("expected second all-store advance to be no-op, got Failed: {error}")
             }
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -922,11 +922,11 @@ fn status_json_payload(health: Value, control_status: Option<Value>) -> Value {
     Value::Object(payload)
 }
 
-/// Run the `status` subcommand -- connect to a running instance's health endpoint.
-pub async fn handle_status(
+async fn handle_status_with_writer<W: std::io::Write + ?Sized>(
     host: &str,
     port: Option<u16>,
     json: bool,
+    out: &mut W,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let port = resolve_port(port);
     let url = format!("http://{}:{}/health", host, port);
@@ -974,22 +974,22 @@ pub async fn handle_status(
 
     if json {
         let control_status = fetch_optional_status_json(&client, &control_url).await;
-        print_pretty_json(&status_json_payload(body, control_status))?;
+        write_pretty_json(&status_json_payload(body, control_status), out)?;
         return Ok(());
     }
 
     // Pretty-print the status summary.
-    println!("Carapace gateway status");
-    println!("=======================");
+    writeln!(out, "Carapace gateway status")?;
+    writeln!(out, "=======================")?;
     if let Some(version) = body.get("version").and_then(|v| v.as_str()) {
-        println!("  Version:  {}", version);
+        writeln!(out, "  Version:  {}", version)?;
     }
     if let Some(uptime) = body.get("uptimeSeconds").and_then(|v| v.as_i64()) {
-        println!("  Uptime:   {}", format_duration(uptime));
+        writeln!(out, "  Uptime:   {}", format_duration(uptime))?;
     }
-    println!("  Address:  {}:{}", host, port);
+    writeln!(out, "  Address:  {}:{}", host, port)?;
     if let Some(status) = body.get("status").and_then(|v| v.as_str()) {
-        println!("  Status:   {}", status);
+        writeln!(out, "  Status:   {}", status)?;
     }
 
     // If the control endpoint is available, try to get richer info.
@@ -1000,19 +1000,29 @@ pub async fn handle_status(
                 .get("totalChannels")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0);
-            println!("  Channels: {}/{} connected", ch, total);
+            writeln!(out, "  Channels: {}/{} connected", ch, total)?;
         }
         if let Some(rt) = ctrl.get("runtime").and_then(|v| v.as_object()) {
             if let (Some(platform), Some(arch)) = (
                 rt.get("platform").and_then(|v| v.as_str()),
                 rt.get("arch").and_then(|v| v.as_str()),
             ) {
-                println!("  Platform: {} ({})", platform, arch);
+                writeln!(out, "  Platform: {} ({})", platform, arch)?;
             }
         }
     }
 
     Ok(())
+}
+
+/// Run the `status` subcommand -- connect to a running instance's health endpoint.
+pub async fn handle_status(
+    host: &str,
+    port: Option<u16>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stdout = std::io::stdout();
+    handle_status_with_writer(host, port, json, &mut stdout).await
 }
 
 /// Run the `task` subcommand family -- manage durable objective tasks.
@@ -4295,8 +4305,17 @@ fn terminal_safe_pretty_json(value: &Value) -> Result<String, serde_json::Error>
     serde_json::to_string_pretty(&owned)
 }
 
+fn write_pretty_json<W: std::io::Write + ?Sized>(
+    value: &Value,
+    out: &mut W,
+) -> Result<(), Box<dyn std::error::Error>> {
+    writeln!(out, "{}", terminal_safe_pretty_json(value)?)?;
+    Ok(())
+}
+
 fn print_pretty_json(value: &Value) -> Result<(), Box<dyn std::error::Error>> {
-    println!("{}", terminal_safe_pretty_json(value)?);
+    let mut stdout = std::io::stdout();
+    write_pretty_json(value, &mut stdout)?;
     Ok(())
 }
 
@@ -14238,9 +14257,20 @@ mod tests {
         assert!(!rendered.contains('\u{202e}'));
         assert!(rendered.contains("\"platform\": \"linux\""));
 
-        handle_status("127.0.0.1", Some(port), true)
+        let mut status_output = Vec::new();
+        handle_status_with_writer("127.0.0.1", Some(port), true, &mut status_output)
             .await
             .expect("status JSON path should fetch, merge, and render");
+        let status_output = String::from_utf8(status_output).expect("status JSON is utf-8");
+        let status_output_json: Value =
+            serde_json::from_str(&status_output).expect("status output is JSON");
+        assert_eq!(status_output_json["health"]["status"], "ok");
+        assert_eq!(status_output_json["controlStatus"]["connectedChannels"], 1);
+        assert_eq!(
+            status_output_json["controlStatus"]["runtime"]["platform"],
+            "linux"
+        );
+        assert!(!status_output.contains('\u{202e}'));
         server.abort();
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -971,9 +971,9 @@ pub async fn handle_status(
     }
 
     let body = read_response_json_value(response).await?;
-    let control_status = fetch_optional_status_json(&client, &control_url).await;
 
     if json {
+        let control_status = fetch_optional_status_json(&client, &control_url).await;
         print_pretty_json(&status_json_payload(body, control_status))?;
         return Ok(());
     }
@@ -993,6 +993,7 @@ pub async fn handle_status(
     }
 
     // If the control endpoint is available, try to get richer info.
+    let control_status = fetch_optional_status_json(&client, &control_url).await;
     if let Some(ctrl) = control_status.as_ref() {
         if let Some(ch) = ctrl.get("connectedChannels").and_then(|v| v.as_u64()) {
             let total = ctrl
@@ -14219,7 +14220,6 @@ mod tests {
             fetch_optional_status_json(&client, &format!("http://127.0.0.1:{port}/control/status"))
                 .await;
         let payload = status_json_payload(health, control_status);
-        server.abort();
 
         assert_eq!(payload["health"]["status"], "ok");
         assert_eq!(payload["health"]["version"], "test-version");
@@ -14237,6 +14237,11 @@ mod tests {
         assert!(rendered.contains("\"connectedChannels\": 1"));
         assert!(!rendered.contains('\u{202e}'));
         assert!(rendered.contains("\"platform\": \"linux\""));
+
+        handle_status("127.0.0.1", Some(port), true)
+            .await
+            .expect("status JSON path should fetch, merge, and render");
+        server.abort();
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -894,6 +894,34 @@ pub fn handle_config_path() {
     println!("{}", config::get_config_path().display());
 }
 
+async fn read_response_json_value(
+    response: reqwest::Response,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let body_text = crate::net_util::read_response_body_text_capped(
+        response,
+        crate::net_util::MAX_RESPONSE_BODY_BYTES,
+    )
+    .await?;
+    Ok(serde_json::from_str(&body_text)?)
+}
+
+async fn fetch_optional_status_json(client: &reqwest::Client, url: &str) -> Option<Value> {
+    let response = client.get(url).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    read_response_json_value(response).await.ok()
+}
+
+fn status_json_payload(health: Value, control_status: Option<Value>) -> Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert("health".to_string(), health);
+    if let Some(control_status) = control_status {
+        payload.insert("controlStatus".to_string(), control_status);
+    }
+    Value::Object(payload)
+}
+
 /// Run the `status` subcommand -- connect to a running instance's health endpoint.
 pub async fn handle_status(
     host: &str,
@@ -902,6 +930,7 @@ pub async fn handle_status(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let port = resolve_port(port);
     let url = format!("http://{}:{}/health", host, port);
+    let control_url = format!("http://{}:{}/control/status", host, port);
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
@@ -941,15 +970,11 @@ pub async fn handle_status(
         std::process::exit(1);
     }
 
-    let body_text = crate::net_util::read_response_body_text_capped(
-        response,
-        crate::net_util::MAX_RESPONSE_BODY_BYTES,
-    )
-    .await?;
-    let body: Value = serde_json::from_str(&body_text)?;
+    let body = read_response_json_value(response).await?;
+    let control_status = fetch_optional_status_json(&client, &control_url).await;
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&body)?);
+        print_pretty_json(&status_json_payload(body, control_status))?;
         return Ok(());
     }
 
@@ -968,32 +993,20 @@ pub async fn handle_status(
     }
 
     // If the control endpoint is available, try to get richer info.
-    let control_url = format!("http://{}:{}/control/status", host, port);
-    if let Ok(resp) = client.get(&control_url).send().await {
-        if resp.status().is_success() {
-            let body_text = crate::net_util::read_response_body_text_capped(
-                resp,
-                crate::net_util::MAX_RESPONSE_BODY_BYTES,
-            )
-            .await;
-            if let Ok(ctrl) = body_text.and_then(|text| {
-                serde_json::from_str::<Value>(&text).map_err(std::io::Error::other)
-            }) {
-                if let Some(ch) = ctrl.get("connectedChannels").and_then(|v| v.as_u64()) {
-                    let total = ctrl
-                        .get("totalChannels")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0);
-                    println!("  Channels: {}/{} connected", ch, total);
-                }
-                if let Some(rt) = ctrl.get("runtime").and_then(|v| v.as_object()) {
-                    if let (Some(platform), Some(arch)) = (
-                        rt.get("platform").and_then(|v| v.as_str()),
-                        rt.get("arch").and_then(|v| v.as_str()),
-                    ) {
-                        println!("  Platform: {} ({})", platform, arch);
-                    }
-                }
+    if let Some(ctrl) = control_status.as_ref() {
+        if let Some(ch) = ctrl.get("connectedChannels").and_then(|v| v.as_u64()) {
+            let total = ctrl
+                .get("totalChannels")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            println!("  Channels: {}/{} connected", ch, total);
+        }
+        if let Some(rt) = ctrl.get("runtime").and_then(|v| v.as_object()) {
+            if let (Some(platform), Some(arch)) = (
+                rt.get("platform").and_then(|v| v.as_str()),
+                rt.get("arch").and_then(|v| v.as_str()),
+            ) {
+                println!("  Platform: {} ({})", platform, arch);
             }
         }
     }
@@ -4264,7 +4277,7 @@ fn extract_control_error_message(body: &[u8]) -> String {
     }
 }
 
-fn print_pretty_json(value: &Value) -> Result<(), Box<dyn std::error::Error>> {
+fn terminal_safe_pretty_json(value: &Value) -> Result<String, serde_json::Error> {
     // SECURITY: every CLI JSON-output site exposes peer-, plugin-,
     // model-, or homeserver-influenced fields to the operator's
     // terminal (Matrix homeserver replies, task payload/reason
@@ -4278,7 +4291,11 @@ fn print_pretty_json(value: &Value) -> Result<(), Box<dyn std::error::Error>> {
     // swap displayed JSON values.
     let mut owned = value.clone();
     strip_terminal_unsafe_chars_in_json(&mut owned);
-    println!("{}", serde_json::to_string_pretty(&owned)?);
+    serde_json::to_string_pretty(&owned)
+}
+
+fn print_pretty_json(value: &Value) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{}", terminal_safe_pretty_json(value)?);
     Ok(())
 }
 
@@ -14144,6 +14161,82 @@ mod tests {
             }
             other => panic!("Expected Status, got {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn test_cli_status_json_payload_fetches_health_and_control_status() {
+        let app = axum::Router::new()
+            .route(
+                "/health",
+                axum::routing::get(|| async {
+                    axum::Json(serde_json::json!({
+                        "status": "ok",
+                        "version": "test-version",
+                        "uptimeSeconds": 42
+                    }))
+                }),
+            )
+            .route(
+                "/control/status",
+                axum::routing::get(|| async {
+                    axum::Json(serde_json::json!({
+                        "ok": true,
+                        "connectedChannels": 1,
+                        "totalChannels": 2,
+                        "runtime": {
+                            "platform": "linux\u{202e}",
+                            "arch": "x86_64"
+                        }
+                    }))
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test status server");
+        let port = listener
+            .local_addr()
+            .expect("read test status server address")
+            .port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve test status responses");
+        });
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("build test client");
+        let health_response = client
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .await
+            .expect("fetch health response");
+        let health = read_response_json_value(health_response)
+            .await
+            .expect("parse health JSON");
+        let control_status =
+            fetch_optional_status_json(&client, &format!("http://127.0.0.1:{port}/control/status"))
+                .await;
+        let payload = status_json_payload(health, control_status);
+        server.abort();
+
+        assert_eq!(payload["health"]["status"], "ok");
+        assert_eq!(payload["health"]["version"], "test-version");
+        assert_eq!(payload["health"]["uptimeSeconds"], 42);
+        assert_eq!(payload["controlStatus"]["connectedChannels"], 1);
+        assert_eq!(payload["controlStatus"]["totalChannels"], 2);
+        assert_eq!(
+            payload["controlStatus"]["runtime"]["platform"],
+            "linux\u{202e}"
+        );
+        assert_eq!(payload["controlStatus"]["runtime"]["arch"], "x86_64");
+
+        let rendered = terminal_safe_pretty_json(&payload).expect("render safe JSON");
+        assert!(rendered.contains("\"controlStatus\""));
+        assert!(rendered.contains("\"connectedChannels\": 1"));
+        assert!(!rendered.contains('\u{202e}'));
+        assert!(rendered.contains("\"platform\": \"linux\""));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -922,6 +922,10 @@ fn status_json_payload(health: Value, control_status: Option<Value>) -> Value {
     Value::Object(payload)
 }
 
+/// Run status and write successful stdout output to `out`.
+///
+/// Connection and non-2xx health failures intentionally preserve the public
+/// CLI behavior: diagnostics go to stderr and the process exits non-zero.
 async fn handle_status_with_writer<W: std::io::Write + ?Sized>(
     host: &str,
     port: Option<u16>,
@@ -14203,8 +14207,9 @@ mod tests {
                         "ok": true,
                         "connectedChannels": 1,
                         "totalChannels": 2,
+                        "homeserverInfluenced": "bad\u{202e}",
                         "runtime": {
-                            "platform": "linux\u{202e}",
+                            "platform": "linux",
                             "arch": "x86_64"
                         }
                     }))
@@ -14246,15 +14251,17 @@ mod tests {
         assert_eq!(payload["controlStatus"]["connectedChannels"], 1);
         assert_eq!(payload["controlStatus"]["totalChannels"], 2);
         assert_eq!(
-            payload["controlStatus"]["runtime"]["platform"],
-            "linux\u{202e}"
+            payload["controlStatus"]["homeserverInfluenced"],
+            "bad\u{202e}"
         );
+        assert_eq!(payload["controlStatus"]["runtime"]["platform"], "linux");
         assert_eq!(payload["controlStatus"]["runtime"]["arch"], "x86_64");
 
         let rendered = terminal_safe_pretty_json(&payload).expect("render safe JSON");
         assert!(rendered.contains("\"controlStatus\""));
         assert!(rendered.contains("\"connectedChannels\": 1"));
         assert!(!rendered.contains('\u{202e}'));
+        assert!(rendered.contains("\"homeserverInfluenced\": \"bad\""));
         assert!(rendered.contains("\"platform\": \"linux\""));
 
         let mut status_output = Vec::new();
@@ -14271,7 +14278,58 @@ mod tests {
             "linux"
         );
         assert!(!status_output.contains('\u{202e}'));
+
+        let mut human_output = Vec::new();
+        handle_status_with_writer("127.0.0.1", Some(port), false, &mut human_output)
+            .await
+            .expect("status human path should fetch and render");
+        let human_output = String::from_utf8(human_output).expect("status human output is utf-8");
+        assert!(human_output.starts_with("Carapace gateway status\n"));
+        assert!(human_output.contains("  Version:  test-version\n"));
+        assert!(human_output.contains("  Uptime:   42s\n"));
+        assert!(human_output.contains("  Address:  127.0.0.1:"));
+        assert!(human_output.contains("  Status:   ok\n"));
+        assert!(human_output.contains("  Channels: 1/2 connected\n"));
+        assert!(human_output.contains("  Platform: linux (x86_64)\n"));
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_cli_status_json_omits_control_status_when_unavailable() {
+        let app = axum::Router::new().route(
+            "/health",
+            axum::routing::get(|| async {
+                axum::Json(serde_json::json!({
+                    "status": "ok",
+                    "version": "test-version",
+                    "uptimeSeconds": 42
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test status server");
+        let port = listener
+            .local_addr()
+            .expect("read test status server address")
+            .port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve test status responses");
+        });
+
+        let mut status_output = Vec::new();
+        handle_status_with_writer("127.0.0.1", Some(port), true, &mut status_output)
+            .await
+            .expect("status JSON path should tolerate missing control status");
+        server.abort();
+
+        let status_output = String::from_utf8(status_output).expect("status JSON is utf-8");
+        let status_output_json: Value =
+            serde_json::from_str(&status_output).expect("status output is JSON");
+        assert_eq!(status_output_json["health"]["status"], "ok");
+        assert!(status_output_json.get("controlStatus").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
 
-        Some(Command::Status { port, host }) => cli::handle_status(&host, port).await,
+        Some(Command::Status { port, host, json }) => cli::handle_status(&host, port, json).await,
 
         Some(Command::Logs {
             lines,


### PR DESCRIPTION
## Summary

- Closes #447 with committed Matrix live-smoke evidence status updates from a local Synapse + Element Web run.
- Adds `cara status --json` so smoke reports can capture a terminal-safe machine-readable status snapshot containing both `/health` and available `/control/status` data.
- Includes the Matrix SDK media SQLite store in `cara matrix rekey-store --new` rotation coverage.

## Evidence

- Committed evidence summary: `docs/channel-smoke.md` records the 2026-05-22 local Synapse + Element Web issue #447 sign-off run.
- Covered token reuse across restart, unencrypted inbound/reply, encrypted Element inbound/reply, allowlisted and refused invites, recovery-key restore without plaintext report capture, SDK store rekey, and SAS verification.
- SAS verification was driven through Element Web with Python Playwright; the helper compared Carapace control SAS values to Element-visible emoji descriptions before confirming.

## Validation

- `scripts/check-docs-state-messaging.sh`
- `scripts/cargo-serial fmt --check`
- `scripts/cargo-serial nextest run test_cli_status --all-targets`
- `scripts/cargo-serial clippy --all-targets --all-features -- -D warnings`
- Previous PR validation also covered `test_advance_matrix_sqlite_store_ciphers`, `test_recover_interrupted_matrix_store_rekey_uses_config_password_derivation`, and `test_matrix_store_cipher_direct_dependency_matches_sdk_wire_format`
- Local Python Playwright Synapse/Element smoke

Closes #447
