### PR TITLE
chore(deps): bump wit dependencies to 0.251.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,8 +667,8 @@ dependencies = [
  "wasmtime",
  "win32job",
  "windows-sys 0.61.2",
- "wit-component 0.250.0",
- "wit-parser 0.250.0",
+ "wit-component 0.251.0",
+ "wit-parser 0.251.0",
  "x509-parser",
  "zeroize",
 ]
@@ -6375,12 +6375,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2271adb766023046af314460f1fae02cc34ea16d736d93404d3b65be44270923"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -6397,14 +6397,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d2fe7edf8b5c8870da3f6796f8ebe1898af1276f18490c861fcb1a11436556"
+checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -6478,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071d99cdfb8111603ed05500506c3298a940b58d609dd0259d3981785dd33556"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.17.0",
@@ -6758,22 +6758,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "250.0.0"
+version = "251.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e9294a1f0204aeb5c47e95165517f43ef3cc895918c4f3e939380d4c290f4a"
+checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.250.0",
+ "wasm-encoder 0.251.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.250.0"
+version = "1.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a549ed329a70e444e0f7796391ab2a87d0aef30ddde9f60e16e429224fafd02"
+checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
 dependencies = [
  "wast",
 ]
@@ -7488,9 +7488,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35e69355f29f746a5b5ed3a81b78a69597d13e24798b89f35f3e2691e59e779"
+checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -7499,11 +7499,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.250.0",
- "wasm-metadata 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasm-metadata 0.251.0",
+ "wasmparser 0.251.0",
  "wat",
- "wit-parser 0.250.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -7545,9 +7545,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7be74761ad42af22e13d82d89804369aa7298d4d67ae1523aa694f2b30e6b7a"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -7559,7 +7559,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,8 +115,8 @@ insta = { version = "1", features = ["json"] }
 tokio-test = "0.4"
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-wit-component = { version = "0.250.0", features = ["dummy-module"] }
-wit-parser = "0.250.0"
+wit-component = { version = "0.251.0", features = ["dummy-module"] }
+wit-parser = "0.251.0"
 matrix-sdk-store-encryption-016 = { package = "matrix-sdk-store-encryption", version = "0.16.1" }
 
 [features]


### PR DESCRIPTION
## Summary

Bundles the wit-parser and wit-component bumps to 0.251.0 in a single commit, superseding #507 and #508.

The two PRs are coupled — wit-component 0.251's `dummy_module` / `embed_component_metadata` signatures expect the wit-parser 0.251 versions of `Resolve` / `ManglingAndAbi`, so each PR alone is red on Clippy and WS Golden with `E0308 — multiple different versions of crate wit_parser in the dependency graph` at `src/test_support/plugins.rs:13-14`. Bundling fixes master in one merge, same pattern as #465 (0.249) and #497 (0.250).

`cargo update -p wit-parser@0.250.0 -p wit-component@0.250.0` also pulls forward the shared transitive deps (`wasm-encoder`, `wasm-metadata`, `wasmparser`, `wast`, `wat`) to 0.251.

Closes #507.
Closes #508.

## Test plan

- [x] `./scripts/cargo-serial clippy --all-targets --all-features -- -D warnings` — clean
- [x] `./scripts/cargo-serial fmt --all -- --check` — clean
- [x] `./scripts/cargo-serial nextest run --all-targets -E 'test(/tool_plugin/) + test(plugins) + test(golden) + test(runtime)'` — 570/570 passed
- [ ] CI green on this branch (Clippy + WS Golden + full test matrix)