### PR TITLE
chore: sync wit dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 99
     groups:
+      wit-tooling:
+        applies-to: "version-updates"
+        patterns:
+          - "wit-*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       cargo-minor-patch:
         applies-to: "version-updates"
         update-types:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,8 +667,8 @@ dependencies = [
  "wasmtime",
  "win32job",
  "windows-sys 0.61.2",
- "wit-component 0.251.0",
- "wit-parser 0.251.0",
+ "wit-component 0.252.0",
+ "wit-parser 0.252.0",
  "x509-parser",
  "zeroize",
 ]
@@ -6375,12 +6375,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.251.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -6397,14 +6397,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
+checksum = "2b7e08e02a3cd55bf778009d4cd6faae50da011f293644daf78a531a32d6d142"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -6478,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.17.0",
@@ -6758,22 +6758,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "251.0.0"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.251.0",
+ "wasm-encoder 0.252.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.251.0"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
  "wast",
 ]
@@ -7488,9 +7488,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
+checksum = "76db0662b590f45d33d0e363fa13539a5a1eecd35d5a12fe208c335461c1053d"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -7499,11 +7499,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.251.0",
- "wasm-metadata 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasm-metadata 0.252.0",
+ "wasmparser 0.252.0",
  "wat",
- "wit-parser 0.251.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
@@ -7545,9 +7545,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -7558,8 +7558,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.251.0",
+ "unicode-ident",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,8 +115,8 @@ insta = { version = "1", features = ["json"] }
 tokio-test = "0.4"
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
-wit-component = { version = "0.251.0", features = ["dummy-module"] }
-wit-parser = "0.251.0"
+wit-component = { version = "0.252.0", features = ["dummy-module"] }
+wit-parser = "0.252.0"
 matrix-sdk-store-encryption-016 = { package = "matrix-sdk-store-encryption", version = "0.16.1" }
 
 [features]

--- a/Justfile
+++ b/Justfile
@@ -24,7 +24,7 @@ test-fast:
 
 # Run the full golden lane (WebSocket traces + golden/schema integration checks).
 test-golden:
-    ./scripts/cargo-serial nextest run --all-targets -P golden
+    ./scripts/run-nextest-guarded.sh --all-targets -P golden
 
 # Run the slower integration lane.
 test-integration:

--- a/scripts/run-nextest-guarded.sh
+++ b/scripts/run-nextest-guarded.sh
@@ -345,6 +345,8 @@ start_nextest() {
     script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
     cargo_serial="${script_dir}/cargo-serial"
 
+    # scripts/cargo-serial is an optional ignored local helper that serializes
+    # Cargo via a repo-local lock; tracked checkouts and CI use plain cargo.
     if [ -x "${cargo_serial}" ]; then
         "${cargo_serial}" nextest run "$@" &
         return

--- a/scripts/run-nextest-guarded.sh
+++ b/scripts/run-nextest-guarded.sh
@@ -339,11 +339,25 @@ list_discovery_pid_etime_and_command() {
         || true
 }
 
+start_nextest() {
+    local script_dir
+    local cargo_serial
+    script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    cargo_serial="${script_dir}/cargo-serial"
+
+    if [ -x "${cargo_serial}" ]; then
+        "${cargo_serial}" nextest run "$@" &
+        return
+    fi
+
+    cargo nextest run "$@" &
+}
+
 main() {
     ensure_nextest_installed || return 1
     initialize_runtime_config
 
-    cargo nextest run "$@" &
+    start_nextest "$@"
     local nextest_pid=$!
 
     while kill -0 "${nextest_pid}" >/dev/null 2>&1; do

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -983,37 +983,92 @@ mod tests {
     use crate::plugins::permissions::{
         compute_effective_permissions, DeclaredPermissions, HttpPermission, PermissionConfig,
     };
-    use tempfile::tempdir;
+    use tempfile::{tempdir, TempDir};
 
-    async fn create_test_credential_store() -> Arc<CredentialStore<MockCredentialBackend>> {
+    struct TestHostContext {
+        ctx: PluginHostContext<MockCredentialBackend>,
+        _temp_dir: TempDir,
+    }
+
+    type TestCredentialStore = Arc<CredentialStore<MockCredentialBackend>>;
+
+    impl std::ops::Deref for TestHostContext {
+        type Target = PluginHostContext<MockCredentialBackend>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.ctx
+        }
+    }
+
+    async fn create_test_credential_store() -> (TestCredentialStore, TempDir) {
         let temp_dir = tempdir().unwrap();
         let backend = MockCredentialBackend::new(true);
-        Arc::new(
+        let credential_store = Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
                 .await
                 .unwrap(),
-        )
+        );
+        (credential_store, temp_dir)
     }
 
-    async fn create_test_context(plugin_id: &str) -> PluginHostContext<MockCredentialBackend> {
-        PluginHostContext::new(
+    async fn create_test_context(plugin_id: &str) -> TestHostContext {
+        let (credential_store, temp_dir) = create_test_credential_store().await;
+        let ctx = PluginHostContext::new(
             plugin_id.to_string(),
-            create_test_credential_store().await,
+            credential_store,
             Arc::new(RateLimiterRegistry::new()),
-        )
+        );
+        TestHostContext {
+            ctx,
+            _temp_dir: temp_dir,
+        }
     }
 
     async fn create_test_context_with_permissions(
         plugin_id: &str,
         permission_enforcer: PermissionEnforcer,
-    ) -> PluginHostContext<MockCredentialBackend> {
-        PluginHostContext::with_permissions(
+    ) -> TestHostContext {
+        let (credential_store, temp_dir) = create_test_credential_store().await;
+        let ctx = PluginHostContext::with_permissions(
             plugin_id.to_string(),
-            create_test_credential_store().await,
+            credential_store,
             Arc::new(RateLimiterRegistry::new()),
             SsrfConfig::default(),
             permission_enforcer,
-        )
+        );
+        TestHostContext {
+            ctx,
+            _temp_dir: temp_dir,
+        }
+    }
+
+    fn permission_enforcer_for(
+        plugin_id: &str,
+        declared: &DeclaredPermissions,
+        config: &PermissionConfig,
+    ) -> PermissionEnforcer {
+        let permissions = compute_effective_permissions(plugin_id, declared, config);
+        PermissionEnforcer::new(permissions, config.enabled)
+    }
+
+    async fn create_test_context_with_http_rate_limit(
+        plugin_id: &str,
+        max_requests_per_minute: usize,
+    ) -> TestHostContext {
+        let declared = DeclaredPermissions {
+            http: Some(HttpPermission {
+                allowed_urls: vec!["https://api.example.com/**".to_string()],
+                max_requests_per_minute: Some(max_requests_per_minute),
+            }),
+            credentials: None,
+            media: None,
+        };
+        let config = PermissionConfig {
+            enabled: true,
+            ..PermissionConfig::default()
+        };
+        let permission_enforcer = permission_enforcer_for(plugin_id, &declared, &config);
+        create_test_context_with_permissions(plugin_id, permission_enforcer).await
     }
 
     #[tokio::test]
@@ -1053,24 +1108,7 @@ mod tests {
     #[tokio::test]
     async fn test_http_fetch_rate_limit() {
         let plugin_id = "test-plugin";
-        let declared = DeclaredPermissions {
-            http: Some(HttpPermission {
-                allowed_urls: vec!["https://api.example.com/**".to_string()],
-                max_requests_per_minute: Some(0),
-            }),
-            credentials: None,
-            media: None,
-        };
-        let config = PermissionConfig {
-            enabled: true,
-            ..PermissionConfig::default()
-        };
-        let permissions = compute_effective_permissions(plugin_id, &declared, &config);
-        let ctx = create_test_context_with_permissions(
-            plugin_id,
-            PermissionEnforcer::new(permissions, true),
-        )
-        .await;
+        let ctx = create_test_context_with_http_rate_limit(plugin_id, 0).await;
 
         let req = HttpRequest {
             method: "GET".to_string(),
@@ -1084,6 +1122,27 @@ mod tests {
             result,
             Err(HostError::Capability(
                 CapabilityError::HttpRateLimitExceeded(0)
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_http_fetch_rate_limit_allows_until_effective_limit() {
+        let plugin_id = "test-plugin";
+        let ctx = create_test_context_with_http_rate_limit(plugin_id, 1).await;
+        let req = HttpRequest {
+            method: "GET".to_string(),
+            url: "https://api.example.com/more".to_string(),
+            headers: vec![],
+            body: None,
+        };
+
+        assert!(ctx.validate_http_request(&req).is_ok());
+        let result = ctx.validate_http_request(&req);
+        assert!(matches!(
+            result,
+            Err(HostError::Capability(
+                CapabilityError::HttpRateLimitExceeded(1)
             ))
         ));
     }
@@ -1240,21 +1299,18 @@ mod tests {
     async fn create_test_context_with_tailscale(
         plugin_id: &str,
         allow_tailscale: bool,
-    ) -> PluginHostContext<MockCredentialBackend> {
-        let temp_dir = tempdir().unwrap();
-        let backend = MockCredentialBackend::new(true);
-        let credential_store = Arc::new(
-            CredentialStore::new(backend, temp_dir.path().to_path_buf())
-                .await
-                .unwrap(),
-        );
-
-        PluginHostContext::with_ssrf_config(
+    ) -> TestHostContext {
+        let (credential_store, temp_dir) = create_test_credential_store().await;
+        let ctx = PluginHostContext::with_ssrf_config(
             plugin_id.to_string(),
             credential_store,
             Arc::new(RateLimiterRegistry::new()),
             SsrfConfig { allow_tailscale },
-        )
+        );
+        TestHostContext {
+            ctx,
+            _temp_dir: temp_dir,
+        }
     }
 
     #[tokio::test]

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -980,21 +980,39 @@ async fn send_http_request(
 mod tests {
     use super::*;
     use crate::credentials::MockCredentialBackend;
+    use crate::plugins::permissions::{
+        compute_effective_permissions, DeclaredPermissions, HttpPermission, PermissionConfig,
+    };
     use tempfile::tempdir;
 
-    async fn create_test_context(plugin_id: &str) -> PluginHostContext<MockCredentialBackend> {
+    async fn create_test_credential_store() -> Arc<CredentialStore<MockCredentialBackend>> {
         let temp_dir = tempdir().unwrap();
         let backend = MockCredentialBackend::new(true);
-        let credential_store = Arc::new(
+        Arc::new(
             CredentialStore::new(backend, temp_dir.path().to_path_buf())
                 .await
                 .unwrap(),
-        );
+        )
+    }
 
+    async fn create_test_context(plugin_id: &str) -> PluginHostContext<MockCredentialBackend> {
         PluginHostContext::new(
             plugin_id.to_string(),
-            credential_store,
+            create_test_credential_store().await,
             Arc::new(RateLimiterRegistry::new()),
+        )
+    }
+
+    async fn create_test_context_with_permissions(
+        plugin_id: &str,
+        permission_enforcer: PermissionEnforcer,
+    ) -> PluginHostContext<MockCredentialBackend> {
+        PluginHostContext::with_permissions(
+            plugin_id.to_string(),
+            create_test_credential_store().await,
+            Arc::new(RateLimiterRegistry::new()),
+            SsrfConfig::default(),
+            permission_enforcer,
         )
     }
 
@@ -1034,20 +1052,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_http_fetch_rate_limit() {
-        let ctx = create_test_context("test-plugin").await;
+        let plugin_id = "test-plugin";
+        let declared = DeclaredPermissions {
+            http: Some(HttpPermission {
+                allowed_urls: vec!["https://api.example.com/**".to_string()],
+                max_requests_per_minute: Some(0),
+            }),
+            credentials: None,
+            media: None,
+        };
+        let config = PermissionConfig {
+            enabled: true,
+            ..PermissionConfig::default()
+        };
+        let permissions = compute_effective_permissions(plugin_id, &declared, &config);
+        let ctx = create_test_context_with_permissions(
+            plugin_id,
+            PermissionEnforcer::new(permissions, true),
+        )
+        .await;
 
-        // Make requests up to the limit
-        for _ in 0..super::super::capabilities::HTTP_RATE_LIMIT_PER_MINUTE {
-            let req = HttpRequest {
-                method: "GET".to_string(),
-                url: "https://api.example.com/data".to_string(),
-                headers: vec![],
-                body: None,
-            };
-            let _ = ctx.http_fetch(req).await;
-        }
-
-        // Next should fail with rate limit
         let req = HttpRequest {
             method: "GET".to_string(),
             url: "https://api.example.com/more".to_string(),
@@ -1056,7 +1080,12 @@ mod tests {
         };
 
         let result = ctx.http_fetch(req).await;
-        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(HostError::Capability(
+                CapabilityError::HttpRateLimitExceeded(0)
+            ))
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- update `wit-component` and `wit-parser` together from `0.251.0` to `0.252.0`
- add a Dependabot `wit-*` group that includes major/minor/patch updates so future paired bumps are filed together
- route the guarded nextest harness through `scripts/cargo-serial` and make the plugin host HTTP rate-limit test deterministic

Supersedes Dependabot PRs #526 and #527.

## Validation

- `just test-one plugins::host::tests::test_http_fetch_rate_limit`
- `just test`
