### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4015,9 +4015,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What

Bumps `quinn-proto` 0.11.14 → 0.11.15 (transitive dependency) to remediate **RUSTSEC-2026-0185** — remote memory exhaustion from unbounded out-of-order stream reassembly (CVSS 7.5, HIGH).

## Why

`cargo audit` flags 0.11.14 as vulnerable; the advisory's prescribed fix is upgrading to ≥0.11.15. This is the failure currently blocking the **Security Audit** job on the open dependency PRs (#539, #540) — and on master itself, where the job has merely been *skipped* on recent commits because no Rust-touching change has merged since the advisory landed (2026-06-22).

Verified locally: `cargo audit` exits 0 after the bump. Lockfile-only patch bump; no source or API changes.