### PR TITLE
fix(docker): satisfy hadolint 2.15.0 (DL3066, DL3025) ahead of #594

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,15 @@ RUN apt-get update \
 
 COPY --from=builder /build/target/release/cara /usr/local/bin/cara
 
+# Pin the runtime user/group to a fixed, numeric uid/gid (satisfies
+# hadolint DL3066 and keeps the runtime identity deterministic instead of
+# relying on whatever `useradd --system` happens to allocate). 10001 sits
+# above the system range (<1000) where apt-installed accounts live, so it
+# will not collide with the ca-certificates/curl packages this stage adds.
+# UPGRADE NOTE: this differs from the previously auto-allocated uid. The
+# daemon refuses to start if its state dir (/data) is owned by another uid
+# (see src/server/startup.rs), so a persistent /data volume created by an
+# older image must be chowned once: `chown -R 10001:10001 /data`.
 RUN groupadd --system --gid 10001 carapace \
     && useradd --system --uid 10001 --gid carapace carapace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN groupadd --system --gid 10001 carapace \
 ENV CARAPACE_STATE_DIR=/data
 RUN mkdir -p /data && chown carapace:carapace /data
 
-USER 10001
+USER 10001:10001
 
 EXPOSE 18789
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,18 @@ RUN apt-get update \
 
 COPY --from=builder /build/target/release/cara /usr/local/bin/cara
 
-RUN groupadd --system carapace && useradd --system --gid carapace carapace
+RUN groupadd --system --gid 10001 carapace \
+    && useradd --system --uid 10001 --gid carapace carapace
 
 # State directory for sessions, cron, config
 ENV CARAPACE_STATE_DIR=/data
 RUN mkdir -p /data && chown carapace:carapace /data
 
-USER carapace
+USER 10001
 
 EXPOSE 18789
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:18789/health || exit 1
+    CMD ["curl", "-f", "http://localhost:18789/health"]
 
 ENTRYPOINT ["cara"]

--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -47,6 +47,17 @@
 
 ## Breaking Changes
 
+- **The container image runs as a fixed `uid:gid` `10001:10001`.**
+  Earlier images let `useradd --system` auto-allocate the `carapace`
+  uid (a low system-range value). The runtime user is now pinned to
+  `10001` so the identity is deterministic across builds. Because the
+  daemon fails closed when its state directory is owned by a different
+  uid (owner-uid check in `src/server/startup.rs`), a container that
+  reuses a persistent `CARAPACE_STATE_DIR` (`/data`) volume created by
+  an older image will refuse to start after upgrading until the volume
+  is re-owned. See Migration for the one-time step. Deployments without
+  a persistent `/data` volume, or that build the image fresh, are
+  unaffected.
 - **`ProviderFingerprint::vertex` is now a named, non-exhaustive
   `VertexProviderFingerprint`.** Embedders that destructure the old tuple must
   read the named fields instead. `ProviderFingerprint` and
@@ -164,6 +175,21 @@
 
 ## Migration
 
+- **Re-own a persistent `/data` volume before upgrading the container.**
+  The runtime user is now the fixed uid/gid `10001:10001` (see Breaking
+  Changes). Operators who mount a persistent `CARAPACE_STATE_DIR`
+  (`/data`) volume populated by an older image must chown it once, or the
+  daemon will fail closed on startup with an owner-uid mismatch error:
+
+  ```sh
+  # named volume
+  docker run --rm -v carapace-data:/data alpine chown -R 10001:10001 /data
+  # bind mount
+  sudo chown -R 10001:10001 /path/to/data
+  ```
+
+  The startup error names this remediation as well. Fresh installs and
+  deployments without a persistent `/data` volume need no action.
 - **Update non-interactive setup automation to pass `--model`.**
   CI/CD jobs, Ansible playbooks, container entrypoints, and local
   bootstrap scripts that invoke `cara setup --provider <provider>`


### PR DESCRIPTION
Closed. Dockerfile hadolint 2.15.0 fix (DL3066/DL3025) plus v0.9.0 release-note migration; superseded/withdrawn.