### PR TITLE
chore: group the wasmtime and wasm-tools bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,22 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 99
     groups:
-      wit-tooling:
+      # wasmtime and the wasm-tools crates ship as one upstream release train:
+      # wasmtime 48 pairs with the 0.257 wit-*/wasmparser line. Bumping them in
+      # separate PRs strands each one until the others merge, and lets the lock
+      # file accumulate several wasmparser versions at once.
+      #
+      # update-types is deliberately omitted, which means every type. These are
+      # 0.x crates, so a 0.255 -> 0.257 bump counts as major; listing the types
+      # explicitly did not group them in practice.
+      wasm-toolchain:
         applies-to: "version-updates"
         patterns:
-          - "wit-*"
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
+          - "wit-parser"
+          - "wit-component"
+          - "wasmtime"
+          - "wasmparser"
+          - "wasm-encoder"
       cargo-minor-patch:
         applies-to: "version-updates"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,12 +21,20 @@ updates:
       # explicitly did not group them in practice.
       wasm-toolchain:
         applies-to: "version-updates"
+        # Covers the whole train, including crates that are transitive today,
+        # so one becoming a direct dependency does not silently fall out of the
+        # group. wasm-bindgen, wasm-streams and similar are deliberately absent:
+        # despite the prefix they are a different project on their own cadence.
         patterns:
-          - "wit-parser"
-          - "wit-component"
+          - "wit-*"
           - "wasmtime"
+          - "wasmtime-*"
           - "wasmparser"
+          - "wasmprinter"
           - "wasm-encoder"
+          - "wasm-compose"
+          - "wasm-metadata"
+          - "wast"
       cargo-minor-patch:
         applies-to: "version-updates"
         update-types:


### PR DESCRIPTION
`wit-parser` and `wit-component` always move together and always arrive as two PRs: #608/#609, #604/#605, #589/#590. The `wit-tooling` group meant to prevent that has never produced a grouped PR - 0 out of 26 wit-* PRs.

## What this actually changes

**It widens the group to the whole upstream release train.** That is the substantive change. wasmtime 48 pairs with the 0.257 `wit-*`/`wasmparser` line, so grouping only the wit crates would still leave #607 stranded in its own PR that has to merge in lockstep. The lock file currently carries `wasmparser` 0.252, 0.255 and 0.256 simultaneously, which is these crates drifting apart across separate PRs.

Patterns cover crates that are transitive today, so one becoming a direct dependency does not silently fall out of the group. A blunt `wasm*` is deliberately avoided: it also matches `wasm-bindgen*`, `wasm-streams` and `wasm_evt_listener`, a different project on its own cadence. Verified against the lock file: 12/12 train crates matched, 0 unrelated caught.

## What it does not fix, and an open question

For a release moving only `wit-parser` and `wit-component`, this change is semantically a no-op, as Codex pointed out in review. `wit-*` already matched both names, and listing `major`/`minor`/`patch` is documented as equivalent to omitting `update-types`. The predicate that actually prevented grouping is untouched.

The empirical pattern across every open PR:

| PR | Bump | Semver | Result |
|---|---|---|---|
| #616 | 5 deps | minor/patch | grouped |
| #609 | wit-parser 0.255.0 -> 0.257.1 | 0.x minor = major | individual |
| #608 | wit-component 0.255.0 -> 0.257.1 | 0.x minor = major | individual |
| #607 | wasmtime 47.0.3 -> 48.0.0 | major | individual |
| #603 | mdns-sd 0.20.3 -> 0.21.0 | 0.x minor = major | individual |

Every minor/patch groups; every major arrives alone. These are 0.x crates, so `0.255 -> 0.257` counts as major. If Dependabot simply does not group major updates in this repo, omitting `update-types` will not help either, and the wit pairing will keep splitting.

That is decidable from the Dependabot job logs under **Insights > Dependency graph > Dependabot**, which are not exposed via the API. Worth checking before merging on the assumption that it fixes the pairing.

Lone major bumps outside this family (`mdns-sd`) intentionally keep getting their own PRs.

## Verifying

Config-only - no effect until Dependabot's next run.