### PR TITLE
chore: track stable Rust instead of pinning 1.94.1

### DIFF
--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_STABLE_TOOLCHAIN: 1.94.1
+  RUST_STABLE_TOOLCHAIN: stable
   CARGO_NEXTEST_VERSION: 0.9.132
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_STABLE_TOOLCHAIN: 1.94.1
-  RUST_MSRV_TOOLCHAIN: 1.94.0
+  RUST_STABLE_TOOLCHAIN: stable
+  RUST_MSRV_TOOLCHAIN: 1.95.0
   CARGO_NEXTEST_VERSION: 0.9.132
   CARGO_AUDIT_VERSION: 0.22.1
   CARGO_DENY_VERSION: 0.19.0
@@ -284,7 +284,7 @@ jobs:
     if: needs.changes.outputs.rust_runtime == 'true' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # 1.94.0
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # pinned action; version comes from RUST_MSRV_TOOLCHAIN
         with:
           toolchain: ${{ env.RUST_MSRV_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_STABLE_TOOLCHAIN: 1.94.1
+  RUST_STABLE_TOOLCHAIN: stable
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "carapace"
 version = "0.8.0"
 edition = "2021"
-rust-version = "1.94"
+rust-version = "1.95"
 description = "A security-focused personal AI assistant — hardened alternative to openclaw/clawdbot"
 license = "Apache-2.0"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # ---- Build stage ----
-FROM rust:1.94.1-slim AS builder
+# Tracks stable, matching rust-toolchain.toml. The runtime stage below floats
+# on debian:bookworm-slim the same way.
+FROM rust:slim AS builder
 
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./

--- a/docs/feature-status.yaml
+++ b/docs/feature-status.yaml
@@ -323,5 +323,5 @@ feature_inventory_markdown: |
   - [x] **Integration tests** — tests/*.rs
   - [x] **Golden snapshot tests** — insta-based snapshot testing
   - [x] **Cross-platform CI** — Linux, macOS, Windows matrix
-  - [x] **MSRV enforcement** — Rust 1.94
+  - [x] **MSRV enforcement** — Rust 1.95
   - [x] **Security scanning** — cargo-audit, cargo-deny, gitleaks, trivy, cargo-geiger

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.1"
+channel = "stable"
 profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -295,10 +295,8 @@ fn sanitize_signal_error_json_value(value: &mut serde_json::Value, label: Option
                 *text = sanitize_signal_error_text(text);
             }
         }
-        serde_json::Value::Number(number) => {
-            if should_redact_signal_json_number(label, number) {
-                *value = serde_json::Value::String("[redacted]".to_string());
-            }
+        serde_json::Value::Number(number) if should_redact_signal_json_number(label, number) => {
+            *value = serde_json::Value::String("[redacted]".to_string());
         }
         _ => {}
     }

--- a/src/server/ws/handlers/mod.rs
+++ b/src/server/ws/handlers/mod.rs
@@ -2,7 +2,15 @@
 
 use serde_json::{json, Value};
 
-use super::*;
+// Import from the parent explicitly rather than glob-importing it. `ws/mod.rs`
+// re-exports names that originate here, so `use super::*` pulled them back in at
+// a second visibility and made every such name ambiguous.
+use std::sync::Arc;
+
+use super::{
+    error_shape, now_ms, ConnectionContext, ErrorShape, WsServerState, ERROR_INVALID_REQUEST,
+    ERROR_UNAVAILABLE,
+};
 
 mod channels;
 mod config;

--- a/src/server/ws/handlers/system.rs
+++ b/src/server/ws/handlers/system.rs
@@ -321,7 +321,7 @@ pub(super) fn handle_system_presence(state: &WsServerState) -> Result<Value, Err
         .collect();
 
     // Sort by ts descending (newest first)
-    entries.sort_by(|a, b| b.0.cmp(&a.0));
+    entries.sort_by_key(|a| std::cmp::Reverse(a.0));
 
     // Limit to MAX_PRESENCE_ENTRIES (Node uses 200)
     let result: Vec<Value> = entries
@@ -574,7 +574,7 @@ fn update_presence_registry(
     // Remove oldest entries when over limit
     if presence.len() > MAX_PRESENCE_ENTRIES {
         let mut entries: Vec<_> = presence.iter().map(|(k, v)| (k.clone(), v.ts)).collect();
-        entries.sort_by(|a, b| a.1.cmp(&b.1)); // Sort by ts ascending (oldest first)
+        entries.sort_by_key(|a| a.1); // Sort by ts ascending (oldest first)
         let to_remove = presence.len() - MAX_PRESENCE_ENTRIES;
         for (key, _) in entries.into_iter().take(to_remove) {
             presence.remove(&key);
@@ -606,12 +606,12 @@ pub(super) fn handle_system_event(
     // `SYSTEM_EVENT_HISTORY_MAX` (1000) history slots with frame-cap-
     // sized strings. The matching constant lives next to the history
     // size constant so future cap rotations stay co-located.
-    if text.len() > super::super::SYSTEM_EVENT_TEXT_MAX_BYTES {
+    if text.len() > crate::server::ws::SYSTEM_EVENT_TEXT_MAX_BYTES {
         return Err(error_shape(
             ERROR_INVALID_REQUEST,
             &format!(
                 "text exceeds {} byte cap",
-                super::super::SYSTEM_EVENT_TEXT_MAX_BYTES
+                crate::server::ws::SYSTEM_EVENT_TEXT_MAX_BYTES
             ),
             None,
         ));
@@ -892,14 +892,14 @@ mod tests {
     fn test_handle_system_event_rejects_oversize_text() {
         let state = WsServerState::new(WsServerConfig::default());
         let conn = make_test_conn();
-        let oversize = "x".repeat(super::super::SYSTEM_EVENT_TEXT_MAX_BYTES + 1);
+        let oversize = "x".repeat(crate::server::ws::SYSTEM_EVENT_TEXT_MAX_BYTES + 1);
         let params = json!({ "text": oversize });
         let err = handle_system_event(Some(&params), &state, &conn)
             .expect_err("oversize text must be rejected before enqueue");
         let serialized = serde_json::to_string(&err).unwrap();
         assert!(
             serialized.contains("byte cap")
-                && serialized.contains(&super::super::SYSTEM_EVENT_TEXT_MAX_BYTES.to_string()),
+                && serialized.contains(&crate::server::ws::SYSTEM_EVENT_TEXT_MAX_BYTES.to_string()),
             "rejection must name the cap; got: {serialized}"
         );
     }
@@ -915,7 +915,7 @@ mod tests {
     #[test]
     fn test_enqueue_system_event_truncates_oversize_text_at_chokepoint() {
         let state = WsServerState::new(WsServerConfig::default());
-        let huge = "x".repeat(super::super::SYSTEM_EVENT_TEXT_MAX_BYTES * 4);
+        let huge = "x".repeat(crate::server::ws::SYSTEM_EVENT_TEXT_MAX_BYTES * 4);
         state.enqueue_system_event(SystemEvent {
             ts: 1,
             text: huge,
@@ -928,7 +928,7 @@ mod tests {
         let history = state.get_system_event_history();
         let last = history.last().expect("event was enqueued");
         assert!(
-            last.text.len() <= super::super::SYSTEM_EVENT_TEXT_MAX_BYTES,
+            last.text.len() <= crate::server::ws::SYSTEM_EVENT_TEXT_MAX_BYTES,
             "chokepoint must truncate; got {} bytes",
             last.text.len()
         );
@@ -943,7 +943,7 @@ mod tests {
     fn test_handle_system_event_accepts_text_at_cap() {
         let state = WsServerState::new(WsServerConfig::default());
         let conn = make_test_conn();
-        let at_cap = "x".repeat(super::super::SYSTEM_EVENT_TEXT_MAX_BYTES);
+        let at_cap = "x".repeat(crate::server::ws::SYSTEM_EVENT_TEXT_MAX_BYTES);
         let params = json!({ "text": at_cap });
         handle_system_event(Some(&params), &state, &conn)
             .expect("text exactly at the cap must be accepted");

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -1631,7 +1631,7 @@ impl WsServerState {
             .collect();
 
         // Sort by ts descending (newest first)
-        entries.sort_by(|a, b| b.0.cmp(&a.0));
+        entries.sort_by_key(|a| std::cmp::Reverse(a.0));
 
         // Limit to MAX_PRESENCE_ENTRIES (Node parity)
         let mut admin = Vec::new();

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -193,15 +193,12 @@ fn is_canonical_session_id(session_hint: &str) -> bool {
 /// Empty hints are discarded. Existing canonical IDs are preserved and
 /// normalized to lowercase to avoid double hashing and key mismatches.
 pub fn canonicalize_optional_session_hint(session_hint: Option<&str>) -> Option<String> {
-    let trimmed = match session_hint {
-        Some(hint) => {
-            let hint = hint.trim();
-            if hint.is_empty() {
-                return None;
-            }
-            hint
+    let trimmed = {
+        let hint = session_hint?.trim();
+        if hint.is_empty() {
+            return None;
         }
-        None => return None,
+        hint
     };
     if is_canonical_session_id(trimmed) {
         Some(trimmed.to_ascii_lowercase())

--- a/src/sessions/store.rs
+++ b/src/sessions/store.rs
@@ -2863,7 +2863,7 @@ impl SessionStore {
         }
 
         available.extend(locked);
-        available.sort_by(|a, b| b.updated_at.unwrap_or(0).cmp(&a.updated_at.unwrap_or(0)));
+        available.sort_by_key(|a| std::cmp::Reverse(a.updated_at.unwrap_or(0)));
 
         let offset = filter.offset.unwrap_or(0);
         let limit = filter.limit.unwrap_or(usize::MAX);
@@ -4076,7 +4076,7 @@ impl SessionStore {
         }
 
         // Sort by updated_at descending
-        result.sort_by(|a, b| b.0.updated_at.cmp(&a.0.updated_at));
+        result.sort_by_key(|a| std::cmp::Reverse(a.0.updated_at));
 
         Ok(result)
     }


### PR DESCRIPTION
## Why the pin was there

It came from "Pin Rust toolchain and CI cargo tools" (8e3026b6), alongside pinned `CARGO_NEXTEST_VERSION`, `CARGO_AUDIT_VERSION` and friends - a reproducibility change, not a compatibility floor. It has moved exactly once since, in the wasmtime 44 -> 45 bump that refused to build without it.

It was not functioning as an MSRV either:

```
RUST_STABLE_TOOLCHAIN  1.94.1
RUST_MSRV_TOOLCHAIN    1.94.0
```

Same release, differing only in patch, so the MSRV job re-tested the compiler the main build already used rather than proving anything about an older one. Stable is now 1.98.1, so the repo sat four releases back with nothing pushing it forward except the occasional wasmtime bump.

## What changed

`rust-toolchain.toml`, both CI workflows and `release.yml` follow `stable`. `rust-version` moves to 1.95 - and `cargo check --all-targets` on 1.95.0 confirms that is a real floor rather than a mirror of whatever stable happens to be, so the MSRV job now tests something.

## The lint fixes are the bulk of it

The pin was hiding 17 errors that newer rustc reports and CI would fail on, since clippy runs with `-D warnings`.

**Ten ambiguous-import-visibility errors came from a cycle.** `ws/mod.rs` re-exports names that originate in `handlers`, and `handlers/mod.rs` pulled them back with `use super::*`, so each name arrived at two visibilities at once. The glob is now an explicit list of the eight names handlers actually needs from its parent.

That surfaced a latent path bug: `system.rs` referenced `SYSTEM_EVENT_TEXT_MAX_BYTES` as `super::super::`, which resolved only because the glob had placed it in `handlers`. Inside `mod tests` the path shifts by one, so those seven references now use the absolute path and mean the same thing from both scopes.

**Seven ordinary clippy fixes.** Five `sort_by` comparators become `sort_by_key`, a nested `if` folds into its match guard, and a `match` on `Option` becomes `?`. All behaviour-preserving.

## Verification

On 1.98.1:

- `cargo clippy --locked --all-features --all-targets -- -D warnings` - clean
- `cargo fmt --check` - clean
- `cargo nextest run` - 4917 run, 4917 passed, 0 skipped

On 1.95.0 (the declared floor):

- `cargo check --all-targets` - passes

## Trade-off worth naming

Tracking `stable` gives up the build reproducibility the original pin bought. A future Rust release can introduce a lint that fails CI on an unrelated PR. That is the cost of staying current, and it is now visible rather than deferred - which is roughly what happened here, except four releases' worth at once.

## Side effect

This unblocks #607. wasmtime 48.0.1 needs rustc 1.95.0, which was the only thing standing in its way.